### PR TITLE
Add SUSE/elemental-team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+
+*       @SUSE/elemental-team


### PR DESCRIPTION
Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
