### PR TITLE
Add missing Goheaders

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters-settings:
     min-complexity: 20 # default is 30 which is too high
   goheader:
     template: |-
-      Copyright © 2022 - {{year}} SUSE LLC
+      Copyright © {{year-range}} SUSE LLC
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters-settings:
   goheader:
     template: |-
       Copyright © {{year-range}} SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/cmd/elemental/main.go
+++ b/cmd/elemental/main.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/internal/cli/action/build.go
+++ b/internal/cli/action/build.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (

--- a/internal/cli/action/install.go
+++ b/internal/cli/action/install.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (

--- a/internal/cli/action/version.go
+++ b/internal/cli/action/version.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (

--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/internal/cli/cmd/version.go
+++ b/internal/cli/cmd/version.go
@@ -1,3 +1,20 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2021 SUSE LLC
+Copyright © 2021-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/fs.go
+++ b/pkg/sys/fs.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/fs_test.go
+++ b/pkg/sys/fs_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/mock/fs.go
+++ b/pkg/sys/mock/fs.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/mock/mounter.go
+++ b/pkg/sys/mock/mounter.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/mock/runner.go
+++ b/pkg/sys/mock/runner.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/mock/syscall.go
+++ b/pkg/sys/mock/syscall.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/mounter/mounter.go
+++ b/pkg/sys/mounter/mounter.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/platform/platform.go
+++ b/pkg/sys/platform/platform.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/platform/platform_test.go
+++ b/pkg/sys/platform/platform_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/runner/runner_test.go
+++ b/pkg/sys/runner/runner_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2021 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/syscall/syscall.go
+++ b/pkg/sys/syscall/syscall.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/system.go
+++ b/pkg/sys/system.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/system_test.go
+++ b/pkg/sys/system_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2021 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sys/vfs/fs.go
+++ b/pkg/sys/vfs/fs.go
@@ -1,5 +1,6 @@
 /*
-Copyright © 2022 - 2025 SUSE LLC
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add missing headers in Go files to make `golangci-lint` happy.