### PR TITLE
Add block package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/suse/elemental/v3
 go 1.24
 
 require (
+	github.com/jaypipes/ghw v0.14.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/sirupsen/logrus v1.9.3
@@ -13,15 +14,21 @@ require (
 )
 
 require (
+	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
+	github.com/jaypipes/pcidb v1.0.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samber/lo v1.47.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
@@ -29,6 +36,7 @@ require (
 	golang.org/x/tools v0.29.0 // indirect
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	howett.net/plist v1.0.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
+github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
 github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
@@ -11,6 +13,9 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -19,10 +24,17 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/Z
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/jaypipes/ghw v0.14.0 h1:Z2AunEykaBYXLgpntVQB8SGmIFuCEmCcj6aS5j8xrys=
+github.com/jaypipes/ghw v0.14.0/go.mod h1:F4UM7Ix55ONYwD3Lck2S4BI+hKezOwtizuJxXDFsioo=
+github.com/jaypipes/pcidb v1.0.1 h1:WB2zh27T3nwg8AE8ei81sNRb9yWBii3JGNJtT7K9Oic=
+github.com/jaypipes/pcidb v1.0.1/go.mod h1:6xYUz/yYEyOkIkUt2t2J2folIuZ4Yg6uByCGFXMCeE4=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
@@ -31,6 +43,8 @@ github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU
 github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -38,6 +52,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -56,6 +72,7 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -68,9 +85,12 @@ google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
+howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/mount-utils v0.32.2 h1:aDwp+ucWiVnDr/LpRg88/dsXf/vm6gI1VZkYH3+3+Vw=

--- a/pkg/block/device.go
+++ b/pkg/block/device.go
@@ -1,0 +1,118 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package block
+
+import (
+	"errors"
+	"time"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+const Ghw = "ghw"
+const Lsblk = "lsblk"
+
+type Device interface {
+	GetAllPartitions() (PartitionList, error)
+	GetDevicePartitions(device string) (PartitionList, error)
+	GetPartitionFS(partition string) (string, error)
+}
+
+// Partition struct represents a partition with its commonly configurable values, size in MiB
+type Partition struct {
+	Name            string
+	FilesystemLabel string
+	Size            uint
+	FS              string
+	Flags           []string
+	MountPoints     []string
+	Path            string
+	Disk            string
+}
+
+type PartitionList []*Partition
+
+// GetByName gets a partitions by its name from the PartitionList
+func (pl PartitionList) GetByName(name string) *Partition {
+	var part *Partition
+
+	for _, p := range pl {
+		if p.Name == name {
+			part = p
+			// Prioritize mounted partitions if there are multiple matches
+			if len(part.MountPoints) > 0 {
+				return part
+			}
+		}
+	}
+	return part
+}
+
+// GetByLabel gets a partition by its label from the PartitionList
+func (pl PartitionList) GetByLabel(label string) *Partition {
+	var part *Partition
+
+	for _, p := range pl {
+		if p.FilesystemLabel == label {
+			part = p
+			// Prioritize mounted partitions if there are multiple matches
+			if len(part.MountPoints) > 0 {
+				return part
+			}
+		}
+	}
+	return part
+}
+
+// GetByNameOrLabel gets a partition by its name or label. It tries by name first
+func (pl PartitionList) GetByNameOrLabel(name, label string) *Partition {
+	part := pl.GetByName(name)
+	if part == nil {
+		part = pl.GetByLabel(label)
+	}
+	return part
+}
+
+// GetPartitionByLabel works like GetPartitionByLabel, but it will try to get as much info as possible from the existing
+// partition and return a Partition object
+func GetPartitionByLabel(s *sys.System, b Device, label string, attempts int) (*Partition, error) {
+	for range attempts {
+		_, _ = s.Runner().Run("udevadm", "settle")
+		parts, err := b.GetAllPartitions()
+		if err != nil {
+			return nil, err
+		}
+		part := parts.GetByLabel(label)
+		if part != nil {
+			return part, nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return nil, errors.New("no device found")
+}
+
+// GetPartitionDeviceByLabel will try to return the device that matches the given label.
+// attempts value sets the number of attempts to find the device, it
+// waits a second between attempts.
+func GetPartitionDeviceByLabel(s *sys.System, b Device, label string, attempts int) (string, error) {
+	part, err := GetPartitionByLabel(s, b, label, attempts)
+	if err != nil {
+		return "", err
+	}
+	return part.Path, nil
+}

--- a/pkg/block/device.go
+++ b/pkg/block/device.go
@@ -88,7 +88,7 @@ func (pl PartitionList) GetByNameOrLabel(name, label string) *Partition {
 	return part
 }
 
-// GetPartitionByLabel works like GetPartitionByLabel, but it will try to get as much info as possible from the existing
+// GetPartitionByLabel works like GetPartitionDeviceByLabel, but it will try to get as much info as possible from the existing
 // partition and return a Partition object
 func GetPartitionByLabel(s *sys.System, b Device, label string, attempts int) (*Partition, error) {
 	for range attempts {

--- a/pkg/block/ghw/ghw.go
+++ b/pkg/block/ghw/ghw.go
@@ -1,0 +1,124 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghw
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaypipes/ghw"
+	ghwblock "github.com/jaypipes/ghw/pkg/block"
+	ghwUtil "github.com/jaypipes/ghw/pkg/util"
+	"github.com/suse/elemental/v3/pkg/block"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+type ghwDevice struct {
+	runner  sys.Runner
+	mounter sys.Mounter
+}
+
+func NewGhwDevice(s *sys.System) *ghwDevice { //nolint:revive
+	return &ghwDevice{runner: s.Runner(), mounter: s.Mounter()}
+}
+
+var _ block.Device = (*ghwDevice)(nil)
+
+// ghwPartitionToInternalPartition transforms a block.Partition from ghw lib to our types.Partition type
+func ghwPartitionToInternalPartition(m sys.Mounter, partition *ghwblock.Partition) *block.Partition {
+	mnts := []string{partition.MountPoint}
+	if partition.MountPoint != "" {
+		extraMnts, err := m.GetMountRefs(partition.MountPoint)
+		if err == nil {
+			mnts = append(mnts, extraMnts...)
+		}
+	}
+	return &block.Partition{
+		FilesystemLabel: partition.FilesystemLabel,
+		Size:            uint(partition.SizeBytes / (1024 * 1024)), // Converts B to MB
+		Name:            partition.Label,
+		FS:              partition.Type,
+		Flags:           nil,
+		MountPoints:     mnts,
+		Path:            filepath.Join("/dev", partition.Name),
+		Disk:            filepath.Join("/dev", partition.Disk.Name),
+	}
+}
+
+// GetAllPartitions returns all partitions in the system for all disks
+func (b ghwDevice) GetAllPartitions() (block.PartitionList, error) {
+	var parts []*block.Partition
+	blockDevices, err := ghwblock.New(ghw.WithDisableTools(), ghw.WithDisableWarnings())
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range blockDevices.Disks {
+		for _, part := range d.Partitions {
+			parts = append(parts, ghwPartitionToInternalPartition(b.mounter, part))
+		}
+	}
+
+	return parts, nil
+}
+
+// GetDevicePartitions gets the partitions for the given disk
+func (b ghwDevice) GetDevicePartitions(device string) (block.PartitionList, error) {
+	var parts []*block.Partition
+	// We want to have the device always prefixed with a /dev
+	if !strings.HasPrefix(device, "/dev") {
+		device = filepath.Join("/dev", device)
+	}
+	blockDevices, err := ghwblock.New(ghw.WithDisableTools(), ghw.WithDisableWarnings())
+	if err != nil {
+		return parts, err
+	}
+
+	for _, disk := range blockDevices.Disks {
+		if filepath.Join("/dev", disk.Name) == device {
+			for _, part := range disk.Partitions {
+				parts = append(parts, ghwPartitionToInternalPartition(b.mounter, part))
+			}
+		}
+	}
+	return parts, nil
+}
+
+// GetPartitionFS gets the FS of a partition given
+func (b ghwDevice) GetPartitionFS(partition string) (string, error) {
+	// We want to have the device always prefixed with a /dev
+	if !strings.HasPrefix(partition, "/dev") {
+		partition = filepath.Join("/dev", partition)
+	}
+	blockDevices, err := ghwblock.New(ghw.WithDisableTools(), ghw.WithDisableWarnings())
+	if err != nil {
+		return "", err
+	}
+
+	for _, disk := range blockDevices.Disks {
+		for _, part := range disk.Partitions {
+			if filepath.Join("/dev", part.Name) == partition {
+				if part.Type == ghwUtil.UNKNOWN {
+					return "", fmt.Errorf("could not find filesystem for partition %s", partition)
+				}
+				return part.Type, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find partition %s", partition)
+}

--- a/pkg/block/ghw/ghw_test.go
+++ b/pkg/block/ghw/ghw_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghw_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/block"
+	"github.com/suse/elemental/v3/pkg/block/ghw"
+	blockmock "github.com/suse/elemental/v3/pkg/block/mock"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+
+	gblock "github.com/jaypipes/ghw/pkg/block"
+)
+
+func TestGhwSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ghw test suite")
+}
+
+var _ = Describe("BlockDevice", Label("ghw"), func() {
+	var ghwTest blockmock.GhwMock
+	var ghwBlock block.Device
+	var runner *sysmock.Runner
+	var mounter *sysmock.Mounter
+	var s *sys.System
+	var err error
+	BeforeEach(func() {
+		ghwTest = blockmock.GhwMock{}
+		mounter = sysmock.NewMounter()
+		runner = sysmock.NewRunner()
+		s, err = sys.NewSystem(sys.WithRunner(runner), sys.WithMounter(mounter))
+		Expect(err).NotTo(HaveOccurred())
+		ghwBlock = ghw.NewGhwDevice(s)
+	})
+	AfterEach(func() {
+		ghwTest.Clean()
+	})
+	Describe("GetPartitionFS", func() {
+		BeforeEach(func() {
+			disk := gblock.Disk{Name: "device", Partitions: []*gblock.Partition{
+				{
+					Name: "device1",
+					Type: "xfs",
+				},
+				{
+					Name: "device2",
+				},
+			}}
+			ghwTest.AddDisk(disk)
+			ghwTest.CreateDevices()
+		})
+		It("returns found device with plain partition device", func() {
+			pFS, err := ghwBlock.GetPartitionFS("device1")
+			Expect(err).To(BeNil())
+			Expect(pFS).To(Equal("xfs"))
+		})
+		It("returns found device with full partition device", func() {
+			pFS, err := ghwBlock.GetPartitionFS("/dev/device1")
+			Expect(err).To(BeNil())
+			Expect(pFS).To(Equal("xfs"))
+		})
+		It("fails if no partition is found", func() {
+			_, err := ghwBlock.GetPartitionFS("device2")
+			Expect(err).NotTo(BeNil())
+		})
+	})
+	Describe("Get Partitions", func() {
+		BeforeEach(func() {
+			disk1 := gblock.Disk{
+				Name: "sda",
+				Partitions: []*gblock.Partition{
+					{
+						Name:            "sda1Test",
+						MountPoint:      "/mnt",
+						FilesystemLabel: "LABEL",
+					},
+					{
+						Name: "sda2Test",
+					},
+				},
+			}
+			disk2 := gblock.Disk{
+				Name: "sdb",
+				Partitions: []*gblock.Partition{
+					{
+						Name: "sdb1Test",
+					},
+				},
+			}
+			mounter.Mount("/dev/sda1Test", "/mnt", "ext4", []string{"defaults"})
+			mounter.Mount("/dev/sda1Test", "/data", "ext4", []string{"defaults"})
+			ghwTest.AddDisk(disk1)
+			ghwTest.AddDisk(disk2)
+			ghwTest.CreateDevices()
+		})
+		It("returns all found partitions and mountpoints", func() {
+			parts, err := ghwBlock.GetAllPartitions()
+			Expect(err).To(BeNil())
+			var devices []string
+			for _, p := range parts {
+				devices = append(devices, p.Path)
+			}
+			p := parts.GetByLabel("LABEL")
+			Expect(p).NotTo(BeNil())
+			Expect(p.MountPoints).To(ContainElements("/mnt", "/data"))
+			Expect(devices).To(ContainElement(ContainSubstring("sda1Test")))
+			Expect(devices).To(ContainElement(ContainSubstring("sda2Test")))
+			Expect(devices).To(ContainElement(ContainSubstring("sdb1Test")))
+		})
+		It("returns found partitions for /dev/sda", func() {
+			parts, err := ghwBlock.GetDevicePartitions("/dev/sda")
+			Expect(err).To(BeNil())
+			var devices []string
+			for _, p := range parts {
+				devices = append(devices, p.Path)
+			}
+			Expect(devices).To(ContainElement(ContainSubstring("sda1Test")))
+			Expect(devices).To(ContainElement(ContainSubstring("sda2Test")))
+			Expect(devices).NotTo(ContainElement(ContainSubstring("sdb1Test")))
+		})
+	})
+})

--- a/pkg/block/lsblk/lsblk.go
+++ b/pkg/block/lsblk/lsblk.go
@@ -1,0 +1,138 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lsblk
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/suse/elemental/v3/pkg/block"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+type lsDevice struct {
+	runner sys.Runner
+}
+
+func NewLsDevice(s *sys.System) *lsDevice { //nolint:revive
+	return &lsDevice{runner: s.Runner()}
+}
+
+var _ block.Device = (*lsDevice)(nil)
+
+type jPart struct {
+	Label       string   `json:"label,omitempty"`
+	Name        string   `json:"partlabel,omitempty"`
+	Size        uint64   `json:"size,omitempty"`
+	FS          string   `json:"fstype,omitempty"`
+	MountPoints []string `json:"mountpoints,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	Disk        string   `json:"pkname,omitempty"`
+	Type        string   `json:"type,omitempty"`
+}
+
+type jParts []*block.Partition
+
+func (p jPart) Partition() *block.Partition {
+	// Converts B to MB
+	return &block.Partition{
+		FilesystemLabel: p.Label,
+		Size:            uint(p.Size / (1024 * 1024)),
+		FS:              p.FS,
+		Flags:           []string{},
+		MountPoints:     p.MountPoints,
+		Path:            p.Path,
+		Disk:            p.Disk,
+		Name:            p.Name,
+	}
+}
+
+func (p *jParts) UnmarshalJSON(data []byte) error {
+	var parts []jPart
+
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return err
+	}
+
+	var partitions jParts
+	for _, part := range parts {
+		// filter only partition or loop devices
+		if part.Type == "part" || part.Type == "loop" {
+			partitions = append(partitions, part.Partition())
+		}
+	}
+	*p = partitions
+	return nil
+}
+
+func unmarshalLsblk(lsblkOut []byte) ([]*block.Partition, error) {
+	var objmap map[string]*json.RawMessage
+	err := json.Unmarshal(lsblkOut, &objmap)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := objmap["blockdevices"]; !ok {
+		return nil, errors.New("Invalid json object, no 'blockdevices' key found")
+	}
+
+	var parts jParts
+	err = json.Unmarshal(*objmap["blockdevices"], &parts)
+	if err != nil {
+		return nil, err
+	}
+
+	return parts, nil
+}
+
+// GetAllPartitions gets a slice of all partition devices found in the host
+// mapped into a v1.PartitionList object.
+func (l lsDevice) GetAllPartitions() (block.PartitionList, error) {
+	out, err := l.runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,PARTLABEL,SIZE,FSTYPE,MOUNTPOINTS,PATH,PKNAME,TYPE")
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalLsblk(out)
+}
+
+// GetDevicePartitions gets a slice of partitions found in the given device mapped
+// into a v1.PartitionList object. If the device is a disk it will list all disk
+// partitions, if the device is already a partition it will simply list a single partition.
+func (l lsDevice) GetDevicePartitions(device string) (block.PartitionList, error) {
+	out, err := l.runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,PARTLABEL,SIZE,FSTYPE,MOUNTPOINTS,PATH,PKNAME,TYPE", device)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalLsblk(out)
+}
+
+// GetPartitionFS gets the filesystem type for the given partition device. If the given device
+// is can't be parsed as a single partition by lsblk it will error out.
+func (l lsDevice) GetPartitionFS(partition string) (string, error) {
+	pLst, err := l.GetDevicePartitions(partition)
+	if err != nil {
+		return "", err
+	}
+	if len(pLst) != 1 {
+		return "", fmt.Errorf("could not parse a single partition: %v", pLst)
+	}
+	return pLst[0].FS, nil
+}

--- a/pkg/block/mock/device.go
+++ b/pkg/block/mock/device.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock
+
+import (
+	"fmt"
+
+	"github.com/suse/elemental/v3/pkg/block"
+)
+
+var _ block.Device = (*Device)(nil)
+
+type Device struct {
+	partitions block.PartitionList
+	err        error
+}
+
+func NewBlockDevice(partitions ...*block.Partition) *Device {
+	return &Device{partitions: partitions}
+}
+
+func (m *Device) SetPartitions(partitions block.PartitionList) {
+	m.partitions = partitions
+}
+
+func (m *Device) SetError(err error) {
+	m.err = err
+}
+
+func (m Device) GetAllPartitions() (block.PartitionList, error) {
+	return m.partitions, m.err
+}
+
+func (m Device) GetDevicePartitions(device string) (block.PartitionList, error) {
+	var parts block.PartitionList
+	for _, part := range m.partitions {
+		if part.Disk == device {
+			parts = append(parts, part)
+		}
+	}
+	return parts, m.err
+}
+
+func (m Device) GetPartitionFS(partition string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+
+	for _, part := range m.partitions {
+		if part.Path == partition {
+			return part.FS, nil
+		}
+	}
+	return "", fmt.Errorf("MockBlockDevice: partition '%s' not found", partition)
+}

--- a/pkg/block/mock/ghw_mock.go
+++ b/pkg/block/mock/ghw_mock.go
@@ -1,0 +1,174 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaypipes/ghw/pkg/block"
+	"github.com/jaypipes/ghw/pkg/context"
+	"github.com/jaypipes/ghw/pkg/linuxpath"
+)
+
+// GhwMock is used to construct a fake disk to present to ghw when scanning block devices
+// The way this works is ghw will use the existing files in the system to determine the different disks, partitions and
+// mountpoints. It uses /sys/block, /proc/self/mounts and /run/udev/data to gather everything
+// It also has an entrypoint to overwrite the root dir from which the paths are constructed so that allows us to override
+// it easily and make it read from a different location.
+// This mock is used to construct a fake FS with all its needed files on a different chroot and just add a Disk with its
+// partitions and let the struct do its thing creating files and mountpoints and such
+// You can even just pass no disks to simulate a system in which there is no disk/no cos partitions
+type GhwMock struct {
+	chroot string
+	paths  *linuxpath.Paths
+	disks  []block.Disk
+	mounts []string
+}
+
+// AddDisk adds a disk to GhwMock
+func (g *GhwMock) AddDisk(disk block.Disk) {
+	g.disks = append(g.disks, disk)
+}
+
+// AddPartitionToDisk will add a partition to the given disk and call Clean+CreateDevices, so we recreate all files
+// It makes no effort checking if the disk exists
+func (g *GhwMock) AddPartitionToDisk(diskName string, partition *block.Partition) {
+	for _, disk := range g.disks {
+		if disk.Name == diskName {
+			disk.Partitions = append(disk.Partitions, partition)
+			g.Clean()
+			g.CreateDevices()
+		}
+	}
+}
+
+// CreateDevices will create a new context and paths for ghw using the Chroot value as base, then set the env var GHW_ROOT so the
+// ghw library picks that up and then iterate over the disks and partitions and create the necessary files
+func (g *GhwMock) CreateDevices() {
+	d, _ := os.MkdirTemp("", "ghwmock")
+	g.chroot = d
+	ctx := context.New()
+	ctx.Chroot = d
+	g.paths = linuxpath.New(ctx)
+	_ = os.Setenv("GHW_CHROOT", g.chroot)
+	// Create the /sys/block dir
+	_ = os.MkdirAll(g.paths.SysBlock, 0755)
+	// Create the /run/udev/data dir
+	_ = os.MkdirAll(g.paths.RunUdevData, 0755)
+	// Create only the /proc/self dir, we add the mounts file afterwards
+	procDir, _ := filepath.Split(g.paths.ProcMounts)
+	_ = os.MkdirAll(procDir, 0755)
+
+	for indexDisk, disk := range g.disks {
+		// For each dir we create the /sys/block/DISK_NAME
+		diskPath := filepath.Join(g.paths.SysBlock, disk.Name)
+		_ = os.Mkdir(diskPath, 0755)
+		for indexPart, partition := range disk.Partitions {
+			// For each partition we create the /sys/block/DISK_NAME/PARTITION_NAME
+			_ = os.Mkdir(filepath.Join(diskPath, partition.Name), 0755)
+			// Create the /sys/block/DISK_NAME/PARTITION_NAME/dev file which contains the major:minor of the partition
+			_ = os.WriteFile(filepath.Join(diskPath, partition.Name, "dev"), []byte(fmt.Sprintf("%d:6%d\n", indexDisk, indexPart)), 0600)
+			// Create the /run/udev/data/bMAJOR:MINOR file with the data inside to mimic the udev database
+			data := []string{fmt.Sprintf("E:ID_FS_LABEL=%s\n", partition.FilesystemLabel)}
+			if partition.Type != "" {
+				data = append(data, fmt.Sprintf("E:ID_FS_TYPE=%s\n", partition.Type))
+			}
+			_ = os.WriteFile(filepath.Join(g.paths.RunUdevData, fmt.Sprintf("b%d:6%d", indexDisk, indexPart)), []byte(strings.Join(data, "")), 0600)
+			// If we got a mountpoint, add it to our fake /proc/self/mounts
+			if partition.MountPoint != "" {
+				// Check if the partition has a fs, otherwise default to ext4
+				if partition.Type == "" {
+					partition.Type = "ext4"
+				}
+				// Prepare the g.mounts with all the mount lines
+				g.mounts = append(
+					g.mounts,
+					fmt.Sprintf("%s %s %s ro,relatime 0 0\n", filepath.Join("/dev", partition.Name), partition.MountPoint, partition.Type))
+			}
+		}
+	}
+	// Finally, write all the mounts
+	_ = os.WriteFile(g.paths.ProcMounts, []byte(strings.Join(g.mounts, "")), 0600)
+}
+
+// RemoveDisk will remove the files for a disk. It makes no effort to check if the disk exists or not
+func (g *GhwMock) RemoveDisk(disk string) {
+	// This could be simpler I think, just removing the /sys/block/DEVICE should make ghw not find anything and not search
+	// for partitions, but just in case do it properly
+	var newMounts []string
+	diskPath := filepath.Join(g.paths.SysBlock, disk)
+	_ = os.RemoveAll(diskPath)
+
+	// Try to find any mounts that match the disk given and remove them from the mounts
+	for _, mount := range g.mounts {
+		fields := strings.Fields(mount)
+		// If first field does not contain the /dev/DEVICE, add it to the newmounts
+		if !strings.Contains(fields[0], filepath.Join("/dev", disk)) {
+			newMounts = append(newMounts, mount)
+		}
+	}
+	g.mounts = newMounts
+	// Write the mounts again
+	_ = os.WriteFile(g.paths.ProcMounts, []byte(strings.Join(g.mounts, "")), 0600)
+}
+
+// RemovePartitionFromDisk will remove the files for a partition
+// It makes no effort checking if the disk/partition/files exist
+func (g *GhwMock) RemovePartitionFromDisk(diskName string, partitionName string) {
+	var newMounts []string
+	diskPath := filepath.Join(g.paths.SysBlock, diskName)
+	// Read the dev major:minor
+	devName, _ := os.ReadFile(filepath.Join(diskPath, partitionName, "dev"))
+	// Remove the MAJOR:MINOR file from the udev database
+	_ = os.RemoveAll(filepath.Join(g.paths.RunUdevData, fmt.Sprintf("b%s", devName)))
+	// Remove the /sys/block/DISK/PARTITION dir
+	_ = os.RemoveAll(filepath.Join(diskPath, partitionName))
+
+	// Try to find any mounts that match the partition given and remove them from the mounts
+	for _, mount := range g.mounts {
+		fields := strings.Fields(mount)
+		// If first field does not contain the /dev/PARTITION, add it to the newmounts
+		if !strings.Contains(fields[0], filepath.Join("/dev", partitionName)) {
+			newMounts = append(newMounts, mount)
+		}
+	}
+	g.mounts = newMounts
+	// Write the mounts again
+	_ = os.WriteFile(g.paths.ProcMounts, []byte(strings.Join(g.mounts, "")), 0600)
+	// Remove it from the partitions list
+	for index, disk := range g.disks {
+		if disk.Name == diskName {
+			var newPartitions []*block.Partition
+			for _, partition := range disk.Partitions {
+				if partition.Name != partitionName {
+					newPartitions = append(newPartitions, partition)
+				}
+			}
+			g.disks[index].Partitions = newPartitions
+		}
+	}
+}
+
+// Clean will remove the chroot dir and unset the env var
+func (g *GhwMock) Clean() {
+	_ = os.Unsetenv("GHW_CHROOT")
+	_ = os.RemoveAll(g.chroot)
+}


### PR DESCRIPTION
The block package adds an interface to list and detect partitions. In former Elemental Toolkit it was first implemented around wrapping lsblk command line and at a later point in time it was reimplemented around ghw library (we had to contribute there too).

This current block package includes both implementations, one around ghw and another one around lsblk. I am not convinced it was a wise move using ghw, hence I'd go back to lsblk because is powerful and provides configurable JSON outputs which are easy to consume. I kept ghw around for the time being just in case we discover some limitation with the lsblk approach.