### PR TITLE
Adding diskrepart package

### DIFF
--- a/pkg/diskrepart/disk.go
+++ b/pkg/diskrepart/disk.go
@@ -1,0 +1,491 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskrepart
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/suse/elemental/v3/pkg/block"
+	"github.com/suse/elemental/v3/pkg/block/lsblk"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner/gdisk"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner/parted"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+const (
+	partitionTries = 10
+	// Parted warning substring for expanded disks without fixing GPT headers
+	partedWarn    = "Not all of the space available"
+	sgdiskProblem = "Problem: The secondary header"
+
+	// Paritioner backend
+	partedBack = "parted"
+	gdiskBack  = "sgdisk"
+)
+
+var unallocatedRegexp = regexp.MustCompile(fmt.Sprintf("(%s|%s)", partedWarn, sgdiskProblem))
+
+type Disk struct {
+	device      string
+	sectorS     uint
+	lastS       uint
+	parts       []partitioner.Partition
+	label       string
+	sys         *sys.System
+	partBackend string
+	blockDevice block.Device
+}
+
+type DiskOptions func(d *Disk) error
+
+func WithGdisk() func(d *Disk) error {
+	return func(d *Disk) error {
+		d.partBackend = gdiskBack
+		return nil
+	}
+}
+
+func WithParted() func(d *Disk) error {
+	return func(d *Disk) error {
+		d.partBackend = partedBack
+		return nil
+	}
+}
+
+func WithBlockDevice(bd block.Device) func(d *Disk) error {
+	return func(d *Disk) error {
+		d.blockDevice = bd
+		return nil
+	}
+}
+
+func MiBToSectors(size uint, sectorSize uint) uint {
+	return size * 1048576 / sectorSize
+}
+
+func NewDisk(s *sys.System, device string, opts ...DiskOptions) *Disk {
+	dev := &Disk{
+		device: device,
+		sys:    s,
+	}
+
+	for _, opt := range opts {
+		if err := opt(dev); err != nil {
+			return nil
+		}
+	}
+
+	if dev.blockDevice == nil {
+		dev.blockDevice = lsblk.NewLsDevice(s)
+	}
+
+	return dev
+}
+
+// FormatDevice formats a block device with the given parameters
+func FormatDevice(s *sys.System, device string, fileSystem string, label string, opts ...string) error {
+	mkfs := NewMkfsCall(s, device, fileSystem, label, opts...)
+	_, err := mkfs.Apply()
+	return err
+}
+
+func (dev Disk) String() string {
+	return dev.device
+}
+
+func (dev Disk) GetSectorSize() uint {
+	return dev.sectorS
+}
+
+func (dev Disk) GetLastSector() uint {
+	return dev.lastS
+}
+
+func (dev Disk) GetLabel() string {
+	return dev.label
+}
+
+func (dev *Disk) Exists() bool {
+	fi, err := dev.sys.FS().Stat(dev.device)
+	if err != nil {
+		return false
+	}
+	// resolve symlink if any
+	if fi.Mode()&os.ModeSymlink != 0 {
+		d, err := dev.sys.FS().Readlink(dev.device)
+		if err != nil {
+			return false
+		}
+		dev.device = d
+	}
+	return true
+}
+
+func (dev *Disk) Reload() error {
+	pc, err := dev.newPartitioner(dev.String())
+	if err != nil {
+		return err
+	}
+
+	prnt, err := pc.Print()
+	if err != nil {
+		return err
+	}
+
+	// if the unallocated space warning is found it is assumed GPT headers
+	// are not properly located to match disk size, so we use sgdisk
+	// to expand the partition table to fully match disk size.
+	// It is expected that in upcoming parted releases (>3.4) there will be
+	// --fix flag to solve this issue transparently on the fly on any parted call.
+	// However this option is not yet present in all major distros.
+	// TODO: Need to experiment with "parted --script --fix /dev/$block_device p"
+	if unallocatedRegexp.Match([]byte(prnt)) {
+		// Parted has not a proper way to doing it in non interactive mode,
+		// because of that we use sgdisk for that...
+		_, err = dev.sys.Runner().Run("sgdisk", "-e", dev.device)
+		if err != nil {
+			return err
+		}
+		// Reload disk data with fixed headers
+		prnt, err = pc.Print()
+		if err != nil {
+			return err
+		}
+	}
+
+	sectorS, err := pc.GetSectorSize(prnt)
+	if err != nil {
+		return err
+	}
+	lastS, err := pc.GetLastSector(prnt)
+	if err != nil {
+		return err
+	}
+	label, err := pc.GetPartitionTableLabel(prnt)
+	if err != nil {
+		return err
+	}
+	partitions := pc.GetPartitions(prnt)
+	dev.sectorS = sectorS
+	dev.lastS = lastS
+	dev.parts = partitions
+	dev.label = label
+	return nil
+}
+
+// Size is expressed in MiB here
+func (dev *Disk) CheckDiskFreeSpaceMiB(minSpace uint) bool {
+	freeS, err := dev.GetFreeSpace()
+	if err != nil {
+		dev.sys.Logger().Warn("Could not calculate disk free space")
+		return false
+	}
+	minSec := MiBToSectors(minSpace, dev.sectorS)
+
+	return freeS >= minSec
+}
+
+func (dev *Disk) GetFreeSpace() (uint, error) {
+	// Check we have loaded partition table data
+	if dev.sectorS == 0 {
+		err := dev.Reload()
+		if err != nil {
+			dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+			return 0, err
+		}
+	}
+
+	return dev.computeFreeSpace(), nil
+}
+
+func (dev Disk) computeFreeSpace() uint {
+	if len(dev.parts) > 0 {
+		lastPart := dev.parts[len(dev.parts)-1]
+		return dev.lastS - (lastPart.StartS + lastPart.SizeS - 1)
+	}
+	// First partition starts at a 1MiB offset
+	return dev.lastS - (1*1024*1024/dev.sectorS - 1)
+}
+
+func (dev Disk) computeFreeSpaceWithoutLast() uint {
+	if len(dev.parts) > 1 {
+		part := dev.parts[len(dev.parts)-2]
+		return dev.lastS - (part.StartS + part.SizeS - 1)
+	}
+	// Assume first partitions is alined to 1MiB
+	return dev.lastS - (1024*1024/dev.sectorS - 1)
+}
+
+func (dev *Disk) NewPartitionTable(label string) (string, error) {
+	pc, err := dev.newPartitioner(dev.String())
+	if err != nil {
+		return "", err
+	}
+
+	err = pc.SetPartitionTableLabel(label)
+	if err != nil {
+		return "", err
+	}
+	pc.WipeTable(true)
+	out, err := pc.WriteChanges()
+	if err != nil {
+		return out, err
+	}
+	err = dev.Reload()
+	if err != nil {
+		dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+		return "", err
+	}
+	return out, nil
+}
+
+// AddPartition adds a partition. Size is expressed in MiB here
+// Size is expressed in MiB here
+func (dev *Disk) AddPartition(size uint, fileSystem string, pLabel string, flags ...string) (int, error) {
+	pc, err := dev.newPartitioner(dev.String())
+	if err != nil {
+		return 0, err
+	}
+
+	// Check we have loaded partition table data
+	if dev.sectorS == 0 {
+		err = dev.Reload()
+		if err != nil {
+			dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+			return 0, err
+		}
+	}
+
+	err = pc.SetPartitionTableLabel(dev.label)
+	if err != nil {
+		return 0, err
+	}
+
+	var partNum int
+	var startS uint
+	if len(dev.parts) > 0 {
+		lastP := len(dev.parts) - 1
+		partNum = dev.parts[lastP].Number
+		startS = dev.parts[lastP].StartS + dev.parts[lastP].SizeS
+	} else {
+		// First partition is aligned at 1MiB
+		startS = 1024 * 1024 / dev.sectorS
+	}
+
+	size = MiBToSectors(size, dev.sectorS)
+	freeS := dev.computeFreeSpace()
+	if size > freeS {
+		return 0, fmt.Errorf("not enough free space in disk. Required: %d sectors; Available %d sectors", size, freeS)
+	}
+
+	partNum++
+	var part = partitioner.Partition{
+		Number:     partNum,
+		StartS:     startS,
+		SizeS:      size,
+		PLabel:     pLabel,
+		FileSystem: fileSystem,
+	}
+
+	pc.CreatePartition(&part)
+	for _, flag := range flags {
+		pc.SetPartitionFlag(partNum, flag, true)
+	}
+
+	out, err := pc.WriteChanges()
+	dev.sys.Logger().Debug("partitioner output: %s", out)
+	if err != nil {
+		dev.sys.Logger().Error("Failed creating partition: %v", err)
+		return 0, err
+	}
+
+	// Reload new partition in dev
+	err = dev.Reload()
+	if err != nil {
+		dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+		return 0, err
+	}
+	return partNum, nil
+}
+
+func (dev Disk) FormatPartition(partNum int, fileSystem string, label string) (string, error) {
+	pDev, err := dev.FindPartitionDevice(partNum)
+	if err != nil {
+		return "", err
+	}
+
+	mkfs := NewMkfsCall(dev.sys, pDev, fileSystem, label)
+	return mkfs.Apply()
+}
+
+func (dev Disk) WipeFsOnPartition(device string) error {
+	_, err := dev.sys.Runner().Run("wipefs", "--all", device)
+	return err
+}
+
+func (dev Disk) FindPartitionDevice(partNum int) (string, error) {
+	re := regexp.MustCompile(`.*\d+$`)
+	var device string
+
+	if match := re.Match([]byte(dev.device)); match {
+		device = fmt.Sprintf("%sp%d", dev.device, partNum)
+	} else {
+		device = fmt.Sprintf("%s%d", dev.device, partNum)
+	}
+
+	for tries := 0; tries <= partitionTries; tries++ {
+		dev.sys.Logger().Debug("Trying to find the partition device %d of device %s (try number %d)", partNum, dev, tries+1)
+		_, _ = dev.sys.Runner().Run("udevadm", "settle")
+		if exists, _ := sys.Exists(dev.sys.FS(), device); exists {
+			return device, nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return "", fmt.Errorf("could not find partition device '%s' for partition %d", device, partNum)
+}
+
+// ExpandLastPartition expands the latest partition in the disk. Size is expressed in MiB here
+// Size is expressed in MiB here
+func (dev *Disk) ExpandLastPartition(size uint) (string, error) {
+	pc, err := dev.newPartitioner(dev.String())
+	if err != nil {
+		return "", err
+	}
+
+	// Check we have loaded partition table data
+	if dev.sectorS == 0 {
+		err = dev.Reload()
+		if err != nil {
+			dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+			return "", err
+		}
+	}
+
+	err = pc.SetPartitionTableLabel(dev.label)
+	if err != nil {
+		return "", err
+	}
+
+	if len(dev.parts) == 0 {
+		return "", errors.New("there is no partition to expand")
+	}
+
+	part := dev.parts[len(dev.parts)-1]
+	if size > 0 {
+		size = MiBToSectors(size, dev.sectorS)
+		part := dev.parts[len(dev.parts)-1]
+		if size < part.SizeS {
+			return "", errors.New("layout plugin can only expand a partition, not shrink it")
+		}
+		freeS := dev.computeFreeSpaceWithoutLast()
+		if size > freeS {
+			return "", fmt.Errorf("not enough free space for to expand last partition up to %d sectors", size)
+		}
+	}
+	part.SizeS = size
+	pc.DeletePartition(part.Number)
+	pc.CreatePartition(&part)
+	out, err := pc.WriteChanges()
+	if err != nil {
+		return out, err
+	}
+	err = dev.Reload()
+	if err != nil {
+		return "", err
+	}
+	pDev, err := dev.FindPartitionDevice(part.Number)
+	if err != nil {
+		return "", err
+	}
+	return dev.expandFilesystem(pDev)
+}
+
+func (dev Disk) expandFilesystem(device string) (outStr string, err error) {
+	var out []byte
+	var tmpDir, fs string
+
+	fs, err = dev.blockDevice.GetPartitionFS(device)
+	if err != nil {
+		return fs, err
+	}
+
+	switch strings.TrimSpace(fs) {
+	case "ext2", "ext3", "ext4":
+		out, err = dev.sys.Runner().Run("e2fsck", "-fy", device)
+		if err != nil {
+			return string(out), err
+		}
+		out, err = dev.sys.Runner().Run("resize2fs", device)
+
+		if err != nil {
+			return string(out), err
+		}
+	case "xfs", "btrfs":
+		// to grow an xfs or btrfs fs it needs to be mounted :/
+		tmpDir, err = sys.TempDir(dev.sys.FS(), "", "partitioner")
+		defer func(fs sys.FS, path string) {
+			_ = fs.RemoveAll(path)
+		}(dev.sys.FS(), tmpDir)
+
+		if err != nil {
+			return string(out), err
+		}
+		err = dev.sys.Mounter().Mount(device, tmpDir, "auto", []string{})
+		if err != nil {
+			return "", err
+		}
+		defer func() {
+			err2 := dev.sys.Mounter().Unmount(tmpDir)
+			if err2 != nil && err == nil {
+				err = err2
+			}
+		}()
+		if strings.TrimSpace(fs) == "xfs" {
+			out, err = dev.sys.Runner().Run("xfs_growfs", tmpDir)
+			if err != nil {
+				return string(out), err
+			}
+		} else {
+			out, err = dev.sys.Runner().Run("btrfs", "filesystem", "resize", "max", tmpDir)
+			if err != nil {
+				return string(out), err
+			}
+		}
+	default:
+		return "", fmt.Errorf("could not find filesystem for %s, not resizing the filesystem", device)
+	}
+
+	return "", nil
+}
+
+func (dev Disk) newPartitioner(device string) (partitioner.Partitioner, error) {
+	switch dev.partBackend {
+	case partedBack:
+		return parted.NewPartedCall(dev.sys, device), nil
+	case gdiskBack, "":
+		return gdisk.NewGdiskCall(dev.sys, device), nil
+	default:
+		return nil, fmt.Errorf("backend '%s' not supported", dev.partBackend)
+	}
+}

--- a/pkg/diskrepart/disk_test.go
+++ b/pkg/diskrepart/disk_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskrepart_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/block"
+	blockmock "github.com/suse/elemental/v3/pkg/block/mock"
+	"github.com/suse/elemental/v3/pkg/diskrepart"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+)
+
+const sgdiskPrint = `Disk /dev/sda: 500118192 sectors, 238.5 GiB
+Logical sector size: 512 bytes
+Disk identifier (GUID): CE4AA9A2-59DF-4DCC-B55A-A27A80676B33
+Partition table holds up to 128 entries
+First usable sector is 34, last usable sector is 500118158
+Partitions will be aligned on 2048-sector boundaries
+Total free space is 2014 sectors (1007.0 KiB)
+
+Number  Start (sector)    End (sector)  Size       Code  Name
+   1            2048          526335   256.0 MiB   EF00
+   2          526336        17303551   8.0 GiB     8200  
+   3        17303552       500118158   230.2 GiB   8300  `
+
+const partedPrint = `BYT;
+/dev/loop0:50593792s:loopback:512:512:msdos:Loopback device:;
+1:2048s:98303s:96256s:ext4::type=83;
+2:98304s:29394943s:29296640s:ext4::boot, type=83;
+3:29394944s:45019135s:15624192s:ext4::type=83;
+4:45019136s:50331647s:5312512s:ext4::type=83;`
+
+func TestDiskRepartSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DiskRepart test suite")
+}
+
+var _ = Describe("DiskRepart", Label("diskrepart"), func() {
+	var runner *sysmock.Runner
+	var mounter *sysmock.Mounter
+	var fs sys.FS
+	var cleanup func()
+	var s *sys.System
+	var dev *diskrepart.Disk
+	var cmds [][]string
+	var printCmd []string
+	var bd *blockmock.Device
+	BeforeEach(func() {
+		var err error
+		runner = sysmock.NewRunner()
+		mounter = sysmock.NewMounter()
+		fs, cleanup, err = sysmock.TestFS(nil)
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(sys.WithMounter(mounter), sys.WithRunner(runner), sys.WithFS(fs))
+		Expect(err).ToNot(HaveOccurred())
+		err = sys.MkdirAll(fs, "/dev", sys.DirPerm)
+		Expect(err).To(BeNil())
+		_, err = fs.Create("/dev/device")
+		Expect(err).To(BeNil())
+
+		bd = blockmock.NewBlockDevice()
+		dev = diskrepart.NewDisk(
+			s, "/dev/device", diskrepart.WithBlockDevice(bd), diskrepart.WithParted(),
+		)
+		printCmd = []string{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "print",
+		}
+		cmds = [][]string{printCmd}
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	It("Creates a disk object", func() {
+		dev = diskrepart.NewDisk(s, "/dev/device", diskrepart.WithParted())
+	})
+	Describe("Load data without changes", func() {
+		BeforeEach(func() {
+			runner.ReturnValue = []byte(partedPrint)
+		})
+		It("Loads disk layout data", func() {
+			Expect(dev.Reload()).To(BeNil())
+			Expect(dev.String()).To(Equal("/dev/device"))
+			Expect(dev.GetSectorSize()).To(Equal(uint(512)))
+			Expect(dev.GetLastSector()).To(Equal(uint(50593792)))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Computes available free space", func() {
+			Expect(dev.GetFreeSpace()).To(Equal(uint(262145)))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Checks it has at least 128MB of free space", func() {
+			Expect(dev.CheckDiskFreeSpaceMiB(128)).To(Equal(true))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Checks it has less than 130MB of free space", func() {
+			Expect(dev.CheckDiskFreeSpaceMiB(130)).To(Equal(false))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Get partition label", func() {
+			dev.Reload()
+			Expect(dev.GetLabel()).To(Equal("msdos"))
+		})
+		It("It fixes GPT headers if the disk was expanded", func() {
+			// for parted regex
+			runner.ReturnValue = []byte("Warning: Not all of the space available to /dev/loop0...\n" + partedPrint)
+			Expect(dev.Reload()).To(BeNil())
+			Expect(runner.MatchMilestones([][]string{
+				{"parted", "--script", "--machine", "--", "/dev/device", "unit", "s", "print"},
+				{"sgdisk", "-e", "/dev/device"},
+				{"parted", "--script", "--machine", "--", "/dev/device", "unit", "s", "print"},
+			})).To(BeNil())
+			// for sgdisk regex
+			dev = diskrepart.NewDisk(s, "/dev/device", diskrepart.WithGdisk())
+			runner.ReturnValue = []byte(sgdiskPrint + "\nProblem: The secondary header's self-pointer indicates that...\n")
+			runner.ClearCmds()
+			Expect(dev.Reload()).To(BeNil())
+			Expect(runner.MatchMilestones([][]string{
+				{"sgdisk", "-p", "-v", "/dev/device"},
+				{"sgdisk", "-e", "/dev/device"},
+				{"sgdisk", "-p", "-v", "/dev/device"},
+			})).To(BeNil())
+		})
+	})
+	Describe("Modify disk", func() {
+		It("Format an already existing partition", func() {
+			err := diskrepart.FormatDevice(s, "/dev/device1", "ext4", "MY_LABEL")
+			Expect(err).To(BeNil())
+			Expect(runner.CmdsMatch([][]string{
+				{"mkfs.ext4", "-L", "MY_LABEL", "/dev/device1"},
+			})).To(BeNil())
+		})
+		It("Fails to create an unsupported partition table label", func() {
+			runner.ReturnValue = []byte(partedPrint)
+			_, err := dev.NewPartitionTable("invalidLabel")
+			Expect(err).NotTo(BeNil())
+		})
+		It("Creates new partition table label", func() {
+			cmds = [][]string{{
+				"parted", "--script", "--machine", "--", "/dev/device",
+				"unit", "s", "mklabel", "gpt",
+			}, {
+				"partx", "-u", "/dev/device",
+			}, printCmd}
+			runner.ReturnValue = []byte(partedPrint)
+			_, err := dev.NewPartitionTable("gpt")
+			Expect(err).To(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Adds a new partition", func() {
+			cmds = [][]string{printCmd, {
+				"parted", "--script", "--machine", "--", "/dev/device",
+				"unit", "s", "mkpart", "primary", "ext4", "50331648", "100%",
+				"set", "5", "boot", "on",
+			}, {
+				"partx", "-u", "/dev/device",
+			}, printCmd}
+			runner.ReturnValue = []byte(partedPrint)
+			num, err := dev.AddPartition(0, "ext4", "ignored", "boot")
+			Expect(err).To(BeNil())
+			Expect(num).To(Equal(5))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Fails to a new partition if there is not enough space available", func() {
+			cmds = [][]string{printCmd}
+			runner.ReturnValue = []byte(partedPrint)
+			_, err := dev.AddPartition(130, "ext4", "ignored")
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Finds device for a given partition number", func() {
+			_, err := fs.Create("/dev/device4")
+			Expect(err).To(BeNil())
+			cmds = [][]string{{"udevadm", "settle"}}
+			Expect(dev.FindPartitionDevice(4)).To(Equal("/dev/device4"))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Does not find device for a given partition number", func() {
+			dev := diskrepart.NewDisk(s, "/dev/lp0")
+			_, err := dev.FindPartitionDevice(4)
+			Expect(err).NotTo(BeNil())
+		})
+		It("Formats a partition", func() {
+			_, err := fs.Create("/dev/device4")
+			Expect(err).To(BeNil())
+			cmds = [][]string{
+				{"udevadm", "settle"},
+				{"mkfs.xfs", "-L", "OEM", "/dev/device4"},
+			}
+			_, err = dev.FormatPartition(4, "xfs", "OEM")
+			Expect(err).To(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Clears filesystem header from a partition", func() {
+			cmds = [][]string{
+				{"wipefs", "--all", "/dev/device1"},
+			}
+			Expect(dev.WipeFsOnPartition("/dev/device1")).To(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("Fails while removing file system header", func() {
+			runner.ReturnError = errors.New("some error")
+			Expect(dev.WipeFsOnPartition("/dev/device1")).NotTo(BeNil())
+		})
+		Describe("Expanding partitions", func() {
+			BeforeEach(func() {
+				cmds = [][]string{
+					printCmd, {
+						"parted", "--script", "--machine", "--", "/dev/device",
+						"unit", "s", "rm", "4", "mkpart", "primary", "", "45019136", "100%",
+					}, {
+						"partx", "-u", "/dev/device",
+					}, printCmd, {"udevadm", "settle"},
+				}
+				runFunc := func(cmd string, args ...string) ([]byte, error) {
+					switch cmd {
+					case "parted":
+						return []byte(partedPrint), nil
+					default:
+						return []byte{}, nil
+					}
+				}
+				runner.SideEffect = runFunc
+			})
+			It("Expands ext4 partition", func() {
+				_, err := fs.Create("/dev/device4")
+				Expect(err).To(BeNil())
+				extCmds := [][]string{
+					{"e2fsck", "-fy", "/dev/device4"}, {"resize2fs", "/dev/device4"},
+				}
+				bd.SetPartitions([]*block.Partition{
+					{
+						Disk: "device",
+						Path: "/dev/device4",
+						FS:   "ext4",
+					},
+				})
+				_, err = dev.ExpandLastPartition(0)
+				Expect(err).To(BeNil())
+				Expect(runner.CmdsMatch(append(cmds, extCmds...))).To(BeNil())
+			})
+			It("Expands xfs partition", func() {
+				_, err := fs.Create("/dev/device4")
+				Expect(err).To(BeNil())
+				xfsCmds := [][]string{{"xfs_growfs"}}
+				bd.SetPartitions([]*block.Partition{
+					{
+						Disk: "device",
+						Path: "/dev/device4",
+						FS:   "xfs",
+					},
+				})
+				_, err = dev.ExpandLastPartition(0)
+				Expect(err).To(BeNil())
+				Expect(runner.CmdsMatch(append(cmds, xfsCmds...))).To(BeNil())
+			})
+			It("Expands btrfs partition", func() {
+				_, err := fs.Create("/dev/device4")
+				Expect(err).To(BeNil())
+				xfsCmds := [][]string{{"btrfs", "filesystem", "resize"}}
+				bd.SetPartitions([]*block.Partition{
+					{
+						Disk: "device",
+						Path: "/dev/device4",
+						FS:   "btrfs",
+					},
+				})
+				_, err = dev.ExpandLastPartition(0)
+				Expect(err).To(BeNil())
+				Expect(runner.CmdsMatch(append(cmds, xfsCmds...))).To(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/diskrepart/mkfs.go
+++ b/pkg/diskrepart/mkfs.go
@@ -1,0 +1,81 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskrepart
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+type MkfsCall struct {
+	fileSystem string
+	label      string
+	customOpts []string
+	dev        string
+	runner     sys.Runner
+}
+
+func NewMkfsCall(s *sys.System, dev string, fileSystem string, label string, customOpts ...string) *MkfsCall {
+	return &MkfsCall{dev: dev, fileSystem: fileSystem, label: label, runner: s.Runner(), customOpts: customOpts}
+}
+
+func (mkfs MkfsCall) buildOptions() ([]string, error) {
+	opts := []string{}
+
+	linuxFS, _ := regexp.MatchString("ext[2-4]|xfs|btrfs", mkfs.fileSystem)
+	fatFS, _ := regexp.MatchString("fat|vfat", mkfs.fileSystem)
+
+	switch {
+	case linuxFS:
+		if mkfs.label != "" {
+			opts = append(opts, "-L")
+			opts = append(opts, mkfs.label)
+		}
+		if len(mkfs.customOpts) > 0 {
+			opts = append(opts, mkfs.customOpts...)
+		}
+		if mkfs.fileSystem == "btrfs" {
+			opts = append(opts, "-f")
+		}
+		opts = append(opts, mkfs.dev)
+	case fatFS:
+		if mkfs.label != "" {
+			opts = append(opts, "-n")
+			opts = append(opts, mkfs.label)
+		}
+		if len(mkfs.customOpts) > 0 {
+			opts = append(opts, mkfs.customOpts...)
+		}
+		opts = append(opts, mkfs.dev)
+	default:
+		return []string{}, fmt.Errorf("unsupported filesystem: %s", mkfs.fileSystem)
+	}
+	return opts, nil
+}
+
+func (mkfs MkfsCall) Apply() (string, error) {
+	opts, err := mkfs.buildOptions()
+	if err != nil {
+		return "", err
+	}
+	tool := fmt.Sprintf("mkfs.%s", mkfs.fileSystem)
+	out, err := mkfs.runner.Run(tool, opts...)
+	return string(out), err
+}

--- a/pkg/diskrepart/mkfs_test.go
+++ b/pkg/diskrepart/mkfs_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskrepart_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/diskrepart"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+)
+
+var _ = Describe("Parted", Label("parted"), func() {
+	var runner *sysmock.Runner
+	var s *sys.System
+	BeforeEach(func() {
+		var err error
+		runner = sysmock.NewRunner()
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(sys.WithRunner(runner))
+		Expect(err).ToNot(HaveOccurred())
+	})
+	It("Successfully formats a partition with xfs", func() {
+		mkfs := diskrepart.NewMkfsCall(s, "/dev/device", "xfs", "OEM")
+		_, err := mkfs.Apply()
+		Expect(err).To(BeNil())
+		cmds := [][]string{{"mkfs.xfs", "-L", "OEM", "/dev/device"}}
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Successfully formats a partition with btrfs", func() {
+		mkfs := diskrepart.NewMkfsCall(s, "/dev/device", "btrfs", "", "--customopt")
+		_, err := mkfs.Apply()
+		Expect(err).To(BeNil())
+		cmds := [][]string{{"mkfs.btrfs", "--customopt", "-f", "/dev/device"}}
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Successfully formats a partition with vfat", func() {
+		mkfs := diskrepart.NewMkfsCall(s, "/dev/device", "vfat", "EFI")
+		_, err := mkfs.Apply()
+		Expect(err).To(BeNil())
+		cmds := [][]string{{"mkfs.vfat", "-n", "EFI", "/dev/device"}}
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Fails for unsupported filesystem", func() {
+		mkfs := diskrepart.NewMkfsCall(s, "/dev/device", "zfs", "OEM")
+		_, err := mkfs.Apply()
+		Expect(err).NotTo(BeNil())
+	})
+})

--- a/pkg/diskrepart/partitioner/gdisk/gdisk.go
+++ b/pkg/diskrepart/partitioner/gdisk/gdisk.go
@@ -1,0 +1,227 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gdisk
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+const (
+	// Partition table types and partition types
+	efiType   = "EF00"
+	biosType  = "EF02" //nolint:unused
+	linuxType = "8300"
+
+	gpt = "gpt"
+)
+
+type gdiskCall struct {
+	dev       string
+	wipe      bool
+	parts     []*partitioner.Partition
+	deletions []int
+	runner    sys.Runner
+	expand    bool
+	pretend   bool
+}
+
+func NewGdiskCall(s *sys.System, dev string) partitioner.Partitioner {
+	return &gdiskCall{
+		dev:       dev,
+		runner:    s.Runner(),
+		parts:     []*partitioner.Partition{},
+		deletions: []int{},
+	}
+}
+
+func (gd gdiskCall) buildOptions() []string {
+	opts := []string{}
+	isFat := regexp.MustCompile("fat|vfat")
+
+	if gd.pretend {
+		opts = append(opts, "-P")
+	}
+
+	if gd.wipe {
+		opts = append(opts, "--zap-all")
+	}
+
+	if gd.expand {
+		opts = append(opts, "-e")
+	}
+
+	for _, partnum := range gd.deletions {
+		opts = append(opts, fmt.Sprintf("-d=%d", partnum))
+	}
+
+	for _, part := range gd.parts {
+		opts = append(opts, fmt.Sprintf("-n=%d:%d:+%d", part.Number, part.StartS, part.SizeS))
+
+		if part.PLabel != "" {
+			opts = append(opts, fmt.Sprintf("-c=%d:%s", part.Number, part.PLabel))
+		}
+
+		// Assumes any fat partition is for EFI
+		if isFat.MatchString(part.FileSystem) {
+			opts = append(opts, fmt.Sprintf("-t=%d:%s", part.Number, efiType))
+		} else if part.FileSystem != "" {
+			opts = append(opts, fmt.Sprintf("-t=%d:%s", part.Number, linuxType))
+		}
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+
+	opts = append(opts, gd.dev)
+	return opts
+}
+
+func (gd gdiskCall) Verify() (string, error) {
+	out, err := gd.runner.Run("sgdisk", "--verify", gd.dev)
+	return string(out), err
+}
+
+func (gd *gdiskCall) WriteChanges() (string, error) {
+	// Run sgdisk with --pretend flag first to as a sanity check
+	// before any change to disk happens
+	gd.SetPretend(true)
+	opts := gd.buildOptions()
+	out, err := gd.runner.Run("sgdisk", opts...)
+	if err != nil {
+		return string(out), err
+	}
+
+	gd.SetPretend(false)
+	opts = gd.buildOptions()
+	out, err = gd.runner.Run("sgdisk", opts...)
+
+	// Notify kernel of partition table changes, swallows errors, just a best effort call
+	_, _ = gd.runner.Run("partx", "-u", gd.dev)
+	gd.wipe = false
+	gd.parts = []*partitioner.Partition{}
+	gd.deletions = []int{}
+	return string(out), err
+}
+
+func (gd gdiskCall) SetPartitionTableLabel(label string) error {
+	if label != "gpt" {
+		return fmt.Errorf("invalid partition table type (%s), only GPT is supported by sgdisk", label)
+	}
+	return nil
+}
+
+func (gd *gdiskCall) CreatePartition(p *partitioner.Partition) {
+	gd.parts = append(gd.parts, p)
+}
+
+func (gd *gdiskCall) DeletePartition(num int) {
+	gd.deletions = append(gd.deletions, num)
+}
+
+func (gd *gdiskCall) SetPartitionFlag(_ int, _ string, _ bool) {
+	// Just implemented in case there is a shared interface with parted wrapper someday
+	// sgdisk does not make use of flags concept, doesn't make much sense for GPT.
+}
+
+func (gd *gdiskCall) WipeTable(wipe bool) {
+	gd.wipe = wipe
+}
+
+func (gd gdiskCall) Print() (string, error) {
+	out, err := gd.runner.Run("sgdisk", "-p", "-v", gd.dev)
+	return string(out), err
+}
+
+// Parses the output of a gdiskCall.Print call
+func (gd gdiskCall) GetLastSector(printOut string) (uint, error) {
+	re := regexp.MustCompile(`last usable sector is (\d+)`)
+	match := re.FindStringSubmatch(printOut)
+	if match != nil {
+		endS, err := strconv.ParseUint(match[1], 10, 0)
+		return uint(endS), err
+	}
+	return 0, errors.New("could not determine last usable sector")
+}
+
+// Parses the output of a gdiskCall.Print call
+func (gd gdiskCall) GetSectorSize(printOut string) (uint, error) {
+	re := regexp.MustCompile(`[Ss]ector size.* (\d+) bytes`)
+	match := re.FindStringSubmatch(printOut)
+	if match != nil {
+		size, err := strconv.ParseUint(match[1], 10, 0)
+		return uint(size), err
+	}
+	return 0, errors.New("could not determine sector size")
+}
+
+// TODO parse printOut from a non gpt disk and return error here
+func (gd gdiskCall) GetPartitionTableLabel(_ string) (string, error) {
+	return gpt, nil
+}
+
+// Parses the output of a gdiskCall.Print call
+func (gd gdiskCall) GetPartitions(printOut string) []partitioner.Partition { //nolint:dupl
+	re := regexp.MustCompile(`^(\d+)\s+(\d+)\s+(\d+).*(EF02|EF00|8300)\s*(.*)$`)
+	var start uint
+	var end uint
+	var size uint
+	var pLabel string
+	var partNum int
+	var partitions []partitioner.Partition
+
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(printOut)))
+	for scanner.Scan() {
+		match := re.FindStringSubmatch(strings.TrimSpace(scanner.Text()))
+		if match != nil {
+			partNum, _ = strconv.Atoi(match[1])
+			parsed, _ := strconv.ParseUint(match[2], 10, 0)
+			start = uint(parsed)
+			parsed, _ = strconv.ParseUint(match[3], 10, 0)
+			end = uint(parsed)
+			size = end - start + 1
+			pLabel = match[5]
+
+			partitions = append(partitions, partitioner.Partition{
+				Number:     partNum,
+				StartS:     start,
+				SizeS:      size,
+				PLabel:     pLabel,
+				FileSystem: "",
+			})
+		}
+	}
+
+	return partitions
+}
+
+func (gd *gdiskCall) SetPretend(pretend bool) {
+	gd.pretend = pretend
+}
+
+func (gd *gdiskCall) ExpandPTable() {
+	gd.expand = true
+}

--- a/pkg/diskrepart/partitioner/gdisk/gdisk_test.go
+++ b/pkg/diskrepart/partitioner/gdisk/gdisk_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gdisk_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner/gdisk"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+)
+
+const sgdiskPrint = `Disk /dev/sda: 500118192 sectors, 238.5 GiB
+Logical sector size: 512 bytes
+Disk identifier (GUID): CE4AA9A2-59DF-4DCC-B55A-A27A80676B33
+Partition table holds up to 128 entries
+First usable sector is 34, last usable sector is 500118158
+Partitions will be aligned on 2048-sector boundaries
+Total free space is 2014 sectors (1007.0 KiB)
+
+Number  Start (sector)    End (sector)  Size       Code  Name
+   1            2048          526335   256.0 MiB   EF00
+   2          526336        17303551   8.0 GiB     8200  
+   3        17303552       500118158   230.2 GiB   8300  `
+
+func TestGdiskSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gdisk test suite")
+}
+
+var _ = Describe("Parted", Label("parted"), func() {
+	var runner *sysmock.Runner
+	var gc partitioner.Partitioner
+	var s *sys.System
+	BeforeEach(func() {
+		var err error
+		runner = sysmock.NewRunner()
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(sys.WithRunner(runner))
+		Expect(err).ToNot(HaveOccurred())
+		gc = gdisk.NewGdiskCall(s, "/dev/device")
+	})
+	It("Write changes does nothing with empty setup", func() {
+		gc := gdisk.NewGdiskCall(s, "/dev/device")
+		_, err := gc.WriteChanges()
+		Expect(err).To(BeNil())
+	})
+	It("Runs complex command", func() {
+		cmds := [][]string{
+			{"sgdisk", "-P", "--zap-all", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
+				"-n=1:206848:+0", "-c=1:p.root", "-t=1:8300", "/dev/device"},
+			{"sgdisk", "--zap-all", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
+				"-n=1:206848:+0", "-c=1:p.root", "-t=1:8300", "/dev/device"},
+			{"partx", "-u", "/dev/device"},
+		}
+		part1 := partitioner.Partition{
+			Number: 0, StartS: 2048, SizeS: 204800,
+			PLabel: "p.efi", FileSystem: "vfat",
+		}
+		gc.CreatePartition(&part1)
+		part2 := partitioner.Partition{
+			Number: 1, StartS: 206848, SizeS: 0,
+			PLabel: "p.root", FileSystem: "ext4",
+		}
+		gc.CreatePartition(&part2)
+		gc.WipeTable(true)
+		_, err := gc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Set a new partition label", func() {
+		cmds := [][]string{
+			{"sgdisk", "-P", "--zap-all", "/dev/device"},
+			{"sgdisk", "--zap-all", "/dev/device"},
+			{"partx", "-u", "/dev/device"},
+		}
+		Expect(gc.SetPartitionTableLabel("gpt")).To(Succeed())
+		gc.WipeTable(true)
+		_, err := gc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Fails setting a new partition label", func() {
+		Expect(gc.SetPartitionTableLabel("msdos")).NotTo(Succeed())
+	})
+	It("Creates a new partition", func() {
+		cmds := [][]string{
+			{"sgdisk", "-n=0:2048:+204800", "-c=0:p.root", "-t=0:8300", "/dev/device"},
+			{"partx", "-u", "/dev/device"},
+			{"sgdisk", "-n=0:2048:+0", "-c=0:p.root", "-t=0:8300", "/dev/device"},
+			{"partx", "-u", "/dev/device"},
+		}
+		partition := partitioner.Partition{
+			Number: 0, StartS: 2048, SizeS: 204800,
+			PLabel: "p.root", FileSystem: "ext4",
+		}
+		gc.CreatePartition(&partition)
+		_, err := gc.WriteChanges()
+		Expect(err).To(BeNil())
+		partition = partitioner.Partition{
+			Number: 0, StartS: 2048, SizeS: 0,
+			PLabel: "p.root", FileSystem: "ext4",
+		}
+		gc.CreatePartition(&partition)
+		_, err = gc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.MatchMilestones(cmds)).To(BeNil())
+	})
+	It("Deletes a partition", func() {
+		cmds := [][]string{
+			{"sgdisk", "-P", "-d=1", "-d=2", "/dev/device"},
+			{"sgdisk", "-d=1", "-d=2", "/dev/device"},
+			{"partx", "-u", "/dev/device"},
+		}
+		gc.DeletePartition(1)
+		gc.DeletePartition(2)
+		_, err := gc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Wipes partition table creating a new one", func() {
+		cmds := [][]string{
+			{"sgdisk", "-P", "--zap-all", "/dev/device"}, {"sgdisk", "--zap-all", "/dev/device"},
+			{"partx", "-u", "/dev/device"},
+		}
+		gc.WipeTable(true)
+		_, err := gc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Prints partition table info", func() {
+		cmd := []string{"sgdisk", "-p", "-v", "/dev/device"}
+		_, err := gc.Print()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch([][]string{cmd})).To(BeNil())
+	})
+	It("Gets last sector of the disk", func() {
+		lastSec, _ := gc.GetLastSector(sgdiskPrint)
+		Expect(lastSec).To(Equal(uint(500118158)))
+		_, err := gc.GetLastSector("invalid parted print output")
+		Expect(err).NotTo(BeNil())
+	})
+	It("Gets sector size of the disk", func() {
+		secSize, _ := gc.GetSectorSize(sgdiskPrint)
+		Expect(secSize).To(Equal(uint(512)))
+		_, err := gc.GetSectorSize("invalid parted print output")
+		Expect(err).NotTo(BeNil())
+	})
+	It("Gets partition table label", func() {
+		label, _ := gc.GetPartitionTableLabel(sgdiskPrint)
+		Expect(label).To(Equal("gpt"))
+	})
+	It("Gets partitions info of the disk", func() {
+		parts := gc.GetPartitions(sgdiskPrint)
+		// Ignores swap partition
+		Expect(len(parts)).To(Equal(2))
+		Expect(parts[1].StartS).To(Equal(uint(17303552)))
+	})
+})

--- a/pkg/diskrepart/partitioner/parted/parted.go
+++ b/pkg/diskrepart/partitioner/parted/parted.go
@@ -1,0 +1,233 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parted
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+const (
+	gpt = "gpt"
+)
+
+type partedCall struct {
+	dev       string
+	wipe      bool
+	parts     []*partitioner.Partition
+	deletions []int
+	label     string
+	runner    sys.Runner
+	flags     []partFlag
+}
+
+type partFlag struct {
+	flag   string
+	active bool
+	number int
+}
+
+func NewPartedCall(s *sys.System, dev string) partitioner.Partitioner {
+	return &partedCall{dev: dev, wipe: false, parts: []*partitioner.Partition{}, deletions: []int{}, label: "", runner: s.Runner(), flags: []partFlag{}}
+}
+
+func (pc partedCall) optionsBuilder() []string {
+	opts := []string{}
+	label := pc.label
+	match, _ := regexp.MatchString(fmt.Sprintf("msdos|%s", gpt), label)
+	// Fallback to gpt if label is empty or invalid
+	if !match {
+		label = gpt
+	}
+
+	if pc.wipe {
+		opts = append(opts, "mklabel", label)
+	}
+
+	for _, partnum := range pc.deletions {
+		opts = append(opts, "rm", fmt.Sprintf("%d", partnum))
+	}
+
+	isFat := regexp.MustCompile("fat|vfat")
+	for _, part := range pc.parts {
+		var pLabel string
+		switch {
+		case label == gpt && part.PLabel != "":
+			pLabel = part.PLabel
+		case label == gpt:
+		default:
+			pLabel = "primary"
+		}
+
+		opts = append(opts, "mkpart", pLabel)
+
+		if isFat.MatchString(part.FileSystem) {
+			opts = append(opts, "fat32")
+		} else {
+			opts = append(opts, part.FileSystem)
+		}
+
+		if part.SizeS == 0 {
+			// Size set to zero means is interperted as all space available
+			opts = append(opts, fmt.Sprintf("%d", part.StartS), "100%")
+		} else {
+			opts = append(opts, fmt.Sprintf("%d", part.StartS), fmt.Sprintf("%d", part.StartS+part.SizeS-1))
+		}
+	}
+
+	for _, flag := range pc.flags {
+		opts = append(opts, "set", fmt.Sprintf("%d", flag.number), flag.flag)
+		if flag.active {
+			opts = append(opts, "on")
+		} else {
+			opts = append(opts, "off")
+		}
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+
+	return append([]string{"--script", "--machine", "--", pc.dev, "unit", "s"}, opts...)
+}
+
+func (pc *partedCall) WriteChanges() (string, error) {
+	opts := pc.optionsBuilder()
+	if len(opts) == 0 {
+		return "", nil
+	}
+	out, err := pc.runner.Run("parted", opts...)
+
+	// Notify kernel of partition table changes, swallows errors, just a best effort call
+	_, _ = pc.runner.Run("partx", "-u", pc.dev)
+	pc.wipe = false
+	pc.parts = []*partitioner.Partition{}
+	pc.deletions = []int{}
+	return string(out), err
+}
+
+func (pc *partedCall) SetPartitionTableLabel(label string) error {
+	match, _ := regexp.MatchString("msdos|gpt", label)
+	if !match {
+		return fmt.Errorf("invalid partition table type, only msdos and gpt are supported")
+	}
+	pc.label = label
+	return nil
+}
+
+func (pc *partedCall) CreatePartition(p *partitioner.Partition) {
+	pc.parts = append(pc.parts, p)
+}
+
+func (pc *partedCall) DeletePartition(num int) {
+	pc.deletions = append(pc.deletions, num)
+}
+
+func (pc *partedCall) SetPartitionFlag(num int, flag string, active bool) {
+	pc.flags = append(pc.flags, partFlag{flag: flag, active: active, number: num})
+}
+
+func (pc *partedCall) WipeTable(wipe bool) {
+	pc.wipe = wipe
+}
+
+func (pc partedCall) Print() (string, error) {
+	out, err := pc.runner.Run("parted", "--script", "--machine", "--", pc.dev, "unit", "s", "print")
+	return string(out), err
+}
+
+// Parses the output of a partedCall.Print call
+func (pc partedCall) parseHeaderFields(printOut string, field int) (string, error) {
+	re := regexp.MustCompile(`^(.*):(\d+)s:(.*):(\d+):(\d+):(.*):(.*):(.*);$`)
+
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(printOut)))
+	for scanner.Scan() {
+		match := re.FindStringSubmatch(strings.TrimSpace(scanner.Text()))
+		if match != nil {
+			return match[field], nil
+		}
+	}
+	return "", errors.New("failed parsing parted header data")
+}
+
+// Parses the output of a partedCall.Print call
+func (pc partedCall) GetLastSector(printOut string) (uint, error) {
+	field, err := pc.parseHeaderFields(printOut, 2)
+	if err != nil {
+		return 0, errors.New("failed parsing last sector")
+	}
+	lastSec, err := strconv.ParseUint(field, 10, 0)
+	return uint(lastSec), err
+}
+
+// Parses the output of a partedCall.Print call
+func (pc partedCall) GetSectorSize(printOut string) (uint, error) {
+	field, err := pc.parseHeaderFields(printOut, 4)
+	if err != nil {
+		return 0, errors.New("failed parsing sector size")
+	}
+	secSize, err := strconv.ParseUint(field, 10, 0)
+	return uint(secSize), err
+}
+
+// Parses the output of a partedCall.Print call
+func (pc partedCall) GetPartitionTableLabel(printOut string) (string, error) {
+	return pc.parseHeaderFields(printOut, 6)
+}
+
+// Parses the output of a GdiskCall.Print call
+func (pc partedCall) GetPartitions(printOut string) []partitioner.Partition { //nolint:dupl
+	re := regexp.MustCompile(`^(\d+):(\d+)s:(\d+)s:(\d+)s:(.*):(.*):(.*);$`)
+	var start uint
+	var end uint
+	var size uint
+	var pLabel string
+	var partNum int
+	var partitions []partitioner.Partition
+
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(printOut)))
+	for scanner.Scan() {
+		match := re.FindStringSubmatch(strings.TrimSpace(scanner.Text()))
+		if match != nil {
+			partNum, _ = strconv.Atoi(match[1])
+			parsed, _ := strconv.ParseUint(match[2], 10, 0)
+			start = uint(parsed)
+			parsed, _ = strconv.ParseUint(match[3], 10, 0)
+			end = uint(parsed)
+			size = end - start + 1
+			pLabel = match[6]
+
+			partitions = append(partitions, partitioner.Partition{
+				Number:     partNum,
+				StartS:     start,
+				SizeS:      size,
+				PLabel:     pLabel,
+				FileSystem: "",
+			})
+		}
+	}
+
+	return partitions
+}

--- a/pkg/diskrepart/partitioner/parted/parted_test.go
+++ b/pkg/diskrepart/partitioner/parted/parted_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parted_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner"
+	"github.com/suse/elemental/v3/pkg/diskrepart/partitioner/parted"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+)
+
+const partedPrint = `BYT;
+/dev/loop0:50593792s:loopback:512:512:msdos:Loopback device:;
+1:2048s:98303s:96256s:ext4::type=83;
+2:98304s:29394943s:29296640s:ext4::boot, type=83;
+3:29394944s:45019135s:15624192s:ext4::type=83;
+4:45019136s:50331647s:5312512s:ext4::type=83;`
+
+func TestPartedSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Parted test suite")
+}
+
+var _ = Describe("Parted", Label("parted"), func() {
+	var runner *sysmock.Runner
+	var pc partitioner.Partitioner
+	var s *sys.System
+	BeforeEach(func() {
+		var err error
+		runner = sysmock.NewRunner()
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(sys.WithRunner(runner))
+		Expect(err).ToNot(HaveOccurred())
+		pc = parted.NewPartedCall(s, "/dev/device")
+	})
+	It("Write changes does nothing with empty setup", func() {
+		pc = parted.NewPartedCall(s, "/dev/device")
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+	})
+	It("Runs complex command", func() {
+		cmds := [][]string{{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "mklabel", "gpt", "mkpart", "p.efi", "fat32",
+			"2048", "206847", "mkpart", "p.root", "ext4", "206848", "100%",
+		}, {
+			"partx", "-u", "/dev/device",
+		}}
+		part1 := partitioner.Partition{
+			Number: 0, StartS: 2048, SizeS: 204800,
+			PLabel: "p.efi", FileSystem: "vfat",
+		}
+		pc.CreatePartition(&part1)
+		part2 := partitioner.Partition{
+			Number: 0, StartS: 206848, SizeS: 0,
+			PLabel: "p.root", FileSystem: "ext4",
+		}
+		pc.CreatePartition(&part2)
+		pc.WipeTable(true)
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Set a new partition label", func() {
+		cmds := [][]string{{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "mklabel", "msdos",
+		}, {
+			"partx", "-u", "/dev/device",
+		}}
+		pc.SetPartitionTableLabel("msdos")
+		pc.WipeTable(true)
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Creates a new partition", func() {
+		cmds := [][]string{{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "mkpart", "p.root", "ext4", "2048", "206847",
+		}, {
+			"partx", "-u", "/dev/device",
+		}, {
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "mkpart", "p.root", "ext4", "2048", "100%",
+		}, {
+			"partx", "-u", "/dev/device",
+		}}
+		partition := partitioner.Partition{
+			Number: 0, StartS: 2048, SizeS: 204800,
+			PLabel: "p.root", FileSystem: "ext4",
+		}
+		pc.CreatePartition(&partition)
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+		partition = partitioner.Partition{
+			Number: 0, StartS: 2048, SizeS: 0,
+			PLabel: "p.root", FileSystem: "ext4",
+		}
+		pc.CreatePartition(&partition)
+		_, err = pc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Deletes a partition", func() {
+		cmds := [][]string{{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "rm", "1", "rm", "2",
+		}, {
+			"partx", "-u", "/dev/device",
+		}}
+		pc.DeletePartition(1)
+		pc.DeletePartition(2)
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Set a partition flag", func() {
+		cmds := [][]string{{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "set", "1", "flag", "on", "set", "2", "flag", "off",
+		}, {
+			"partx", "-u", "/dev/device",
+		}}
+		pc.SetPartitionFlag(1, "flag", true)
+		pc.SetPartitionFlag(2, "flag", false)
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Wipes partition table creating a new one", func() {
+		cmds := [][]string{{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "mklabel", "gpt",
+		}, {
+			"partx", "-u", "/dev/device",
+		}}
+		pc.WipeTable(true)
+		_, err := pc.WriteChanges()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch(cmds)).To(BeNil())
+	})
+	It("Prints partitin table info", func() {
+		cmd := []string{
+			"parted", "--script", "--machine", "--", "/dev/device",
+			"unit", "s", "print",
+		}
+		_, err := pc.Print()
+		Expect(err).To(BeNil())
+		Expect(runner.CmdsMatch([][]string{cmd})).To(BeNil())
+	})
+	It("Gets last sector of the disk", func() {
+		lastSec, _ := pc.GetLastSector(partedPrint)
+		Expect(lastSec).To(Equal(uint(50593792)))
+		_, err := pc.GetLastSector("invalid parted print output")
+		Expect(err).NotTo(BeNil())
+	})
+	It("Gets sector size of the disk", func() {
+		secSize, _ := pc.GetSectorSize(partedPrint)
+		Expect(secSize).To(Equal(uint(512)))
+		_, err := pc.GetSectorSize("invalid parted print output")
+		Expect(err).NotTo(BeNil())
+	})
+	It("Gets partition table label", func() {
+		label, _ := pc.GetPartitionTableLabel(partedPrint)
+		Expect(label).To(Equal("msdos"))
+		_, err := pc.GetPartitionTableLabel("invalid parted print output")
+		Expect(err).NotTo(BeNil())
+	})
+	It("Gets partitions info of the disk", func() {
+		parts := pc.GetPartitions(partedPrint)
+		Expect(len(parts)).To(Equal(4))
+		Expect(parts[1].StartS).To(Equal(uint(98304)))
+	})
+})

--- a/pkg/diskrepart/partitioner/partitioner.go
+++ b/pkg/diskrepart/partitioner/partitioner.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package partitioner
+
+type Partitioner interface {
+	WriteChanges() (string, error)
+	SetPartitionTableLabel(label string) error
+	CreatePartition(p *Partition)
+	DeletePartition(num int)
+	SetPartitionFlag(num int, flag string, active bool)
+	WipeTable(wipe bool)
+	GetLastSector(printOut string) (uint, error)
+	Print() (string, error)
+	GetSectorSize(printOut string) (uint, error)
+	GetPartitionTableLabel(printOut string) (string, error)
+	GetPartitions(printOut string) []Partition
+}
+
+// We only manage sizes in sectors unit for the Partition structre in parted wrapper
+// FileSystem here is only used by parted to determine the partition ID or type
+type Partition struct {
+	Number     int
+	StartS     uint
+	SizeS      uint
+	PLabel     string
+	FileSystem string
+}


### PR DESCRIPTION
This diskrepart package defines objects and interfaces to handle disk partitioning tasks. There are two different implementations for the partitioner interface, one based on parted and another one based on sgdisk.

Former Elemental Toolkit started wrapping around parted to provide legacy msdos partition table support. However to build RAW disks in unprivileged environments sgdisk was required and a new implementation of the interface got included.