### PR TITLE
Extend runner interface and add rsync package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-GINKGO?= "github.com/onsi/ginkgo/v2/ginkgo"
+GINKGO?="github.com/onsi/ginkgo/v2/ginkgo"
 
-PKG:=./pkg/...
+PKG?=./pkg/...
 
 .PHONY: unit-tests
 unit-tests:

--- a/pkg/rsync/sync.go
+++ b/pkg/rsync/sync.go
@@ -1,0 +1,133 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rsync
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+type Rsync struct {
+	ctx   context.Context
+	flags []string
+	s     *sys.System
+}
+
+type Opts func(r *Rsync)
+
+func WithFlags(flags ...string) Opts {
+	return func(r *Rsync) {
+		r.flags = flags
+	}
+}
+
+func WithContext(ctx context.Context) Opts {
+	return func(r *Rsync) {
+		r.ctx = ctx
+	}
+}
+
+func NewRsync(s *sys.System, opts ...Opts) *Rsync {
+	rsync := &Rsync{
+		flags: DefaultFlags(),
+		s:     s,
+	}
+
+	for _, o := range opts {
+		o(rsync)
+	}
+	return rsync
+}
+
+// SyncData rsync's source folder contents to a target folder content,
+// both are expected to exist before hand.
+func (r Rsync) SyncData(source string, target string, excludes ...string) error {
+	flags := r.flags
+	for _, e := range excludes {
+		flags = append(flags, fmt.Sprintf("--exclude=%s", e))
+	}
+
+	return r.rsyncWrapper(source, target, flags)
+}
+
+// MirrorData rsync's source folder contents to a target folder content, in contrast, to SyncData this
+// method adds the --delete flag which forces the deletion of files in target that are missing in source.
+func (r Rsync) MirrorData(source string, target string, excludes ...string) error {
+	flags := r.flags
+	if !slices.Contains(flags, "--delete") {
+		flags = append(flags, "--delete")
+	}
+	for _, e := range excludes {
+		flags = append(flags, fmt.Sprintf("--exclude=%s", e))
+	}
+
+	return r.rsyncWrapper(source, target, flags)
+}
+
+func (r Rsync) rsyncWrapper(source string, target string, flags []string) error {
+	var err error
+
+	fs := r.s.FS()
+	log := r.s.Logger()
+
+	if s, err := fs.RawPath(source); err == nil {
+		source = s
+	}
+	if t, err := fs.RawPath(target); err == nil {
+		target = t
+	}
+
+	if !strings.HasSuffix(source, "/") {
+		source = fmt.Sprintf("%s/", source)
+	}
+
+	if !strings.HasSuffix(target, "/") {
+		target = fmt.Sprintf("%s/", target)
+	}
+
+	log.Info("Starting rsync...")
+
+	args := flags
+	args = append(args, source, target)
+
+	if r.ctx != nil {
+		err = r.s.Runner().RunContextParseOutput(r.ctx, func(msg string) {
+			log.Debug("synchronizing: %s", msg)
+		}, func(msg string) {
+			log.Debug("rsync stderr: %s", msg)
+		}, "rsync", args...)
+	} else {
+		_, err = r.s.Runner().Run("rsync", args...)
+	}
+
+	if err != nil {
+		log.Error("rsync finished with errors: %s", err.Error())
+		return err
+	}
+
+	log.Info("Finished syncing")
+	return nil
+}
+
+func DefaultFlags() []string {
+	return []string{"--info=progress2", "--human-readable", "--partial", "--archive", "--xattrs", "--acls", "--filter=-x security.selinux"}
+}

--- a/pkg/rsync/sync_test.go
+++ b/pkg/rsync/sync_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rsync_test
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/rsync"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+)
+
+func TestRsyncSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rsync test suite")
+}
+
+func getNamesFromListFiles(list []fs.DirEntry) []string {
+	var names []string
+	for _, f := range list {
+		names = append(names, f.Name())
+	}
+	return names
+}
+
+var _ = Describe("Sync tests", Label("rsync"), func() {
+	var sourceDir, destDir string
+	var err error
+	var tfs sys.FS
+	var s *sys.System
+	var logger log.Logger
+	var cleanup func()
+	var memLog *bytes.Buffer
+	BeforeEach(func() {
+		memLog = &bytes.Buffer{}
+		logger = log.New(log.WithBuffer(memLog))
+		logger.SetLevel(log.DebugLevel())
+
+		tfs, cleanup, err = sysmock.TestFS(nil)
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(sys.WithFS(tfs), sys.WithLogger(logger))
+		Expect(err).NotTo(HaveOccurred())
+		s.Logger().SetLevel(log.DebugLevel())
+		sourceDir, err = sys.TempDir(tfs, "", "elementalsource")
+		Expect(err).ShouldNot(HaveOccurred())
+		destDir, err = sys.TempDir(tfs, "", "elementaltarget")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("Copies all files from source to target", func() {
+		for range 5 {
+			_, _ = sys.TempFile(tfs, sourceDir, "file*")
+		}
+
+		r := rsync.NewRsync(s)
+		Expect(r.SyncData(sourceDir, destDir)).To(BeNil())
+
+		filesDest, err := tfs.ReadDir(destDir)
+		Expect(err).To(BeNil())
+
+		destNames := getNamesFromListFiles(filesDest)
+		filesSource, err := tfs.ReadDir(sourceDir)
+		Expect(err).To(BeNil())
+
+		SourceNames := getNamesFromListFiles(filesSource)
+
+		// Should be the same files in both dirs now
+		Expect(destNames).To(Equal(SourceNames))
+	})
+
+	It("Copies all files from source to target respecting excludes", func() {
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "host"), sys.DirPerm)
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "run"), sys.DirPerm)
+
+		// /tmp/run would be excluded as well, as we define an exclude without the "/" prefix
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "tmp", "run"), sys.DirPerm)
+
+		for range 5 {
+			_, _ = sys.TempFile(tfs, sourceDir, "file*")
+		}
+
+		r := rsync.NewRsync(s)
+		Expect(r.SyncData(sourceDir, destDir, "host", "run")).To(BeNil())
+
+		filesDest, err := tfs.ReadDir(destDir)
+		Expect(err).To(BeNil())
+
+		destNames := getNamesFromListFiles(filesDest)
+
+		filesSource, err := tfs.ReadDir(sourceDir)
+		Expect(err).To(BeNil())
+
+		sourceNames := getNamesFromListFiles(filesSource)
+
+		// Shouldn't be the same
+		Expect(destNames).ToNot(Equal(sourceNames))
+
+		Expect(slices.Contains(destNames, "host")).To(BeFalse())
+		Expect(slices.Contains(destNames, "run")).To(BeFalse())
+
+		Expect(slices.Contains(sourceNames, "host")).To(BeTrue())
+		Expect(slices.Contains(sourceNames, "run")).To(BeTrue())
+
+		// /tmp/run is not copied over
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "tmp", "run"))).To(BeFalse())
+	})
+
+	It("Copies all files from source to target respecting excludes with '/' prefix", func() {
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "host"), sys.DirPerm)
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "run"), sys.DirPerm)
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "var", "run"), sys.DirPerm)
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "tmp", "host"), sys.DirPerm)
+
+		r := rsync.NewRsync(s)
+		Expect(r.SyncData(sourceDir, destDir, "/host", "/run")).To(BeNil())
+
+		filesDest, err := tfs.ReadDir(destDir)
+		Expect(err).To(BeNil())
+		destNames := getNamesFromListFiles(filesDest)
+
+		filesSource, err := tfs.ReadDir(sourceDir)
+		Expect(err).To(BeNil())
+		sourceNames := getNamesFromListFiles(filesSource)
+
+		// Shouldn't be the same
+		Expect(destNames).ToNot(Equal(sourceNames))
+
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "var", "run"))).To(BeTrue())
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "tmp", "host"))).To(BeTrue())
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "host"))).To(BeFalse())
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "run"))).To(BeFalse())
+	})
+
+	It("Copies all files from source to target respecting excludes with wildcards", func() {
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "run"), sys.DirPerm)
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "var", "run"), sys.DirPerm)
+		Expect(tfs.WriteFile(filepath.Join(sourceDir, "run", "testfile"), []byte{}, sys.DirPerm)).To(Succeed())
+
+		r := rsync.NewRsync(s)
+		Expect(r.SyncData(sourceDir, destDir, "/run/*")).To(BeNil())
+
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "var", "run"))).To(BeTrue())
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "run"))).To(BeTrue())
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "run", "testfile"))).To(BeFalse())
+	})
+
+	It("Mirrors all files from source to destination deleting pre-existing files in destination if needed", func() {
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "run"), sys.DirPerm)
+		sys.MkdirAll(tfs, filepath.Join(sourceDir, "var", "run"), sys.DirPerm)
+		Expect(tfs.WriteFile(filepath.Join(sourceDir, "run", "testfile"), []byte{}, sys.DirPerm)).To(Succeed())
+		Expect(tfs.WriteFile(filepath.Join(destDir, "testfile"), []byte{}, sys.DirPerm)).To(Succeed())
+
+		r := rsync.NewRsync(s)
+		Expect(r.MirrorData(sourceDir, destDir)).To(BeNil())
+
+		filesDest, err := tfs.ReadDir(destDir)
+		Expect(err).To(BeNil())
+		destNames := getNamesFromListFiles(filesDest)
+
+		filesSource, err := tfs.ReadDir(sourceDir)
+		Expect(err).To(BeNil())
+		sourceNames := getNamesFromListFiles(filesSource)
+
+		// Should be the same
+		Expect(destNames).To(Equal(sourceNames))
+
+		// pre-exising file in destination deleted if this is not part of source
+		Expect(sys.Exists(tfs, filepath.Join(destDir, "testfile"))).To(BeFalse())
+	})
+
+	It("should not fail if dirs are empty", func() {
+		Expect(rsync.NewRsync(s).SyncData(sourceDir, destDir)).To(BeNil())
+	})
+	It("should not fail if destination does not exist", func() {
+		Expect(rsync.NewRsync(s).SyncData(sourceDir, "/welp")).To(Succeed())
+		exists, err := sys.Exists(tfs, "/welp")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+	It("should fail if source does not exist", func() {
+		Expect(rsync.NewRsync(s).SyncData("/welp", destDir)).NotTo(BeNil())
+	})
+	It("uses context to cancel an inprogress sync and logs progress", func() {
+		Expect(sys.MkdirAll(tfs, filepath.Join(sourceDir, "subfolder"), sys.DirPerm)).To(Succeed())
+		f, err := tfs.Create(filepath.Join(sourceDir, "subfolder/file2"))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(f.Truncate(10 * 1024 * 1024)).To(Succeed()) // 10MB
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+		r := rsync.NewRsync(
+			s, rsync.WithFlags(append(rsync.DefaultFlags(), "--bwlimit=1M")...),
+			rsync.WithContext(ctx),
+		)
+		wg.Add(1)
+		go func() {
+			err = r.SyncData(sourceDir, destDir)
+			wg.Done()
+		}()
+		time.Sleep(1 * time.Second)
+		cancel()
+		wg.Wait()
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("killed"))
+		// Check there are progress messages
+		Expect(memLog.String()).To(ContainSubstring("synchronizing:"))
+	})
+})

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -138,8 +138,8 @@ func parseReader(wg *sync.WaitGroup, reader io.Reader, parser func(string)) {
 	scanner := bufio.NewScanner(reader)
 	scanner.Split(scanLines)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.TrimSpace(line) == "" {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
 			continue
 		}
 		parser(line)
@@ -152,12 +152,13 @@ func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
 	}
-	if i := bytes.IndexByte(data, '\n'); i >= 0 {
-		// We have a full newline-terminated line.
-		return i + 1, data[0:i], nil
+	newLine := func(c rune) bool {
+		if c == '\n' || c == '\r' {
+			return true
+		}
+		return false
 	}
-	if i := bytes.IndexByte(data, '\r'); i >= 0 {
-		// We have a full newline-terminated line.
+	if i := bytes.IndexFunc(data, newLine); i >= 0 {
 		return i + 1, data[0:i], nil
 	}
 	// If we're at EOF, we have a final, non-terminated line. Return it.

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -18,9 +18,13 @@ limitations under the License.
 package runner
 
 import (
-	"fmt"
+	"bufio"
+	"bytes"
+	"context"
+	"io"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/suse/elemental/v3/pkg/log"
 )
@@ -45,27 +49,121 @@ func NewRunner(opts ...RunOption) *run { //nolint:revive
 	return r
 }
 
-func (r run) InitCmd(command string, args ...string) *exec.Cmd {
-	return exec.Command(command, args...)
-}
-
-func (r run) RunCmd(cmd *exec.Cmd) ([]byte, error) {
-	return cmd.CombinedOutput()
-}
-
 func (r run) Run(command string, args ...string) ([]byte, error) {
-	r.debug(fmt.Sprintf("Running cmd: '%s %s'", command, strings.Join(args, " ")))
-	cmd := r.InitCmd(command, args...)
-	out, err := r.RunCmd(cmd)
+	r.debug("Running cmd: '%s %s'", command, strings.Join(args, " "))
+	cmd := exec.Command(command, args...)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		r.debug(fmt.Sprintf("'%s' command reported an error: %s", command, err.Error()))
-		r.debug(fmt.Sprintf("'%s' command output: %s", command, out))
+		r.debug("'%s' command reported an error: %s", command, err.Error())
+		r.debug("'%s' command output: %s", command, out)
 	}
 	return out, err
 }
 
-func (r run) debug(msg string) {
-	if r.logger != nil {
-		r.logger.Debug(msg)
+func (r run) RunContext(ctx context.Context, command string, args ...string) ([]byte, error) {
+	r.debug("Running cmd: '%s %s'", command, strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, command, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.debug("'%s' command reported an error: %s", command, err.Error())
+		r.debug("'%s' command output: %s", command, out)
 	}
+	return out, err
+}
+
+func (r run) RunContextParseOutput(ctx context.Context, stdoutH, stderrH func(string), command string, args ...string) error {
+	var err error
+	var stdoutP, stderrP io.ReadCloser
+	var wg sync.WaitGroup
+
+	r.debug("Running cmd: '%s %s'", command, strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, command, args...)
+	if stdoutH != nil {
+		stdoutP, err = cmd.StdoutPipe()
+		if err != nil {
+			r.debug("cound not pipe stdout for command '%s': %s", command, err.Error())
+			return err
+		}
+		defer stdoutP.Close()
+	}
+	if stderrH != nil {
+		stderrP, err = cmd.StderrPipe()
+		if err != nil {
+			r.debug("cound not pipe stderr for command '%s': %s", command, err.Error())
+			return err
+		}
+		defer stderrP.Close()
+	}
+	err = cmd.Start()
+	if err != nil {
+		r.debug("'%s' command reported an error: %s", command, err.Error())
+		return err
+	}
+
+	if stdoutP != nil {
+		wg.Add(1)
+		go parseReader(&wg, stdoutP, stdoutH)
+	}
+
+	if stderrP != nil {
+		wg.Add(1)
+		go parseReader(&wg, stderrP, stderrH)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		r.debug("'%s' command exited with error: %s", command, err.Error())
+		return err
+	}
+
+	if stderrP != nil {
+		_ = stderrP.Close()
+	}
+
+	if stdoutP != nil {
+		_ = stdoutP.Close()
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r run) debug(msg string, args ...any) {
+	if r.logger != nil {
+		r.logger.Debug(msg, args...)
+	}
+}
+
+func parseReader(wg *sync.WaitGroup, reader io.Reader, parser func(string)) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(scanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parser(line)
+	}
+	wg.Done()
+}
+
+// scanLine is a port form the bufio.ScanLines including '/r' rune as a line break
+func scanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	if i := bytes.IndexByte(data, '\r'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
 }

--- a/pkg/sys/runner/runner_test.go
+++ b/pkg/sys/runner/runner_test.go
@@ -20,7 +20,6 @@ package runner_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"slices"
 	"sync"
 	"testing"
@@ -119,7 +118,5 @@ var _ = Describe("Runner", Label("runner"), func() {
 		Expect(slices.Contains(stdout, "stdout")).To(BeTrue())
 		Expect(len(stderr)).To(Equal(3))
 		Expect(slices.Contains(stderr, "stderr")).To(BeTrue())
-		fmt.Println(stdout)
-		fmt.Println(stderr)
 	})
 })

--- a/pkg/sys/system.go
+++ b/pkg/sys/system.go
@@ -18,6 +18,7 @@ limitations under the License.
 package sys
 
 import (
+	"context"
 	"os/exec"
 	"runtime"
 
@@ -39,9 +40,9 @@ type Mounter interface {
 }
 
 type Runner interface {
-	InitCmd(string, ...string) *exec.Cmd
-	Run(string, ...string) ([]byte, error)
-	RunCmd(cmd *exec.Cmd) ([]byte, error)
+	Run(cmd string, args ...string) ([]byte, error)
+	RunContext(cxt context.Context, cmd string, args ...string) ([]byte, error)
+	RunContextParseOutput(ctx context.Context, stdoutH, stderrH func(line string), cmd string, args ...string) error
 }
 
 type Syscall interface {


### PR DESCRIPTION
This commit extends Runner interface with a couple of additional methods to support running commands with an associated Context. It also provides a new method to parse in real-time stdout and stderr.

The rsync package is wrapper for rsync command. It can be initiated with a Context in case the caller considers some sort of cancellation logic.