### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    labels:
+      - dependencies
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies


### PR DESCRIPTION
Add config for dependabot to update direct go.mod dependencies and
github-actions weekly.

The PRs will be opened with the "dependencies" label.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
