### PR TITLE
Remove gomod github.com/suse/elemental dependency

### DIFF
--- a/cmd/elemental/main.go
+++ b/cmd/elemental/main.go
@@ -21,9 +21,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/suse/elemental/internal/cli/action"
-	"github.com/suse/elemental/internal/cli/cmd"
 	"github.com/urfave/cli/v2"
+
+	"github.com/suse/elemental/v3/internal/cli/action"
+	"github.com/suse/elemental/v3/internal/cli/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/sirupsen/logrus v1.9.3
-	github.com/suse/elemental v0.0.0-20250228142830-404c12c956c8
 	github.com/twpayne/go-vfs/v4 v4.3.0
 	github.com/urfave/cli/v2 v2.27.5
 	k8s.io/mount-utils v0.32.2

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/suse/elemental v0.0.0-20250228142830-404c12c956c8 h1:JVrHwOGBovebge440YdSKPJTn53QVPPIhDS8byWeSP8=
-github.com/suse/elemental v0.0.0-20250228142830-404c12c956c8/go.mod h1:PAS4KuUZrWggC4y2/+gz85c0JppZwutgu8K4M1HWd10=
 github.com/twpayne/go-vfs/v4 v4.3.0 h1:rTqFzzOQ/6ESKTSiwVubHlCBedJDOhQyVSnw8rQNZhU=
 github.com/twpayne/go-vfs/v4 v4.3.0/go.mod h1:tq2UVhnUepesc0lSnPJH/jQ8HruGhzwZe2r5kDFpEIw=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=

--- a/internal/cli/action/build.go
+++ b/internal/cli/action/build.go
@@ -20,8 +20,9 @@ package action
 import (
 	"log"
 
-	"github.com/suse/elemental/internal/cli/cmd"
 	"github.com/urfave/cli/v2"
+
+	"github.com/suse/elemental/v3/internal/cli/cmd"
 )
 
 func Build(*cli.Context) error {

--- a/internal/cli/action/install.go
+++ b/internal/cli/action/install.go
@@ -20,8 +20,9 @@ package action
 import (
 	"log"
 
-	"github.com/suse/elemental/internal/cli/cmd"
 	"github.com/urfave/cli/v2"
+
+	"github.com/suse/elemental/v3/internal/cli/cmd"
 )
 
 func Install(*cli.Context) error {


### PR DESCRIPTION
Should point to github.com/suse/elemental/v3 to actually use the code
from the repo.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
