### PR TITLE
Switch go version to 1.N.P syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/suse/elemental/v3
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0


### PR DESCRIPTION
This is a pre-requisite for CodeGL to work and required since Go 1.21.0 as per https://go.dev/doc/toolchain#version