### PR TITLE
Adds ImageSource type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containerd/containerd/v2 v2.0.4
+	github.com/distribution/reference v0.6.0
 	github.com/google/go-containerregistry v0.20.3
 	github.com/jaypipes/ghw v0.16.0
 	github.com/onsi/ginkgo/v2 v2.23.3
@@ -28,7 +29,6 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v27.5.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v27.5.0+incompatible // indirect

--- a/internal/cli/action/install.go
+++ b/internal/cli/action/install.go
@@ -68,8 +68,12 @@ func digestInstallSetup(s *sys.System, flags *cmd.InstallFlags) (*deployment.Dep
 	if flags.Target != "" && len(d.Disks) > 0 {
 		d.Disks[0].Device = flags.Target
 	}
-	d.SourceOS = flags.OperatingSystemImage
-	err := d.Sanitize(s)
+	srcOS, err := deployment.NewSrcFromURI(flags.OperatingSystemImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing OS source URI ('%s'): %w", flags.OperatingSystemImage, err)
+	}
+	d.SourceOS = srcOS
+	err = d.Sanitize(s)
 	if err != nil {
 		return nil, fmt.Errorf("inconsistent deployment setup found: %w", err)
 	}

--- a/internal/cli/action/install_test.go
+++ b/internal/cli/action/install_test.go
@@ -107,4 +107,11 @@ var _ = Describe("Install action", Label("install"), func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("inconsistent deployment"))
 	})
+	It("fails if the given OS uri is not valid", func() {
+		cmd.InstallArgs.Target = "/dev/device"
+		cmd.InstallArgs.OperatingSystemImage = "https://example.com/my/image"
+		err = action.Install(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("image source type not supported"))
+	})
 })

--- a/pkg/deployment/image_source.go
+++ b/pkg/deployment/image_source.go
@@ -1,0 +1,200 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/distribution/reference"
+)
+
+type ImageSrcType int
+
+const (
+	Dir ImageSrcType = iota + 1
+	OCI
+	Raw
+)
+
+func ParseSrcImageType(i string) (ImageSrcType, error) {
+	switch i {
+	case "", "oci":
+		return OCI, nil
+	case "dir":
+		return Dir, nil
+	case "raw":
+		return Raw, nil
+	default:
+		return ImageSrcType(0), fmt.Errorf("image source type not supported: %s", i)
+	}
+}
+
+func (i ImageSrcType) String() string {
+	switch i {
+	case OCI:
+		return "oci"
+	case Dir:
+		return "dir"
+	case Raw:
+		return "raw"
+	default:
+		return Unknown
+	}
+}
+
+type ImageSource struct {
+	uri     string
+	digest  string
+	srcType ImageSrcType
+}
+
+func (i *ImageSource) SetDigest(digest string) {
+	i.digest = digest
+}
+
+func (i ImageSource) GetDigest() string {
+	return i.digest
+}
+
+func (i ImageSource) URI() string {
+	return i.uri
+}
+
+func (i ImageSource) IsOCI() bool {
+	return i.srcType == OCI
+}
+
+func (i ImageSource) IsDir() bool {
+	return i.srcType == Dir
+}
+
+func (i ImageSource) IsRaw() bool {
+	return i.srcType == Raw
+}
+
+func (i ImageSource) IsEmpty() bool {
+	if i.srcType == 0 {
+		return true
+	}
+	if i.uri == "" {
+		return true
+	}
+	return false
+}
+
+func (i ImageSource) String() string {
+	if i.IsEmpty() {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s", i.srcType, i.uri)
+}
+
+func NewSrcFromURI(uri string) (*ImageSource, error) {
+	src := ImageSource{}
+	err := src.updateFromURI(uri)
+	return &src, err
+}
+
+func NewEmptySrc() *ImageSource {
+	return &ImageSource{}
+}
+
+func NewOCISrc(src string) *ImageSource {
+	return &ImageSource{uri: src, srcType: OCI}
+}
+
+func NewRawSrc(src string) *ImageSource {
+	return &ImageSource{uri: src, srcType: Raw}
+}
+
+func NewDirSrc(src string) *ImageSource {
+	return &ImageSource{uri: src, srcType: Dir}
+}
+
+func (i ImageSource) MarshalJSON() ([]byte, error) {
+	imgSrc := map[string]string{}
+	if i.digest != "" {
+		imgSrc["digest"] = i.digest
+	}
+	imgSrc["uri"] = i.String()
+	return json.Marshal(imgSrc)
+}
+
+func (i *ImageSource) UnmarshalJSON(data []byte) (err error) {
+	imgSrc := map[string]string{}
+	if err = json.Unmarshal(data, &imgSrc); err != nil {
+		return err
+	}
+	if imgSrc["uri"] == "" {
+		return fmt.Errorf("no 'uri' provided for the image source: %s", string(data))
+	}
+
+	err = i.updateFromURI(imgSrc["uri"])
+	if err != nil {
+		return err
+	}
+	i.digest = imgSrc["digest"]
+	return err
+}
+
+func (i *ImageSource) updateFromURI(uri string) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	scheme := u.Scheme
+	value := u.Opaque
+	if value == "" {
+		value = filepath.Join(u.Host, u.Path)
+	}
+	srcType, err := ParseSrcImageType(scheme)
+	if err != nil {
+		return err
+	}
+	i.srcType = srcType
+	i.uri = value
+	if scheme == "" {
+		uri, err = parseImageReference(uri)
+		if err != nil {
+			return err
+		}
+		i.uri = uri
+		return nil
+	}
+	if srcType == OCI {
+		uri, err = parseImageReference(value)
+		if err != nil {
+			return err
+		}
+		i.uri = uri
+	}
+	return nil
+}
+
+func parseImageReference(ref string) (string, error) {
+	n, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return "", fmt.Errorf("invalid image reference %s", ref)
+	} else if reference.IsNameOnly(n) {
+		ref += ":latest"
+	}
+	return ref, nil
+}

--- a/pkg/deployment/image_source_test.go
+++ b/pkg/deployment/image_source_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	"github.com/suse/elemental/v3/pkg/deployment"
+)
+
+const src = `
+uri: raw:///path/to/image/file.raw
+digest: adfasdfadsfaf
+`
+
+var _ = Describe("Image Source", Label("imagesource"), func() {
+	It("initiates an OCI image source from URI", func() {
+		imgsrc, err := deployment.NewSrcFromURI("registry.org/my/image")
+		Expect(err).NotTo(HaveOccurred())
+		fmt.Printf("imgsrc '%+v'\n", imgsrc)
+		Expect(imgsrc.String()).To(Equal("oci://registry.org/my/image:latest"))
+		Expect(imgsrc.IsOCI()).To(BeTrue())
+		Expect(imgsrc.URI()).To(Equal("registry.org/my/image:latest"))
+		Expect(imgsrc.IsEmpty()).To(BeFalse())
+	})
+	It("initiates a Raw image source from URI", func() {
+		imgsrc, err := deployment.NewSrcFromURI("raw:///some/path/to/image")
+		Expect(err).NotTo(HaveOccurred())
+		fmt.Printf("imgsrc '%+v'\n", imgsrc)
+		Expect(imgsrc.String()).To(Equal("raw:///some/path/to/image"))
+		Expect(imgsrc.IsOCI()).To(BeFalse())
+		Expect(imgsrc.IsRaw()).To(BeTrue())
+		Expect(imgsrc.URI()).To(Equal("/some/path/to/image"))
+	})
+	It("initiates a Dir image source from URI", func() {
+		imgsrc, err := deployment.NewSrcFromURI("dir://some/path/to/directory")
+		Expect(err).NotTo(HaveOccurred())
+		fmt.Printf("imgsrc '%+v'\n", imgsrc)
+		Expect(imgsrc.String()).To(Equal("dir://some/path/to/directory"))
+		Expect(imgsrc.IsDir()).To(BeTrue())
+		Expect(imgsrc.IsRaw()).To(BeFalse())
+		Expect(imgsrc.URI()).To(Equal("some/path/to/directory"))
+	})
+	It("fails with unknown schema in URI", func() {
+		imgsrc, err := deployment.NewSrcFromURI("https://example.com/my/image")
+		Expect(err).To(HaveOccurred())
+		Expect(imgsrc.IsEmpty()).To(BeTrue())
+	})
+	It("initiates an empty image source", func() {
+		imgsrc := deployment.NewEmptySrc()
+		Expect(imgsrc.IsEmpty()).To(BeTrue())
+	})
+	It("initiates an OCI image source", func() {
+		imgsrc := deployment.NewOCISrc("my/ref:mytag")
+		Expect(imgsrc.IsDir()).To(BeFalse())
+		Expect(imgsrc.IsOCI()).To(BeTrue())
+		Expect(imgsrc.GetDigest()).To(BeEmpty())
+		imgsrc.SetDigest("somedigest")
+		Expect(imgsrc.GetDigest()).To(Equal("somedigest"))
+	})
+	It("initiates a Raw image source", func() {
+		imgsrc := deployment.NewRawSrc("my/image.raw")
+		Expect(imgsrc.IsRaw()).To(BeTrue())
+	})
+	It("initiates a Dir image source", func() {
+		imgsrc := deployment.NewDirSrc("/some/dir")
+		Expect(imgsrc.IsDir()).To(BeTrue())
+	})
+	It("serializes an image source", func() {
+		imgsrc, err := deployment.NewSrcFromURI("oci://registry.org/my/image")
+		Expect(err).NotTo(HaveOccurred())
+		imgsrc.SetDigest("somedigest")
+		data, err := yaml.Marshal(imgsrc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(`digest: somedigest
+uri: oci://registry.org/my/image:latest
+`))
+	})
+	It("deserializes an image source", func() {
+		imgsrc := deployment.NewEmptySrc()
+		Expect(yaml.Unmarshal([]byte(src), imgsrc)).To(Succeed())
+		Expect(imgsrc.IsEmpty()).To(BeFalse())
+		Expect(imgsrc.IsRaw()).To(BeTrue())
+		Expect(imgsrc.String()).To(Equal("raw:///path/to/image/file.raw"))
+		Expect(imgsrc.GetDigest()).To(Equal("adfasdfadsfaf"))
+	})
+	It("fails to deserialize an image without uri", func() {
+		imgsrc := deployment.NewEmptySrc()
+		Expect(yaml.Unmarshal([]byte("digest: adfadsfa"), imgsrc)).NotTo(Succeed())
+	})
+	It("fails to deserialize invalid URI type", func() {
+		imgsrc := deployment.NewEmptySrc()
+		Expect(yaml.Unmarshal([]byte("uri: https://example/com"), imgsrc)).NotTo(Succeed())
+	})
+})


### PR DESCRIPTION
This commit adds image source type which is used to handle image sources as uri where the uri scheme defines the source type.

It currently supports oci, dir and raw. For instance:

* "raw:///path/to/image.raw"
* "dir:///path/to/directory/tree"
* "oci://my.registry.org/image:tag"