### PR TITLE
Handle deployment file

### DIFF
--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -152,6 +152,15 @@ var _ = Describe("Deployment", Label("deployment"), func() {
 		Expect(len(rD.Disks[0].Partitions)).To(Equal(2))
 		Expect(rD.Sanitize(s)).To(Succeed())
 	})
+	It("overwrites any pre-existing deployment file", func() {
+		d := deployment.DefaultDeployment()
+		Expect(d.WriteDeploymentFile(s, "/some/dir")).To(Succeed())
+		d.Disks[0].Device = "/dev/newdevice"
+		Expect(d.WriteDeploymentFile(s, "/some/dir")).To(Succeed())
+		rD, err := deployment.ReadDeployment(s, "/some/dir")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rD.Disks[0].Device).To(Equal("/dev/newdevice"))
+	})
 	It("fails to read a non existing deployment", func() {
 		_, err := deployment.ReadDeployment(s, "/some/dir")
 		Expect(err).To(HaveOccurred())


### PR DESCRIPTION
This commit includes utilities to write and read /etc/elemental/deployment.yaml file, which is essentially a serialization of the Deployment struct.

This is helpful for life cycle management to know the details of a current system.

In addition, paritions size type has been changed from int to uint.