### PR TITLE
Add disk_repart standalone methods

### DIFF
--- a/pkg/diskrepart/disk.go
+++ b/pkg/diskrepart/disk.go
@@ -211,7 +211,7 @@ func (dev *Disk) GetFreeSpace() (uint, error) {
 	if dev.sectorS == 0 {
 		err := dev.Reload()
 		if err != nil {
-			dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+			dev.sys.Logger().Error("failed analyzing disk: %v", err)
 			return 0, err
 		}
 	}
@@ -254,14 +254,13 @@ func (dev *Disk) NewPartitionTable(label string) (string, error) {
 	}
 	err = dev.Reload()
 	if err != nil {
-		dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+		dev.sys.Logger().Error("failed analyzing disk: %v", err)
 		return "", err
 	}
 	return out, nil
 }
 
 // AddPartition adds a partition. Size is expressed in MiB here
-// Size is expressed in MiB here
 func (dev *Disk) AddPartition(size uint, fileSystem string, pLabel string, flags ...string) (int, error) {
 	pc, err := dev.newPartitioner(dev.String())
 	if err != nil {
@@ -272,7 +271,7 @@ func (dev *Disk) AddPartition(size uint, fileSystem string, pLabel string, flags
 	if dev.sectorS == 0 {
 		err = dev.Reload()
 		if err != nil {
-			dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+			dev.sys.Logger().Error("failed analyzing disk: %v", err)
 			return 0, err
 		}
 	}
@@ -316,14 +315,14 @@ func (dev *Disk) AddPartition(size uint, fileSystem string, pLabel string, flags
 	out, err := pc.WriteChanges()
 	dev.sys.Logger().Debug("partitioner output: %s", out)
 	if err != nil {
-		dev.sys.Logger().Error("Failed creating partition: %v", err)
+		dev.sys.Logger().Error("failed creating partition: %v", err)
 		return 0, err
 	}
 
 	// Reload new partition in dev
 	err = dev.Reload()
 	if err != nil {
-		dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+		dev.sys.Logger().Error("failed analyzing disk: %v", err)
 		return 0, err
 	}
 	return partNum, nil
@@ -379,7 +378,7 @@ func (dev *Disk) ExpandLastPartition(size uint) error {
 	if dev.sectorS == 0 {
 		err = dev.Reload()
 		if err != nil {
-			dev.sys.Logger().Error("Failed analyzing disk: %v\n", err)
+			dev.sys.Logger().Error("failed analyzing disk: %v", err)
 			return err
 		}
 	}

--- a/pkg/diskrepart/disk.go
+++ b/pkg/diskrepart/disk.go
@@ -455,7 +455,7 @@ func (dev Disk) expandFilesystem(device string) (err error) {
 		if err != nil {
 			return err
 		}
-		err = dev.sys.Mounter().Mount(device, tmpDir, "auto", []string{})
+		err = dev.sys.Mounter().Mount(device, tmpDir, "", []string{})
 		if err != nil {
 			return err
 		}

--- a/pkg/diskrepart/disk_repart.go
+++ b/pkg/diskrepart/disk_repart.go
@@ -96,7 +96,7 @@ func AddAndFormatPartition(s *sys.System, disk *Disk, part *deployment.Partition
 	s.Logger().Debug("Formatting partition with uuid %s", fuuid)
 	err = FormatDevice(s, partDev, part.FileSystem.String(), part.Label, fuuid)
 	if err != nil {
-		s.Logger().Error("Failed formatting partition %s", part.Label)
+		s.Logger().Error("failed formatting partition %s", part.Label)
 		return err
 	}
 	part.UUID = vfatUUIDSanitize(fuuid, part.FileSystem)

--- a/pkg/diskrepart/disk_repart.go
+++ b/pkg/diskrepart/disk_repart.go
@@ -1,0 +1,136 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskrepart
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/suse/elemental/v3/pkg/deployment"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+const (
+	// Partition table type
+	gpt = "gpt"
+
+	// ESP partition type
+	esp = "esp"
+)
+
+// PartitionAndFormatDevice creates a new empty partition table on target disk
+// and applies the configured disk layout by creating and formatting all
+// required partitions
+func PartitionAndFormatDevice(s *sys.System, d *deployment.Disk) error {
+	disk := NewDisk(s, d.Device)
+
+	if !disk.Exists() {
+		return fmt.Errorf("disk %s does not exist", d.Device)
+	}
+
+	s.Logger().Info("Partitioning device '%s'", d.Device)
+	out, err := disk.NewPartitionTable(gpt)
+	if err != nil {
+		s.Logger().Error("failed creating new partition table: %s", out)
+		return err
+	}
+	for _, part := range d.Partitions {
+		err := AddAndFormatPartition(s, disk, part)
+		if err != nil {
+			s.Logger().Error("failed creating new %s partition", part.Role.String())
+			return err
+		}
+	}
+	return nil
+}
+
+// AddAndFormatPartition adds the given partition to the given disk. The partition is appended
+// after last already existing partition. The partition is also formatted with the given
+// parameters.
+func AddAndFormatPartition(s *sys.System, disk *Disk, part *deployment.Partition) error {
+	s.Logger().Debug("Adding %s partition with label %s", part.Role.String(), part.Label)
+
+	var pLabel string
+	var flags []string
+	switch part.Role {
+	case deployment.EFI:
+		flags = append(flags, esp)
+		pLabel = part.Role.String()
+	case deployment.System, deployment.Recovery:
+		pLabel = part.Role.String()
+	}
+
+	num, err := disk.AddPartition(uint(part.Size), part.FileSystem.String(), pLabel, flags...)
+	if err != nil {
+		s.Logger().Error("failed creating %s partition", part.Label)
+		return err
+	}
+	partDev, err := disk.FindPartitionDevice(num)
+	if err != nil {
+		return err
+	}
+
+	fuuid := part.UUID
+	if fuuid == "" {
+		fuuid = generateUUID(part.FileSystem)
+	}
+
+	s.Logger().Debug("Formatting partition with uuid %s", fuuid)
+	err = FormatDevice(s, partDev, part.FileSystem.String(), part.Label, fuuid)
+	if err != nil {
+		s.Logger().Error("Failed formatting partition %s", part.Label)
+		return err
+	}
+	part.UUID = vfatUUIDSanitize(fuuid, part.FileSystem)
+	return nil
+}
+
+func checkUUID(id string, f deployment.FileSystem) bool {
+	if f == deployment.VFat {
+		id = strings.ReplaceAll(id, "-", "")
+		if len([]rune(id)) != 8 {
+			return false
+		}
+		_, err := hex.DecodeString(id)
+		return err == nil
+	}
+	_, err := uuid.Parse(id)
+	return err == nil
+}
+
+func generateUUID(f deployment.FileSystem) string {
+	id := uuid.Must(uuid.NewRandom()).String()
+	if f == deployment.VFat {
+		return strings.Split(id, "-")[0]
+	}
+	return id
+}
+
+func vfatUUIDSanitize(id string, f deployment.FileSystem) string {
+	if f == deployment.VFat {
+		id = strings.ToUpper(id)
+		runes := []rune(id)[0:4]
+		runes = append(runes, []rune("-")...)
+		runes = append(runes, []rune(id)[4:]...)
+		return string(runes)
+	}
+	return id
+}

--- a/pkg/diskrepart/mkfs_test.go
+++ b/pkg/diskrepart/mkfs_test.go
@@ -19,6 +19,7 @@ package diskrepart_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,7 +55,7 @@ var _ = Describe("Parted", Label("parted"), func() {
 		Expect(runner.CmdsMatch(cmds)).To(BeNil())
 	})
 	It("Successfully formats a partition with vfat", func() {
-		mkfs := diskrepart.NewMkfsCall(s, "/dev/device", "vfat", "EFI", validUUID)
+		mkfs := diskrepart.NewMkfsCall(s, "/dev/device", "vfat", "EFI", strings.Split(validUUID, "-")[0])
 		Expect(mkfs.Apply()).To(Succeed())
 		cmds := [][]string{{"mkfs.vfat", "-n", "EFI", "-i", vfatUUID, "/dev/device"}}
 		Expect(runner.CmdsMatch(cmds)).To(BeNil())


### PR DESCRIPTION
This PR adds some helper methods to apply a given deployment specification to the requested disks. It reparts and formats partitions as requested.

More over UUID management for VFAT has been fixed as input format of mkfs.vfat volume ID is different from what lsblk reports as UUID (ea56fe78 vs EA56-FE78).

Signed-off-by: David Cassany <dcassany@suse.com>