### PR TITLE
Add selinux package

### DIFF
--- a/pkg/chroot/chroot_test.go
+++ b/pkg/chroot/chroot_test.go
@@ -80,12 +80,26 @@ var _ = Describe("Chroot", Label("chroot"), func() {
 		})
 	})
 	Describe("on success", func() {
-		It("command should be called in the chroot", func() {
+		It("calls a command in a chroot", func() {
 			_, err := chr.Run("chroot-command")
 			Expect(err).To(BeNil())
 			Expect(syscall.WasChrootCalledWith("/whatever")).To(BeTrue())
 		})
-		It("commands should be called with a customized chroot", func() {
+		It("prepares chroot with and without default binds", func() {
+			Expect(chr.Prepare()).To(Succeed())
+			lst, err := mounter.List()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(lst)).To(Equal(4))
+			Expect(chr.Close()).To(Succeed())
+
+			chr = chroot.NewChroot(s, "/whatever", chroot.WithoutDefaultBinds())
+			Expect(chr.Prepare()).To(Succeed())
+			lst, err = mounter.List()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(lst)).To(Equal(0))
+			Expect(chr.Close()).To(Succeed())
+		})
+		It("calls a command in a chroot with a customized binds", func() {
 			binds := map[string]string{
 				"/host/dir":  "/in/chroot/path",
 				"/host/file": "/in/chroot/file",

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -31,6 +31,7 @@ const (
 	SelinuxTargetedContextFile = selinuxTargetedPath + "/contexts/files/file_contexts"
 
 	selinuxTargetedPath = "/etc/selinux/targeted"
+	debugLines          = 10
 )
 
 // Relabel will relabel the system if it finds the context
@@ -43,8 +44,8 @@ func Relabel(ctx context.Context, s *sys.System, rootDir string, extraPaths ...s
 		args := []string{"-i", "-F"}
 
 		// We only keep last 10 lines of the stdout and stderr for debugging purposes
-		stdOut := ring.New(10)
-		stdErr := ring.New(10)
+		stdOut := ring.New(debugLines)
+		stdErr := ring.New(debugLines)
 
 		if rootDir == "/" || rootDir == "" {
 			args = append(args, contextFile, "/")
@@ -80,8 +81,8 @@ func ChrootedRelabel(ctx context.Context, s *sys.System, rootDir string, bind ma
 	existsCon, _ := vfs.Exists(s.FS(), contextsFile)
 
 	if existsCon && len(extraPaths) > 0 {
-		stdOut := ring.New(10)
-		stdErr := ring.New(10)
+		stdOut := ring.New(debugLines)
+		stdErr := ring.New(debugLines)
 
 		args := []string{"-i", "-F", "-r", rootDir, contextsFile}
 		for _, path := range extraPaths {

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selinux
+
+import (
+	"container/ring"
+	"context"
+	"path/filepath"
+
+	"github.com/suse/elemental/v3/pkg/chroot"
+	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+const (
+	SelinuxTargetedContextFile = selinuxTargetedPath + "/contexts/files/file_contexts"
+
+	selinuxTargetedPath = "/etc/selinux/targeted"
+)
+
+// Relabel will relabel the system if it finds the context
+func Relabel(ctx context.Context, s *sys.System, rootDir string, extraPaths ...string) error {
+	contextFile := filepath.Join(rootDir, SelinuxTargetedContextFile)
+	contextExists, _ := vfs.Exists(s.FS(), contextFile)
+
+	if contextExists {
+		var err error
+		args := []string{"-i", "-F"}
+
+		// We only keep last 10 lines of the stdout and stderr for debugging purposes
+		stdOut := ring.New(10)
+		stdErr := ring.New(10)
+
+		if rootDir == "/" || rootDir == "" {
+			args = append(args, contextFile, "/")
+		} else {
+			args = append(args, "-r", rootDir, contextFile, rootDir)
+		}
+		args = append(args, extraPaths...)
+		err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", args...)
+		logOutput(s, stdOut, stdErr)
+		return err
+	}
+
+	s.Logger().Debug("Not relabelling SELinux, no context found")
+	return nil
+}
+
+// ChrootedRelabel relables with setfiles the given root in a chroot env. Additionaly after the first
+// chrooted call it runs a non chrooted call to relabel any mountpoint used within the chroot.
+func ChrootedRelabel(ctx context.Context, s *sys.System, rootDir string, bind map[string]string) (err error) {
+	extraPaths := []string{}
+
+	for _, v := range bind {
+		extraPaths = append(extraPaths, v)
+	}
+
+	callback := func() error { return Relabel(ctx, s, "/", extraPaths...) }
+	err = chroot.ChrootedCallback(s, rootDir, bind, callback, chroot.WithoutDefaultBinds())
+	if err != nil {
+		return err
+	}
+
+	contextsFile := filepath.Join(rootDir, SelinuxTargetedContextFile)
+	existsCon, _ := vfs.Exists(s.FS(), contextsFile)
+
+	if existsCon && len(extraPaths) > 0 {
+		stdOut := ring.New(10)
+		stdErr := ring.New(10)
+
+		args := []string{"-i", "-F", "-r", rootDir, contextsFile}
+		for _, path := range extraPaths {
+			args = append(args, filepath.Join(rootDir, path))
+		}
+		err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", args...)
+		logOutput(s, stdOut, stdErr)
+	}
+
+	return err
+}
+
+func stdHander(r *ring.Ring) func(string) {
+	return func(line string) {
+		r.Value = line
+		r = r.Next()
+	}
+}
+
+func logOutput(s *sys.System, stdOut, stdErr *ring.Ring) {
+	output := "\n------- stdOut -------\n"
+	stdOut.Do(func(v any) {
+		if v != nil {
+			output += v.(string) + "\n"
+		}
+	})
+	output += "------- stdErr -------\n"
+	stdErr.Do(func(v any) {
+		if v != nil {
+			output += v.(string) + "\n"
+		}
+	})
+	output += "----------------------\n"
+	s.Logger().Debug("SELinux setfile call stdout: %s", output)
+}

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selinux_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/selinux"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+func TestSELinuxSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SELinux test suite")
+}
+
+var _ = Describe("DiskRepart", Label("diskrepart"), func() {
+	var runner *sysmock.Runner
+	var mounter *sysmock.Mounter
+	var syscall *sysmock.Syscall
+	var fs vfs.FS
+	var cleanup func()
+	var s *sys.System
+	var root string
+	var contextFile string
+	var buffer *bytes.Buffer
+
+	BeforeEach(func() {
+		var err error
+		syscall = &sysmock.Syscall{}
+		buffer = &bytes.Buffer{}
+		runner = sysmock.NewRunner()
+		mounter = sysmock.NewMounter()
+		fs, cleanup, err = sysmock.TestFS(nil)
+		Expect(err).ToNot(HaveOccurred())
+		logger := log.New(log.WithBuffer(buffer))
+		logger.SetLevel(log.DebugLevel())
+		s, err = sys.NewSystem(
+			sys.WithMounter(mounter), sys.WithRunner(runner),
+			sys.WithFS(fs), sys.WithLogger(logger),
+			sys.WithSyscall(syscall),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		root = "/some/root"
+		Expect(vfs.MkdirAll(fs, root, vfs.DirPerm)).To(Succeed())
+		contextFile = filepath.Join(root, selinux.SelinuxTargetedContextFile)
+		Expect(vfs.MkdirAll(fs, filepath.Dir(contextFile), vfs.DirPerm)).To(Succeed())
+		Expect(vfs.MkdirAll(fs, filepath.Dir(selinux.SelinuxTargetedContextFile), vfs.DirPerm)).To(Succeed())
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	It("relabels the given paths for the targeted context", func() {
+		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
+		Expect(selinux.Relabel(context.Background(), s, root)).To(Succeed())
+		Expect(runner.CmdsMatch([][]string{{
+			"setfiles", "-i", "-F", "-r", "/some/root",
+			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root",
+		}})).To(Succeed())
+	})
+	It("does nothing if the context is not found", func() {
+		Expect(selinux.Relabel(context.Background(), s, root)).To(Succeed())
+		Expect(runner.CmdsMatch([][]string{{}}))
+		Expect(buffer.String()).To(ContainSubstring("no context found"))
+	})
+	It("errors out if setfiles call fails", func() {
+		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+			if cmd == "setfiles" {
+				return []byte{}, fmt.Errorf("setfiles failed")
+			}
+			return []byte{}, nil
+		}
+		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
+		Expect(selinux.Relabel(context.Background(), s, root)).NotTo(Succeed())
+	})
+	It("relabels the given paths for the targeted context in a chroot env", func() {
+		Expect(fs.WriteFile(selinux.SelinuxTargetedContextFile, []byte{}, vfs.FilePerm)).To(Succeed())
+		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
+		Expect(vfs.MkdirAll(fs, "/partition/var", vfs.DirPerm)).To(Succeed())
+		Expect(selinux.ChrootedRelabel(
+			context.Background(), s, root, map[string]string{"/partition/var": "/var"}),
+		).To(Succeed())
+		Expect(runner.CmdsMatch([][]string{
+			{"setfiles", "-i", "-F", "/etc/selinux/targeted/contexts/files/file_contexts", "/", "/var"},
+			{"sync"},
+			{"setfiles", "-i", "-F", "-r", "/some/root", "/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root/var"},
+		})).To(Succeed())
+	})
+	It("fails to relabel in a chroot env if chroot mounts fail", func() {
+		Expect(fs.WriteFile(selinux.SelinuxTargetedContextFile, []byte{}, vfs.FilePerm)).To(Succeed())
+		// /partion/var does not exist
+		Expect(selinux.ChrootedRelabel(
+			context.Background(), s, root, map[string]string{"/partition/var": "/var"}),
+		).NotTo(Succeed())
+	})
+	It("does nothing if the context is not found in chroot", func() {
+		Expect(vfs.MkdirAll(fs, "/partition/var", vfs.DirPerm)).To(Succeed())
+		Expect(selinux.ChrootedRelabel(
+			context.Background(), s, root, map[string]string{"/partition/var": "/var"}),
+		).To(Succeed())
+		Expect(runner.CmdsMatch([][]string{{}}))
+		Expect(buffer.String()).To(ContainSubstring("no context found"))
+	})
+})


### PR DESCRIPTION
This PR adds the SELinux package (a setfiles wrapper to relabel a directory tree) and extends the chroot package to allow setting chroot envs without the default bind mounts (/dev, /proc, /sys), which are not always required.