### PR TITLE
Add btrfs package

### DIFF
--- a/pkg/btrfs/btrfs.go
+++ b/pkg/btrfs/btrfs.go
@@ -1,0 +1,148 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package btrfs
+
+import (
+	"path/filepath"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+const TopSubVol = "@"
+
+// EnableQuota enables btrfs quota the btrfs filesystem, path is usually the
+// mountpoint of the btrfs filesystem
+func EnableQuota(s *sys.System, path string) error {
+	s.Logger().Debug("Enabling btrfs quota")
+	cmdOut, err := s.Runner().Run("btrfs", "quota", "enable", path)
+	if err != nil {
+		s.Logger().Error("failed setting quota for btrfs partition at %s: %s", path, string(cmdOut))
+		return err
+	}
+	return nil
+}
+
+// CreateSubvolume creates a btrfs subvolume to the given path
+func CreateSubvolume(s *sys.System, path string, copyOnWrite bool) error {
+	s.Logger().Debug("Creating subvolume: %s", path)
+	err := vfs.MkdirAll(s.FS(), filepath.Dir(path), vfs.DirPerm)
+	if err != nil {
+		s.Logger().Error("failed creating subvolume path: %s", path)
+		return err
+	}
+	cmdOut, err := s.Runner().Run("btrfs", "subvolume", "create", path)
+	if err != nil {
+		s.Logger().Error("failed creating subvolume %s: %s", path, string(cmdOut))
+		return err
+	}
+	if !copyOnWrite {
+		return NoCopyOnWrite(s, path)
+	}
+	return nil
+}
+
+// NoCopyOnWrite disables copy on write to the given subvolume
+func NoCopyOnWrite(s *sys.System, path string) error {
+	cmdOut, err := s.Runner().Run("chattr", "+C", path)
+	if err != nil {
+		s.Logger().Error("failed setting no copy on write for volume '%s': %s", path, string(cmdOut))
+		return err
+	}
+	return nil
+}
+
+// CreateSnapshot creates a btrfs snapshot to the given path from the given base
+func CreateSnapshot(s *sys.System, path, base string, copyOnWrite bool) error {
+	s.Logger().Debug("Creating snapshot: %s", path)
+	err := vfs.MkdirAll(s.FS(), filepath.Dir(path), vfs.DirPerm)
+	if err != nil {
+		s.Logger().Error("failed creating snapshot subvolume path: %s", path)
+		return err
+	}
+
+	cmdOut, err := s.Runner().Run("btrfs", "subvolume", "snapshot", base, path)
+	if err != nil {
+		s.Logger().Error("failed creating snapshot subvolume '%s': %s", path, string(cmdOut))
+		return err
+	}
+	if !copyOnWrite {
+		return NoCopyOnWrite(s, path)
+	}
+	return nil
+}
+
+// CreateQuotaGroup creates the given quota group for the btrfs filesystem,
+// path is usually the mountpoint of the btrfs filesystem
+func CreateQuotaGroup(s *sys.System, path, qGroup string) error {
+	s.Logger().Debug("Create btrfs quota group")
+	cmdOut, err := s.Runner().Run("btrfs", "qgroup", "create", qGroup, path)
+	if err != nil {
+		s.Logger().Error("failed creating quota group for %s: %s", path, string(cmdOut))
+		return err
+	}
+	return nil
+}
+
+// SetBtrfsPartition configures toplevel subvolume, enables quota sets the quota group 1/0,
+// and defines the toplevel subvolume as the default subvolume. Path is the mountpoint of the btrfs filesystem.
+func SetBtrfsPartition(s *sys.System, path string) error {
+	err := EnableQuota(s, path)
+	if err != nil {
+		return err
+	}
+	subvolume := filepath.Join(path, TopSubVol)
+	err = CreateSubvolume(s, subvolume, true)
+	if err != nil {
+		return err
+	}
+	err = CreateQuotaGroup(s, path, "1/0")
+	if err != nil {
+		return err
+	}
+	return SetDefaultSubvolume(s, subvolume)
+}
+
+// DeleteSubvolume removes the given subvolume. Before removing the subvolume
+// it sets the RW property to ensure it can be deleted, if deletion fails
+// the property change remains applied.
+func DeleteSubvolume(s *sys.System, path string) error {
+	s.Logger().Debug("Setting rw property to subvolume: %s", path)
+	_, err := s.Runner().Run("btrfs", "property", "set", "rw", "true", path)
+	if err != nil {
+		s.Logger().Error("failed setting rw to snapshot '%s' before deletion", path)
+		return err
+	}
+	_, err = s.Runner().Run("btrfs", "subvolume", "delete", "-c", "-R", path)
+	if err != nil {
+		s.Logger().Error("failed deleting snapshot '%s'", path)
+		return err
+	}
+	return nil
+}
+
+// SetDefaultSubvolume sets the given subvolume as the default subvolume to mount
+func SetDefaultSubvolume(s *sys.System, path string) error {
+	s.Logger().Debug("Setting default subvolume")
+	_, err := s.Runner().Run("btrfs", "subvolume", "set-default", path)
+	if err != nil {
+		s.Logger().Error("failed setting the default subvolume to %s", path)
+		return err
+	}
+	return nil
+}

--- a/pkg/btrfs/btrfs_test.go
+++ b/pkg/btrfs/btrfs_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package btrfs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/btrfs"
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+func TestBtrfsSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Btrfs test suite")
+}
+
+var _ = Describe("DirectoryUnpacker", Label("directory"), func() {
+	var tfs vfs.FS
+	var s *sys.System
+	var cleanup func()
+	var err error
+	var runner *sysmock.Runner
+	BeforeEach(func() {
+		runner = sysmock.NewRunner()
+		tfs, cleanup, err = sysmock.TestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs), sys.WithLogger(log.New(log.WithDiscardAll())),
+			sys.WithRunner(runner),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vfs.MkdirAll(tfs, "/etc", vfs.DirPerm)).To(Succeed())
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	It("enables quota", func() {
+		Expect(btrfs.EnableQuota(s, "/path/to/mountpoint")).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{{
+			"btrfs", "quota", "enable", "/path/to/mountpoint",
+		}})).To(Succeed())
+	})
+	It("creates a subvolume without copy on write", func() {
+		Expect(btrfs.CreateSubvolume(s, "/path/to/subvolume", false)).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{
+			{"btrfs", "subvolume", "create", "/path/to/subvolume"},
+			{"chattr", "+C", "/path/to/subvolume"},
+		})).To(Succeed())
+	})
+	It("creates a snapshot without copy on write", func() {
+		Expect(btrfs.CreateSnapshot(s, "/path/to/new/subvolume", "/path/to/old/subvolume", false)).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{
+			{"btrfs", "subvolume", "snapshot", "/path/to/old/subvolume", "/path/to/new/subvolume"},
+			{"chattr", "+C", "/path/to/new/subvolume"},
+		})).To(Succeed())
+	})
+	It("creates a quota group", func() {
+		Expect(btrfs.CreateQuotaGroup(s, "/path/to/subvolume", "1/0")).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{
+			{"btrfs", "qgroup", "create", "1/0", "/path/to/subvolume"},
+		})).To(Succeed())
+	})
+	It("sets default subvolume", func() {
+		Expect(btrfs.SetDefaultSubvolume(s, "/path/to/subvolume")).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{
+			{"btrfs", "subvolume", "set-default", "/path/to/subvolume"},
+		})).To(Succeed())
+	})
+	It("deletes subvolume", func() {
+		Expect(btrfs.DeleteSubvolume(s, "/path/to/subvolume")).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{
+			{"btrfs", "property", "set", "rw", "true", "/path/to/subvolume"},
+			{"btrfs", "subvolume", "delete", "-c", "-R", "/path/to/subvolume"},
+		})).To(Succeed())
+	})
+	It("sets a btrfs partition", func() {
+		Expect(btrfs.SetBtrfsPartition(s, "/path/to/mountpoint")).To(Succeed())
+		Expect(runner.IncludesCmds([][]string{
+			{"btrfs", "quota", "enable", "/path/to/mountpoint"},
+			{"btrfs", "subvolume", "create", "/path/to/mountpoint/@"},
+			{"btrfs", "qgroup", "create", "1/0", "/path/to/mountpoint"},
+			{"btrfs", "subvolume", "set-default", "/path/to/mountpoint/@"},
+		})).To(Succeed())
+	})
+})

--- a/pkg/snapper/snapper_test.go
+++ b/pkg/snapper/snapper_test.go
@@ -162,36 +162,36 @@ var _ = Describe("DiskRepart", Label("diskrepart"), func() {
 		Expect(err).To(HaveOccurred())
 	})
 	It("sets default snapshot", func() {
-		Expect(snap.SetDefault("/some/root", 3, false, map[string]string{"key": "value"})).To(Succeed())
+		Expect(snap.SetDefault("/some/root", 3, map[string]string{"key": "value"})).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{
-			"env", "LC_ALL=C", "snapper", "--no-dbus", "--root", "/some/root", "modify",
-			"--default", "--read-only", "--userdata", "key=value", "3",
+			"snapper", "--no-dbus", "--root", "/some/root", "modify",
+			"--default", "--userdata", "key=value", "3",
 		}})).To(Succeed())
 
-		Expect(snap.SetDefault("/some/root", 3, true, nil)).To(Succeed())
+		Expect(snap.SetDefault("/some/root", 3, nil)).To(Succeed())
 		Expect(runner.IncludesCmds([][]string{{
-			"env", "LC_ALL=C", "snapper", "--no-dbus", "--root", "/some/root", "modify",
-			"--default", "--read-write", "3",
+			"snapper", "--no-dbus", "--root", "/some/root", "modify",
+			"--default", "3",
 		}})).To(Succeed())
 
 		runner.ReturnError = fmt.Errorf("snapper modify failed")
-		Expect(snap.SetDefault("/some/root", 3, true, nil)).NotTo(Succeed())
+		Expect(snap.SetDefault("/some/root", 3, nil)).NotTo(Succeed())
 	})
-	It("cleans up old snapshots", func() {
-		Expect(snap.SetDefault("/some/root", 3, false, map[string]string{"key": "value"})).To(Succeed())
+	It("sets snapshot permissions", func() {
+		Expect(snap.SetPermissions("/some/root", 3, true)).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{
-			"env", "LC_ALL=C", "snapper", "--no-dbus", "--root", "/some/root", "modify",
-			"--default", "--read-only", "--userdata", "key=value", "3",
+			"snapper", "--no-dbus", "--root", "/some/root", "modify",
+			"--read-write", "3",
 		}})).To(Succeed())
 
-		Expect(snap.SetDefault("/some/root", 3, true, nil)).To(Succeed())
+		Expect(snap.SetPermissions("/some/root", 3, false)).To(Succeed())
 		Expect(runner.IncludesCmds([][]string{{
-			"env", "LC_ALL=C", "snapper", "--no-dbus", "--root", "/some/root", "modify",
-			"--default", "--read-write", "3",
+			"snapper", "--no-dbus", "--root", "/some/root", "modify",
+			"--read-only", "3",
 		}})).To(Succeed())
 
 		runner.ReturnError = fmt.Errorf("snapper modify failed")
-		Expect(snap.SetDefault("/some/root", 3, true, nil)).NotTo(Succeed())
+		Expect(snap.SetDefault("/some/root", 3, nil)).NotTo(Succeed())
 	})
 	Describe("ListSnapshots", func() {
 		It("gets the list of snapshots", func() {


### PR DESCRIPTION
btrfs package is just a wrapper around btrfs tools. Create and delete subvolumes or snapshots and some other actions such as quota handling and default
subvolume setting.

This is essentially required for corner cases where snapper client is not enough or where snapper is not ready yet.