### PR TITLE
Update deployment

### DIFF
--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -161,8 +161,9 @@ var _ = Describe("Deployment", Label("deployment"), func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rD.Disks[0].Device).To(Equal("/dev/newdevice"))
 	})
-	It("fails to read a non existing deployment", func() {
+	It("throws a warning tyring to read a non existing deployment", func() {
 		_, err := deployment.ReadDeployment(s, "/some/dir")
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(buffer.String()).To(ContainSubstring("deployment file not found"))
 	})
 })


### PR DESCRIPTION
This commit encompasses three little changes:

* Rename Function to Role, this was a leftover of a previous rename.
* Do not error out if the deployment file can't be read, just throw a warning.
* Remove the sanity check to constraint snapshotted volumes to the system partition.