### PR TITLE
ci/unit-tests: add verbose mode with Ginkgo

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -e
 
-          make unit-tests
+          make VERBOSE=true unit-tests
 
           # Remove mock files from coverage analysis
           sed -n -i '/\/mock\//!p' coverprofile.out

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,22 @@ LDFLAGS:=-w -s
 LDFLAGS+=-X "$(GO_MODULE)/internal/cli/cmd.version=$(GIT_TAG)"
 LDFLAGS+=-X "$(GO_MODULE)/internal/cli/cmd.gitCommit=$(GIT_COMMIT)"
 
+# No verbose unit tests by default
+ifeq ($(VERBOSE),true)
+	VERBOSE_TEST?=-v
+endif
+
 elemental:
 	go build -ldflags '$(LDFLAGS)' -o $@ ./cmd/...
 
 .PHONY: unit-tests
 unit-tests:
-	go run $(GINKGO) --label-filter '!rootlesskit' --race --cover --coverpkg=github.com/suse/elemental/... --github-output -p -r ${PKG}
+	go run $(GINKGO) --label-filter '!rootlesskit' --race --cover --coverpkg=github.com/suse/elemental/... --github-output -p -r $(VERBOSE_TEST) ${PKG}
 ifeq (, $(shell which rootlesskit 2>/dev/null))
 	@echo "No rootlesskit utility found, not executing tests requiring it"
 else
 	@mv coverprofile.out coverprofile.out.bk
-	rootlesskit go run $(GINKGO) --label-filter 'rootlesskit' --race --cover --coverpkg=github.com/suse/elemental/... --github-output -p -r ${PKG}
+	rootlesskit go run $(GINKGO) --label-filter 'rootlesskit' --race --cover --coverpkg=github.com/suse/elemental/... --github-output -p -r $(VERBOSE_TEST) ${PKG}
 	@grep -v "mode: atomic" coverprofile.out >> coverprofile.out.bk
 	@mv coverprofile.out.bk coverprofile.out
 endif


### PR DESCRIPTION
Add verbose mode to have all messages in the unit-tests log, as some are not showned by default. Could be useful for debugging purposes.