### PR TITLE
Add EFI package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/suse/elemental/v3
 go 1.24.0
 
 require (
+	github.com/canonical/go-efilib v1.5.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containerd/containerd/v2 v2.0.5
 	github.com/distribution/reference v0.6.0
@@ -66,6 +67,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.33.0 // indirect
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVd
 github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/canonical/go-efilib v1.5.0 h1:6Igh42xng23i9IJ992KsOHf/TE74VGGPZ1iW0JeRxSA=
+github.com/canonical/go-efilib v1.5.0/go.mod h1:n0Ttsy1JuHAvqaFbZBs6PAzoiiJdfkHsAmDOEbexYEQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -205,6 +207,8 @@ go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwE
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=

--- a/pkg/efi/efi.go
+++ b/pkg/efi/efi.go
@@ -1,0 +1,108 @@
+/*
+Copyright © 2021 - 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efi
+
+import (
+	"io"
+
+	efi "github.com/canonical/go-efilib"
+	efi_linux "github.com/canonical/go-efilib/linux"
+)
+
+type (
+	VariableDescriptor       = efi.VariableDescriptor
+	VariableAttributes       = efi.VariableAttributes
+	GUID                     = efi.GUID
+	LoadOption               = efi.LoadOption
+	DevicePath               = efi.DevicePath
+	FilePathToDevicePathMode = efi_linux.FilePathToDevicePathMode
+)
+
+var (
+	ErrVarsUnavailable = efi.ErrVarsUnavailable
+	ErrVarNotExist     = efi.ErrVarNotExist
+	ErrVarPermission   = efi.ErrVarPermission
+
+	GlobalVariable       = efi.GlobalVariable
+	AttributeNonVolatile = efi.AttributeNonVolatile
+
+	NewFilePathDevicePathNode = efi.NewFilePathDevicePathNode
+)
+
+type Variables interface {
+	ListVariables() ([]VariableDescriptor, error)
+	GetVariable(guid GUID, name string) (data []byte, attrs VariableAttributes, err error)
+	WriteVariable(name string, guid GUID, attrs VariableAttributes, data []byte) error
+	NewFileDevicePath(filepath string, mode FilePathToDevicePathMode) (DevicePath, error)
+	DelVariable(guid GUID, name string) error
+	ReadLoadOption(r io.Reader) (out *LoadOption, err error)
+}
+
+type Vars struct{}
+
+var _ Variables = (*Vars)(nil)
+
+func (v Vars) DelVariable(guid GUID, name string) error {
+	_, attrs, err := v.GetVariable(guid, name)
+	if err != nil {
+		return err
+	}
+
+	return v.WriteVariable(name, guid, attrs, nil)
+}
+
+func (v Vars) NewFileDevicePath(filepath string, mode efi_linux.FilePathToDevicePathMode) (efi.DevicePath, error) {
+	return efi_linux.FilePathToDevicePath(filepath, mode)
+}
+
+func (Vars) ListVariables() ([]efi.VariableDescriptor, error) {
+	return efi.ListVariables(efi.DefaultVarContext)
+}
+
+func (Vars) GetVariable(guid efi.GUID, name string) (data []byte, attrs efi.VariableAttributes, err error) {
+	return efi.ReadVariable(efi.DefaultVarContext, name, guid)
+}
+
+func (Vars) WriteVariable(name string, guid GUID, attrs VariableAttributes, data []byte) error {
+	return efi.WriteVariable(efi.DefaultVarContext, name, guid, attrs, data)
+}
+
+func (Vars) ReadLoadOption(r io.Reader) (out *efi.LoadOption, err error) {
+	return efi.ReadLoadOption(r)
+}
+
+type BootManager struct {
+	efivars        Variables
+	entries        map[uint16]BootEntryVariable
+	bootOrder      []uint16
+	bootOrderAttrs VariableAttributes
+}
+
+type BootEntryVariable struct {
+	BootNumber uint16
+	Data       []byte
+	Attributes VariableAttributes
+	LoadOption *LoadOption
+}
+
+type BootEntry struct {
+	Filename    string
+	Label       string
+	Options     string
+	Description string
+}

--- a/pkg/efi/manager.go
+++ b/pkg/efi/manager.go
@@ -1,0 +1,198 @@
+// nolint:goheader
+
+// This file is part of nullboot
+// Copyright 2021 Canonical Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Package efi contains a boot management library
+package efi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"path"
+
+	efi "github.com/canonical/go-efilib"
+	efilinux "github.com/canonical/go-efilib/linux"
+
+	"github.com/suse/elemental/v3/pkg/log"
+)
+
+const (
+	maxBootEntries uint16 = math.MaxUint16 // Maximum number of boot entries we can hold
+)
+
+// NewBootManagerForVariables returns a boot manager for the given EFIVariables manager
+func NewBootManagerForVariables(logger log.Logger, efivars Variables) (BootManager, error) {
+	var err error
+	bm := BootManager{}
+	bm.efivars = efivars
+
+	if !VariablesSupported(efivars) {
+		return BootManager{}, fmt.Errorf("variables not supported")
+	}
+
+	bootOrderBytes, bootOrderAttrs, err := bm.efivars.GetVariable(efi.GlobalVariable, "BootOrder")
+	if err != nil {
+		bootOrderBytes = nil
+		bootOrderAttrs = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
+	}
+	bm.bootOrder = make([]uint16, len(bootOrderBytes)/2)
+	bm.bootOrderAttrs = bootOrderAttrs
+	for i := 0; i < len(bootOrderBytes); i += 2 {
+		// FIXME: It's probably not valid to assume little-endian here?
+		bm.bootOrder[i/2] = binary.LittleEndian.Uint16(bootOrderBytes[i : i+2])
+	}
+
+	bm.entries = make(map[uint16]BootEntryVariable)
+	names, err := GetVariableNames(bm.efivars, efi.GlobalVariable)
+	if err != nil {
+		return BootManager{}, fmt.Errorf("cannot obtain list of global variables: %s", err.Error())
+	}
+	for _, name := range names {
+		var entry BootEntryVariable
+		if parsed, err := fmt.Sscanf(name, "Boot%04X", &entry.BootNumber); len(name) != 8 || parsed != 1 || err != nil {
+			continue
+		}
+		entry.Data, entry.Attributes, err = bm.efivars.GetVariable(efi.GlobalVariable, name)
+		if err != nil {
+			return BootManager{}, fmt.Errorf("cannot read %s: %s", name, err.Error())
+		}
+		entry.LoadOption, err = bm.efivars.ReadLoadOption(bytes.NewReader(entry.Data))
+		if err != nil {
+			logger.Warn("Error reading efi load option for '%s': %s", name, err.Error())
+			continue
+		}
+
+		bm.entries[entry.BootNumber] = entry
+	}
+
+	return bm, nil
+}
+
+// FindOrCreateEntry finds a matching entry in the boot device selection menu,
+// or creates one if it is missing.
+//
+// It returns the number of the entry created, or -1 on failure, with error set.
+//
+// The argument relativeTo specifies the directory entry.Filename is in.
+func (bm *BootManager) FindOrCreateEntry(entry BootEntry, relativeTo string) (uint16, error) {
+	bootNext, err := bm.NextFreeEntry()
+	if err != nil {
+		return 0, err
+	}
+	variable := fmt.Sprintf("Boot%04X", bootNext)
+
+	dp, err := bm.efivars.NewFileDevicePath(path.Join(relativeTo, entry.Filename), efilinux.ShortFormPathHD)
+	if err != nil {
+		return 0, err
+	}
+
+	optionalData := new(bytes.Buffer)
+	_ = binary.Write(optionalData, binary.LittleEndian, efi.ConvertUTF8ToUCS2(entry.Options+"\x00"))
+
+	loadoption := &efi.LoadOption{
+		Attributes:   efi.LoadOptionActive,
+		Description:  entry.Label,
+		FilePath:     dp,
+		OptionalData: optionalData.Bytes()}
+
+	loadoptionBytes, err := loadoption.Bytes()
+	if err != nil {
+		return 0, fmt.Errorf("cannot encode load option: %s", err.Error())
+	}
+
+	entryVar := BootEntryVariable{
+		BootNumber: bootNext,
+		Data:       loadoptionBytes,
+		Attributes: efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess,
+		LoadOption: loadoption,
+	}
+
+	// Detect duplicates and ignore
+	for _, existingVar := range bm.entries {
+		if bytes.Equal(existingVar.Data, entryVar.Data) && existingVar.Attributes == entryVar.Attributes {
+			return existingVar.BootNumber, nil
+		}
+	}
+
+	if err := bm.efivars.WriteVariable(variable, efi.GlobalVariable, entryVar.Attributes, entryVar.Data); err != nil {
+		return 0, err
+	}
+
+	bm.entries[bootNext] = entryVar
+
+	return bootNext, nil
+}
+
+// NextFreeEntry returns the number of the next free Boot variable.
+func (bm *BootManager) NextFreeEntry() (uint16, error) {
+	for i := uint16(0); i < maxBootEntries; i++ {
+		if _, ok := bm.entries[i]; !ok {
+			return i, nil
+		}
+	}
+
+	return 0, fmt.Errorf("maximum number of boot entries exceeded")
+}
+
+// PrependAndSetBootOrder commits a new boot order or returns an error.
+//
+// The boot order specified is prepended to the existing one, and the order
+// is deduplicated before committing.
+func (bm *BootManager) PrependAndSetBootOrder(head []uint16) error {
+	var newOrder []uint16
+
+	// Combine head with existing boot order, filter out duplicates and non-existing entries
+	for _, num := range append(append([]uint16(nil), head...), bm.bootOrder...) {
+		isDuplicate := false
+		for _, otherNum := range newOrder {
+			if otherNum == num {
+				isDuplicate = true
+			}
+		}
+		if _, ok := bm.entries[num]; ok && !isDuplicate {
+			newOrder = append(newOrder, num)
+		}
+	}
+
+	// Encode the boot order to bytes
+	var output []byte
+	for _, num := range newOrder {
+		var numBytes [2]byte
+		binary.LittleEndian.PutUint16(numBytes[0:], uint16(num))
+		output = append(output, numBytes[0], numBytes[1])
+	}
+
+	// Set the boot order and update our cache
+	if err := bm.efivars.WriteVariable("BootOrder", efi.GlobalVariable, bm.bootOrderAttrs, output); err != nil {
+		return err
+	}
+
+	bm.bootOrder = newOrder
+	return nil
+
+}
+
+// VariablesSupported indicates whether variables can be accessed.
+func VariablesSupported(efiVars Variables) bool {
+	_, err := efiVars.ListVariables()
+	return err == nil
+}
+
+// GetVariableNames returns the names of every variable with the specified GUID.
+func GetVariableNames(efiVars Variables, filterGUID efi.GUID) (names []string, err error) {
+	vars, err := efiVars.ListVariables()
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range vars {
+		if entry.GUID != filterGUID {
+			continue
+		}
+		names = append(names, entry.Name)
+	}
+	return names, nil
+}

--- a/pkg/efi/manager_test.go
+++ b/pkg/efi/manager_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright © 2021 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efi_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/efi"
+	"github.com/suse/elemental/v3/pkg/log"
+
+	"github.com/suse/elemental/v3/pkg/efi/mock"
+)
+
+func TestEFISuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EFI test suite")
+}
+
+var _ = Describe("EFI Manager", Label("efi", "manager"), func() {
+	var logger log.Logger
+
+	BeforeEach(func() {
+		logger = log.New(log.WithDiscardAll())
+	})
+
+	It("creates a BootManager without error", func() {
+		var vars efi.Variables = mock.NewMockEFIVariables()
+
+		manager, err := efi.NewBootManagerForVariables(nil, vars)
+		Expect(err).To(BeNil())
+
+		Expect(manager).ToNot(BeNil())
+	})
+
+	It("creates a BootManager with ReadLoadOptions error", func() {
+		var vars efi.Variables = mock.NewMockEFIVariables().WithLoadOptionError(fmt.Errorf("cannot read device path: cannot decode node: 1: invalid length 14 bytes (too large)"))
+
+		err := vars.WriteVariable("BootOrder", efi.GlobalVariable, efi.AttributeNonVolatile, []byte("0001"))
+		Expect(err).To(BeNil())
+
+		err = vars.WriteVariable("Boot0001", efi.GlobalVariable, efi.AttributeNonVolatile, []byte("test.efi"))
+		Expect(err).To(BeNil())
+
+		manager, err := efi.NewBootManagerForVariables(logger, vars)
+		Expect(err).To(BeNil())
+
+		Expect(manager).ToNot(BeNil())
+	})
+})

--- a/pkg/efi/mock/efi.go
+++ b/pkg/efi/mock/efi.go
@@ -1,0 +1,101 @@
+/*
+Copyright © 2022 - 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mock
+
+import (
+	"io"
+	"strings"
+
+	"github.com/twpayne/go-vfs/v4"
+
+	"github.com/suse/elemental/v3/pkg/efi"
+)
+
+type mockEFIVariable struct {
+	data  []byte
+	attrs efi.VariableAttributes
+}
+
+// EFIVariables implements an in-memory variable store.
+type EFIVariables struct {
+	store         map[efi.VariableDescriptor]mockEFIVariable
+	loadOptionErr error
+}
+
+var _ efi.Variables = (*EFIVariables)(nil)
+
+func NewMockEFIVariables() *EFIVariables {
+	return &EFIVariables{
+		store: make(map[efi.VariableDescriptor]mockEFIVariable),
+	}
+}
+
+func (m *EFIVariables) WithLoadOptionError(err error) *EFIVariables {
+	m.loadOptionErr = err
+	return m
+}
+
+func (m EFIVariables) DelVariable(_ efi.GUID, _ string) error {
+	return nil
+}
+
+// ListVariables implements EFIVariables
+func (m EFIVariables) ListVariables() (out []efi.VariableDescriptor, err error) {
+	for k := range m.store {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// GetVariable implements EFIVariables
+func (m EFIVariables) GetVariable(guid efi.GUID, name string) (data []byte, attrs efi.VariableAttributes, err error) {
+	out, ok := m.store[efi.VariableDescriptor{Name: name, GUID: guid}]
+	if !ok {
+		return nil, 0, efi.ErrVarNotExist
+	}
+	return out.data, out.attrs, nil
+}
+
+// WriteVariable implements EFIVariables
+func (m EFIVariables) WriteVariable(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+	if len(data) == 0 {
+		delete(m.store, efi.VariableDescriptor{Name: name, GUID: guid})
+	} else {
+		m.store[efi.VariableDescriptor{Name: name, GUID: guid}] = mockEFIVariable{data, attrs}
+	}
+	return nil
+}
+
+func (m EFIVariables) ReadLoadOption(_ io.Reader) (out *efi.LoadOption, err error) {
+	return nil, m.loadOptionErr
+}
+
+func (m EFIVariables) NewFileDevicePath(fpath string, _ efi.FilePathToDevicePathMode) (efi.DevicePath, error) {
+	file, err := vfs.OSFS.Open(fpath)
+	if err != nil {
+		return nil, err
+	}
+	file.Close()
+
+	const espLocation = "/boot/efi/"
+	fpath = strings.TrimPrefix(fpath, espLocation)
+
+	return efi.DevicePath{
+		efi.NewFilePathDevicePathNode(fpath),
+	}, nil
+}


### PR DESCRIPTION
The EFI package contains functionality to read/write EFI vars and modify
the boot-entries of the system.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
