### PR TITLE
Remove sector size from deployment struct

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -187,7 +187,6 @@ type Partitions []*Partition
 type Disk struct {
 	Device     string     `json:"device,omitempty"`
 	Partitions Partitions `json:"partitions"`
-	SectorSize uint       `json:"sectorSize,omitempty"`
 }
 
 type Deployment struct {


### PR DESCRIPTION
This commit removes sector size from the deployment struct because this is not a deployment parameter, this is a given from the context and hardware.

In installation scope sector size can't be customized, it is a parameter of the target device. Sector size is only potentially configurable in a disk image building context.