### PR TITLE
Add start sector field in deployment

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -185,8 +185,9 @@ type Partition struct {
 type Partitions []*Partition
 
 type Disk struct {
-	Device     string     `json:"device,omitempty"`
-	Partitions Partitions `json:"partitions"`
+	Device      string     `json:"device,omitempty"`
+	Partitions  Partitions `json:"partitions"`
+	StartSector uint       `json:"startSector,omitempty"`
 }
 
 type Deployment struct {

--- a/pkg/diskrepart/disk.go
+++ b/pkg/diskrepart/disk.go
@@ -61,28 +61,28 @@ type Disk struct {
 
 type DiskOptions func(d *Disk) error
 
-func WithGdisk() func(d *Disk) error {
+func WithGdisk() DiskOptions {
 	return func(d *Disk) error {
 		d.partBackend = gdiskBack
 		return nil
 	}
 }
 
-func WithParted() func(d *Disk) error {
+func WithParted() DiskOptions {
 	return func(d *Disk) error {
 		d.partBackend = partedBack
 		return nil
 	}
 }
 
-func WithBlockDevice(bd block.Device) func(d *Disk) error {
+func WithBlockDevice(bd block.Device) DiskOptions {
 	return func(d *Disk) error {
 		d.blockDevice = bd
 		return nil
 	}
 }
 
-func WithStartSector(startSector uint) func(d *Disk) error {
+func WithStartSector(startSector uint) DiskOptions {
 	return func(d *Disk) error {
 		d.startSector = startSector
 		return nil

--- a/pkg/diskrepart/disk_repart.go
+++ b/pkg/diskrepart/disk_repart.go
@@ -52,7 +52,7 @@ func FormatDevice(s *sys.System, device string, fileSystem string, label string,
 // and applies the configured disk layout by creating and formatting all
 // required partitions
 func PartitionAndFormatDevice(s *sys.System, d *deployment.Disk) error {
-	disk := NewDisk(s, d.Device)
+	disk := NewDisk(s, d.Device, WithStartSector(d.StartSector))
 
 	if !disk.Exists() {
 		return fmt.Errorf("disk %s does not exist", d.Device)


### PR DESCRIPTION
This commit adds a startSector attribute in Disk struct. This is used to set the first sector in disk that is used for a partition. This is specially relevant for some ARM devices requiring the ESP partition at a very specific position.

If unset defaults to 1MiB which is 2048 for disks with a sector size of 512 bytes.