### PR TITLE
Set partition alignement

### DIFF
--- a/pkg/diskrepart/disk_repart_test.go
+++ b/pkg/diskrepart/disk_repart_test.go
@@ -89,10 +89,10 @@ var _ = Describe("DiskRepart", Label("diskrepart"), func() {
 				if args[0] == "-p" {
 					return []byte(table), nil
 				}
-				if strings.HasPrefix(args[0], "-n=1") {
+				if strings.HasPrefix(strings.Join(args, " "), "--align-end -n=1") {
 					table += firstPart
 				}
-				if strings.HasPrefix(args[0], "-n=2") {
+				if strings.HasPrefix(strings.Join(args, " "), "--align-end -n=2") {
 					table += secondPart
 				}
 				return runner.ReturnValue, runner.ReturnError
@@ -108,9 +108,9 @@ var _ = Describe("DiskRepart", Label("diskrepart"), func() {
 			{"sgdisk", "--zap-all", "/dev/device"},
 			{"partx", "-u", "/dev/device"},
 			{"sgdisk", "-p", "-v", "/dev/device"},
-			{"sgdisk", "-n=1:2048:+2097152", "-c=1:efi", "-t=1:EF00", "/dev/device"},
+			{"sgdisk", "--align-end", "-n=1:2048:+2097152", "-c=1:efi", "-t=1:EF00", "/dev/device"},
 			{"mkfs.vfat", "-n", "EFI", "-i"},
-			{"sgdisk", "-n=2:2099200:+0", "-c=2:system", "-t=2:8300", "/dev/device"},
+			{"sgdisk", "--align-end", "-n=2:2099200:+0", "-c=2:system", "-t=2:8300", "/dev/device"},
 			{"mkfs.btrfs", "-L", "SYSTEM", "-U"},
 		})).To(Succeed())
 	})

--- a/pkg/diskrepart/partitioner/gdisk/gdisk.go
+++ b/pkg/diskrepart/partitioner/gdisk/gdisk.go
@@ -77,6 +77,10 @@ func (gd gdiskCall) buildOptions() []string {
 		opts = append(opts, fmt.Sprintf("-d=%d", partnum))
 	}
 
+	if len(gd.parts) > 0 {
+		opts = append(opts, "--align-end")
+	}
+
 	for _, part := range gd.parts {
 		opts = append(opts, fmt.Sprintf("-n=%d:%d:+%d", part.Number, part.StartS, part.SizeS))
 

--- a/pkg/diskrepart/partitioner/gdisk/gdisk_test.go
+++ b/pkg/diskrepart/partitioner/gdisk/gdisk_test.go
@@ -65,9 +65,9 @@ var _ = Describe("Parted", Label("parted"), func() {
 	})
 	It("Runs complex command", func() {
 		cmds := [][]string{
-			{"sgdisk", "-P", "--zap-all", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
+			{"sgdisk", "-P", "--zap-all", "--align-end", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
 				"-n=1:206848:+0", "-c=1:p.root", "-t=1:8300", "/dev/device"},
-			{"sgdisk", "--zap-all", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
+			{"sgdisk", "--zap-all", "--align-end", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
 				"-n=1:206848:+0", "-c=1:p.root", "-t=1:8300", "/dev/device"},
 			{"partx", "-u", "/dev/device"},
 		}
@@ -103,9 +103,9 @@ var _ = Describe("Parted", Label("parted"), func() {
 	})
 	It("Creates a new partition", func() {
 		cmds := [][]string{
-			{"sgdisk", "-n=0:2048:+204800", "-c=0:p.root", "-t=0:8300", "/dev/device"},
+			{"sgdisk", "--align-end", "-n=0:2048:+204800", "-c=0:p.root", "-t=0:8300", "/dev/device"},
 			{"partx", "-u", "/dev/device"},
-			{"sgdisk", "-n=0:2048:+0", "-c=0:p.root", "-t=0:8300", "/dev/device"},
+			{"sgdisk", "--align-end", "-n=0:2048:+0", "-c=0:p.root", "-t=0:8300", "/dev/device"},
 			{"partx", "-u", "/dev/device"},
 		}
 		partition := partitioner.Partition{


### PR DESCRIPTION
Sgdisk uses 1MiB alignement by default on partition start but not on partition end. Partitions partitions are always defined as a multiple of 1MiB with the only exception of the last partition, which takes all available space.

This commit ensures the last partition is also aligned to 1MiB. This turns to be a requirement for encryption tools.