### PR TITLE
Standardize OCI opts

### DIFF
--- a/internal/cli/action/unpack.go
+++ b/internal/cli/action/unpack.go
@@ -39,10 +39,10 @@ func Unpack(ctx *cli.Context) error {
 
 	s.Logger().Info("Starting unpack action with args: %+v", args)
 
-	unpacker := unpack.NewOCIUnpacker(s, args.Image).
-		WithLocal(args.Local).
-		WithPlatformRef(args.Platform).
-		WithVerify(args.Verify)
+	unpacker := unpack.NewOCIUnpacker(s, args.Image,
+		unpack.WithLocal(args.Local),
+		unpack.WithPlatformRef(args.Platform),
+		unpack.WithVerify(args.Verify))
 
 	ctxSignal, stop := signal.NotifyContext(ctx.Context, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()

--- a/pkg/unpack/oci.go
+++ b/pkg/unpack/oci.go
@@ -48,33 +48,42 @@ type OCI struct {
 
 type OCIOpt func(*OCI)
 
-func (o *OCI) WithLocal(local bool) *OCI {
-	o.local = local
-	return o
+func WithLocal(local bool) OCIOpt {
+	return func(o *OCI) {
+		o.local = local
+	}
 }
 
-func (o *OCI) WithVerify(verify bool) *OCI {
-	o.verify = verify
-	return o
+func WithVerify(verify bool) OCIOpt {
+	return func(o *OCI) {
+		o.verify = verify
+	}
 }
 
-func (o *OCI) WithPlatformRef(platform string) *OCI {
-	o.platformRef = platform
-	return o
+func WithPlatformRef(platform string) OCIOpt {
+	return func(o *OCI) {
+		o.platformRef = platform
+	}
 }
 
-func (o *OCI) WithImageRef(imageRef string) *OCI {
-	o.imageRef = imageRef
-	return o
+func WithImageRef(imageRef string) OCIOpt {
+	return func(o *OCI) {
+		o.imageRef = imageRef
+	}
 }
 
-func NewOCIUnpacker(s *sys.System, imageRef string) *OCI {
+func NewOCIUnpacker(s *sys.System, imageRef string, opts ...OCIOpt) *OCI {
 	unpacker := &OCI{
 		s:           s,
 		verify:      true,
 		platformRef: s.Platform().String(),
 		imageRef:    imageRef,
 	}
+
+	for _, o := range opts {
+		o(unpacker)
+	}
+
 	return unpacker
 }
 


### PR DESCRIPTION
Use the same opts-approach as done in other parts of the code-base.

This adapts the OCI-unpacker to use the OCIOpt alias to pass in options
to the NewOCIUnpacker.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
