### PR TITLE
Rename binary to elemental-toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ go.work.sum
 # coverage report
 coverprofile.out
 
-# elemental binary
-elemental
+# elemental binaries
+elemental-toolkit

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ ifeq ($(VERBOSE),true)
 	VERBOSE_TEST?=-v
 endif
 
-elemental: $(GO_FILES)
-	go build -ldflags '$(LDFLAGS)' -o $@ ./cmd/...
+elemental-toolkit: $(GO_FILES)
+	go build -ldflags '$(LDFLAGS)' -o $@ ./cmd/elemental-toolkit
 
 .PHONY: unit-tests
 unit-tests:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ GIT_COMMIT_SHORT?=$(shell git rev-parse --short HEAD)
 GIT_TAG?=$(shell git describe --candidates=50 --abbrev=0 --tags 2>/dev/null || echo "v0.0.1" )
 
 LDFLAGS:=-w -s
-LDFLAGS+=-X "$(GO_MODULE)/internal/cli/cmd.version=$(GIT_TAG)"
-LDFLAGS+=-X "$(GO_MODULE)/internal/cli/cmd.gitCommit=$(GIT_COMMIT)"
+LDFLAGS+=-X "$(GO_MODULE)/internal/cli/version.version=$(GIT_TAG)"
+LDFLAGS+=-X "$(GO_MODULE)/internal/cli/version.gitCommit=$(GIT_COMMIT)"
 
 # No verbose unit tests by default
 ifeq ($(VERBOSE),true)

--- a/cmd/elemental-toolkit/main.go
+++ b/cmd/elemental-toolkit/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/suse/elemental/v3/internal/cli/action"
 	"github.com/suse/elemental/v3/internal/cli/cmd"
+	"github.com/suse/elemental/v3/internal/cli/version"
 	"github.com/urfave/cli/v2"
 )
 
@@ -33,7 +34,7 @@ func main() {
 		cmd.NewInstallCommand(action.Install),
 		cmd.NewUpgradeCommand(action.Upgrade),
 		cmd.NewUnpackImageCommand(action.Unpack),
-		cmd.NewVersionCommand(),
+		version.NewVersionCommand(app.Name),
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/elemental-toolkit/main.go
+++ b/cmd/elemental-toolkit/main.go
@@ -21,10 +21,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/suse/elemental/v3/internal/cli/action"
 	"github.com/suse/elemental/v3/internal/cli/cmd"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {

--- a/cmd/elemental-toolkit/main.go
+++ b/cmd/elemental-toolkit/main.go
@@ -22,22 +22,24 @@ import (
 	"os"
 
 	"github.com/suse/elemental/v3/internal/cli/action"
+	"github.com/suse/elemental/v3/internal/cli/app"
 	"github.com/suse/elemental/v3/internal/cli/cmd"
 	"github.com/suse/elemental/v3/internal/cli/version"
-	"github.com/urfave/cli/v2"
 )
 
 func main() {
-	app := cmd.NewApp()
-	app.Commands = []*cli.Command{
-		cmd.NewBuildCommand(action.Build),
-		cmd.NewInstallCommand(action.Install),
-		cmd.NewUpgradeCommand(action.Upgrade),
-		cmd.NewUnpackImageCommand(action.Unpack),
-		version.NewVersionCommand(app.Name),
-	}
+	appName := app.Name()
+	application := app.New(
+		cmd.Usage,
+		cmd.GlobalFlags(),
+		cmd.Setup,
+		cmd.NewBuildCommand(appName, action.Build),
+		cmd.NewInstallCommand(appName, action.Install),
+		cmd.NewUpgradeCommand(appName, action.Upgrade),
+		cmd.NewUnpackImageCommand(appName, action.Unpack),
+		version.NewVersionCommand(appName))
 
-	if err := app.Run(os.Args); err != nil {
+	if err := application.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -15,33 +15,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package app
 
 import (
-	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/urfave/cli/v2"
 )
 
-type UpgradeFlags struct {
-	OperatingSystemImage string
+func Name() string {
+	return filepath.Base(os.Args[0])
 }
 
-var UpgradeArgs UpgradeFlags
+func New(usage string, globalFlags []cli.Flag, setupFunc cli.BeforeFunc, commands ...*cli.Command) *cli.App {
+	app := cli.NewApp()
 
-func NewUpgradeCommand(appName string, action func(*cli.Context) error) *cli.Command {
-	return &cli.Command{
-		Name:      "upgrade",
-		Usage:     "Upgrade system from an OS image",
-		UsageText: fmt.Sprintf("%s upgrade [OPTIONS]", appName),
-		Action:    action,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:        "os-image",
-				Usage:       "image containing the operating system",
-				Destination: &UpgradeArgs.OperatingSystemImage,
-				Required:    true,
-			},
-		},
-	}
+	app.Flags = globalFlags
+	app.Name = Name()
+	app.Commands = commands
+	app.Usage = usage
+	app.Suggest = true
+	app.Before = setupFunc
+
+	return app
 }

--- a/internal/cli/cmd/build.go
+++ b/internal/cli/cmd/build.go
@@ -30,11 +30,11 @@ type BuildFlags struct {
 
 var BuildArgs BuildFlags
 
-func NewBuildCommand(action func(*cli.Context) error) *cli.Command {
+func NewBuildCommand(appName string, action func(*cli.Context) error) *cli.Command {
 	return &cli.Command{
 		Name:      "build",
 		Usage:     "Build new image",
-		UsageText: fmt.Sprintf("%s build [OPTIONS]", appName()),
+		UsageText: fmt.Sprintf("%s build [OPTIONS]", appName),
 		Action:    action,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -31,11 +31,11 @@ type InstallFlags struct {
 
 var InstallArgs InstallFlags
 
-func NewInstallCommand(action func(*cli.Context) error) *cli.Command {
+func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Command {
 	return &cli.Command{
 		Name:      "install",
 		Usage:     "Install an OCI image on a target system",
-		UsageText: fmt.Sprintf("%s install [OPTIONS]", appName()),
+		UsageText: fmt.Sprintf("%s install [OPTIONS]", appName),
 		Action:    action,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -18,57 +18,35 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/sys"
 )
 
-type GlobalFlags struct {
-	Debug bool
-}
+const Usage = "Build, install and upgrade infrastructure platforms"
 
-var GlobalArgs GlobalFlags
-
-func appName() string {
-	return filepath.Base(os.Args[0])
-}
-
-func globalFlags() []cli.Flag {
+func GlobalFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
-			Name:        "debug",
-			Usage:       "Set logging at debug level",
-			Destination: &GlobalArgs.Debug,
+			Name:  "debug",
+			Usage: "Set logging at debug level",
 		},
 	}
 }
 
-func NewApp() *cli.App {
-	app := cli.NewApp()
-
-	app.Flags = globalFlags()
-	app.Name = appName()
-	app.Usage = "Build, install and upgrade infrastructure platforms"
-	app.Suggest = true
-	app.Before = func(ctx *cli.Context) error {
-		s, err := sys.NewSystem()
-		if err != nil {
-			return err
-		}
-
-		if ctx.Bool("debug") {
-			s.Logger().SetLevel(log.DebugLevel())
-		}
-		if ctx.App.Metadata == nil {
-			ctx.App.Metadata = map[string]any{}
-		}
-		ctx.App.Metadata["system"] = s
-		return nil
+func Setup(ctx *cli.Context) error {
+	s, err := sys.NewSystem()
+	if err != nil {
+		return err
 	}
 
-	return app
+	if ctx.Bool("debug") {
+		s.Logger().SetLevel(log.DebugLevel())
+	}
+	if ctx.App.Metadata == nil {
+		ctx.App.Metadata = map[string]any{}
+	}
+	ctx.App.Metadata["system"] = s
+	return nil
 }

--- a/internal/cli/cmd/unpack-image.go
+++ b/internal/cli/cmd/unpack-image.go
@@ -33,11 +33,11 @@ type UnpackFlags struct {
 
 var UnpackArgs UnpackFlags
 
-func NewUnpackImageCommand(action func(*cli.Context) error) *cli.Command {
+func NewUnpackImageCommand(appName string, action func(*cli.Context) error) *cli.Command {
 	return &cli.Command{
 		Name:      "unpack-image",
 		Usage:     "Unpacks an image to the specified location",
-		UsageText: fmt.Sprintf("%s unpack-image [OPTIONS]", appName()),
+		UsageText: fmt.Sprintf("%s unpack-image [OPTIONS]", appName),
 		Action:    action,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package version
 
 import (
 	"fmt"
@@ -29,12 +29,12 @@ var (
 	gitCommit = ""
 )
 
-func NewVersionCommand() *cli.Command {
+func NewVersionCommand(appName string) *cli.Command {
 	return &cli.Command{
 		Name:      "version",
 		Aliases:   []string{"v"},
 		Usage:     "Inspect program version",
-		UsageText: fmt.Sprintf("%s version", appName()),
+		UsageText: fmt.Sprintf("%s version", appName),
 		Action: func(*cli.Context) error {
 			commit := gitCommit
 			if len(commit) > 7 {


### PR DESCRIPTION
- Renames produced binary to elemental-toolkit
- Extracts version command and restructures app creation to allow for reusability
- Next PR will include further separation of the `internal/cli` package: 
  - `internal/cli/elemental/...` 
  - `internal/cli/elemental-toolkit/...`