### PR TITLE
Add overlaytree and config script as installation parameters

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -190,7 +190,7 @@ type Disk struct {
 	StartSector uint       `json:"startSector,omitempty"`
 }
 
-// MarshalJson on disks omits the device name as this is a runtime information
+// MarshalJSON on disks omits the device name as this is a runtime information
 // which might not be consistent across reboots, there is no need to store it.
 func (d Disk) MarshalJSON() ([]byte, error) {
 	type diskAlias Disk
@@ -202,11 +202,11 @@ func (d Disk) MarshalJSON() ([]byte, error) {
 type Deployment struct {
 	SourceOS *ImageSource `json:"sourceOS"`
 	Disks    []*Disk      `json:"disks"`
-	// Consider adding a systemd-sysext list here and
-	// some other well known set of structers such as charts.
-	// Also abitrary data would be intersting (e.g. tarballs).
+	// Consider adding a systemd-sysext list here
 	// All of them would extracted in the RO context, so only
 	// additions to the RWVolumes would succeed.
+	OverlayTree *ImageSource `json:"overlayTree"`
+	CfgScript   string       `json:"configScript"`
 
 	// Also bootloader details could be added here
 }

--- a/pkg/fstab/fstab_test.go
+++ b/pkg/fstab/fstab_test.go
@@ -46,7 +46,7 @@ UUID=uuid   /data btrfs defaults,subvol=/@/new/data     0 0
 UUID=afadf  /etc  btrfs defaults,subvol=/@/new/path/etc 0 0
 `
 
-var _ = Describe("DirectoryUnpacker", Label("directory"), func() {
+var _ = Describe("Fstab", Label("fstab"), func() {
 	var tfs vfs.FS
 	var s *sys.System
 	var cleanup func()

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Install", Label("install"), func() {
 		d.Disks[0].Partitions[0].UUID = "34A8-ABB8"
 		d.Disks[0].Partitions[1].UUID = "34a8abb8-ddb3-48a2-8ecc-2443e92c7510"
 		d.SourceOS = deployment.NewDirSrc("/some/dir")
-		d.CfgScript = "/opt/tree"
+		d.CfgScript = "/opt/config.sh"
 		d.OverlayTree = deployment.NewDirSrc("/opt/tree")
 		Expect(d.Sanitize(s)).To(Succeed())
 		i = install.New(context.Background(), s, install.WithTransaction(t))
@@ -195,12 +195,6 @@ var _ = Describe("Install", Label("install"), func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("commit failed"))
 		Expect(t.RollbackCalled()).To(BeTrue())
-	})
-	It("fails on config hook execution", func() {
-		syscall.ErrorOnChroot = true
-		err := i.Install(d)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("chroot error"))
 	})
 	It("fails on transaction close", func() {
 		t.CloseErr = fmt.Errorf("close failed")

--- a/pkg/transaction/mock/snapper.go
+++ b/pkg/transaction/mock/snapper.go
@@ -27,6 +27,7 @@ type Transactioner struct {
 	StartErr       error
 	MergeErr       error
 	CommitErr      error
+	SetDefaultErr  error
 	Trans          *transaction.Transaction
 	SrcDigest      string
 	rollbackCalled bool
@@ -49,8 +50,12 @@ func (m Transactioner) Merge(_ *transaction.Transaction) error {
 	return m.MergeErr
 }
 
-func (m Transactioner) Commit(_ *transaction.Transaction, _ transaction.Hook, _ transaction.HookBinds) error {
+func (m Transactioner) Commit(_ *transaction.Transaction) error {
 	return m.CommitErr
+}
+
+func (m Transactioner) Close(_ *transaction.Transaction) error {
+	return m.SetDefaultErr
 }
 
 func (m *Transactioner) Rollback(_ *transaction.Transaction, err error) error {

--- a/pkg/transaction/mock/snapper.go
+++ b/pkg/transaction/mock/snapper.go
@@ -27,7 +27,7 @@ type Transactioner struct {
 	StartErr       error
 	MergeErr       error
 	CommitErr      error
-	SetDefaultErr  error
+	CloseErr       error
 	Trans          *transaction.Transaction
 	SrcDigest      string
 	rollbackCalled bool
@@ -55,7 +55,7 @@ func (m Transactioner) Commit(_ *transaction.Transaction) error {
 }
 
 func (m Transactioner) Close(_ *transaction.Transaction) error {
-	return m.SetDefaultErr
+	return m.CloseErr
 }
 
 func (m *Transactioner) Rollback(_ *transaction.Transaction, err error) error {

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -25,10 +25,12 @@ type transactionState int
 
 const (
 	started transactionState = iota + 1
+	updated
 	committed
-	closed
 	failed
 )
+
+type UpdateHook func() error
 
 type Merge struct {
 	Old      string // old unmodified tree
@@ -45,9 +47,8 @@ type Transaction struct {
 
 type Interface interface {
 	Init(deployment.Deployment) error
-	Start(*deployment.ImageSource) (*Transaction, error)
-	Merge(*Transaction) error
+	Start() (*Transaction, error)
+	Update(*Transaction, *deployment.ImageSource, UpdateHook) error
 	Commit(*Transaction) error
-	Close(*Transaction) error
 	Rollback(*Transaction, error) error
 }

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -30,10 +30,6 @@ const (
 	failed
 )
 
-type Hook func() error
-
-type HookBinds map[string]string
-
 type Merge struct {
 	Old      string // old unmodified tree
 	New      string // new base tree where modifications should be applied

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -83,9 +83,15 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 		return err
 	}
 
-	err = u.t.Commit(trans, nil, nil)
+	err = u.t.Commit(trans)
 	if err != nil {
 		u.s.Logger().Error("upgrade failed, could not close snapper transaction")
+		return err
+	}
+
+	err = u.t.Close(trans)
+	if err != nil {
+		u.s.Logger().Error("upgrade failed, could not set default snapper snapshot")
 		return err
 	}
 


### PR DESCRIPTION
This PR is two fold:

* Refactors transaction interface: the transaction commit method is divided into two: `Commit` and `Close`. Commits sets all required snapshots and its permissions, but it does not set the default snapshot neither runs any sort of customization hook. `Close` method essentially sets the default snapshot and clears/closes all resources associated with the transaction (e.g. mount points). None of the two encompasses any hook execution, hence this refactor is essentially driven to move out the customization logic from the transaction package and simply run it after `Commit`, but before `Close`.

* Adds a configuration script and overlay tree to the deployment. This is essentially to allow setting a custom configuration script and a custom directory tree to overlay over the dumped OS image. This allows extracting the contents of a tarball at OS root and execute a given script just after. These two steps happens between transaction `Commit` and transaction `Close`.
