### PR TITLE
Add go.{mod,sum} to GO_FILES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PKG?=./pkg/... ./internal/...
 
 GO_MODULE ?= $(shell go list -m)
 GO_FILES  = $(shell find ./ -name '*.go' -not -name '*_test.go')
+GO_FILES  += ./go.mod
+GO_FILES  += ./go.sum
 
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 GIT_COMMIT_SHORT?=$(shell git rev-parse --short HEAD)


### PR DESCRIPTION
This makes the binaries correctly depend on the go.mod and go.sum files.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
