### PR TITLE
Install bootloader

### DIFF
--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -129,6 +129,10 @@ func digestInstallSetup(s *sys.System, flags *cmd.InstallFlags) (*deployment.Dep
 		d.BootConfig.Bootloader = flags.Bootloader
 	}
 
+	if flags.KernelCmdline != "" {
+		d.BootConfig.KernelCmdline = flags.KernelCmdline
+	}
+
 	err := d.Sanitize(s)
 	if err != nil {
 		return nil, fmt.Errorf("inconsistent deployment setup found: %w", err)

--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -125,7 +125,7 @@ func digestInstallSetup(s *sys.System, flags *cmd.InstallFlags) (*deployment.Dep
 		}
 	}
 
-	if flags.Bootloader != "none" {
+	if flags.Bootloader != bootloader.BootNone {
 		d.BootConfig.Bootloader = flags.Bootloader
 	}
 

--- a/internal/cli/elemental-toolkit/cmd/install.go
+++ b/internal/cli/elemental-toolkit/cmd/install.go
@@ -30,6 +30,7 @@ type InstallFlags struct {
 	ConfigScript         string
 	Overlay              string
 	CreateBootEntry      bool
+	Bootloader           string
 }
 
 var InstallArgs InstallFlags
@@ -72,6 +73,13 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Name:        "create-boot-entry",
 				Usage:       "Create EFI boot entry",
 				Destination: &InstallArgs.CreateBootEntry,
+			},
+			&cli.StringFlag{
+				Name:        "bootloader",
+				Aliases:     []string{"b"},
+				Value:       "none",
+				Usage:       "Bundled bootloader to install to ESP",
+				Destination: &InstallArgs.Bootloader,
 			},
 		},
 	}

--- a/internal/cli/elemental-toolkit/cmd/install.go
+++ b/internal/cli/elemental-toolkit/cmd/install.go
@@ -78,7 +78,7 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 			&cli.StringFlag{
 				Name:        "bootloader",
 				Aliases:     []string{"b"},
-				Value:       "none",
+				Value:       "grub",
 				Usage:       "Bundled bootloader to install to ESP",
 				Destination: &InstallArgs.Bootloader,
 			},

--- a/internal/cli/elemental-toolkit/cmd/install.go
+++ b/internal/cli/elemental-toolkit/cmd/install.go
@@ -31,6 +31,7 @@ type InstallFlags struct {
 	Overlay              string
 	CreateBootEntry      bool
 	Bootloader           string
+	KernelCmdline        string
 }
 
 var InstallArgs InstallFlags
@@ -80,6 +81,12 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Value:       "none",
 				Usage:       "Bundled bootloader to install to ESP",
 				Destination: &InstallArgs.Bootloader,
+			},
+			&cli.StringFlag{
+				Name:        "cmdline",
+				Value:       "",
+				Usage:       "Kernel cmdline for installed system",
+				Destination: &InstallArgs.KernelCmdline,
 			},
 		},
 	}

--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -26,7 +26,7 @@ import (
 )
 
 type Bootloader interface {
-	Install(rootPath string, esp *deployment.Partition) error
+	Install(rootPath string, d *deployment.Deployment) error
 }
 
 const (
@@ -42,7 +42,7 @@ func NewNone(s *sys.System) *None {
 	return &None{s}
 }
 
-func (n *None) Install(_ string, _ *deployment.Partition) error {
+func (n *None) Install(_ string, _ *deployment.Deployment) error {
 	n.s.Logger().Info("Skipping bootloader installation")
 	return nil
 }

--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootloader
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+type Bootloader interface {
+	Install(rootPath string) error
+}
+
+const (
+	BootNone = "none"
+	BootGrub = "grub"
+)
+
+type None struct {
+	s *sys.System
+}
+
+func NewNone(s *sys.System) *None {
+	return &None{s}
+}
+
+func (n *None) Install(rootPath string) error {
+	n.s.Logger().Info("Skipping bootloader installation")
+	return nil
+}
+
+func New(name string, s *sys.System) (Bootloader, error) {
+	switch name {
+	case BootNone:
+		return NewNone(s), nil
+	case BootGrub:
+		return NewGrub(s), nil
+	}
+
+	return nil, fmt.Errorf("new bootloader '%s': %w", name, errors.ErrUnsupported)
+}

--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -21,11 +21,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/sys"
 )
 
 type Bootloader interface {
-	Install(rootPath string) error
+	Install(rootPath string, esp *deployment.Partition) error
 }
 
 const (
@@ -41,7 +42,7 @@ func NewNone(s *sys.System) *None {
 	return &None{s}
 }
 
-func (n *None) Install(rootPath string) error {
+func (n *None) Install(_ string, _ *deployment.Partition) error {
 	n.s.Logger().Info("Skipping bootloader installation")
 	return nil
 }

--- a/pkg/bootloader/bootloader_test.go
+++ b/pkg/bootloader/bootloader_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/suse/elemental/v3/pkg/bootloader"
 	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/sys"
-	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
-	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
 func TestBootloaderSuite(t *testing.T) {
@@ -37,23 +35,14 @@ func TestBootloaderSuite(t *testing.T) {
 }
 
 var _ = Describe("Bootloader tests", Label("bootloader", "grub", "none"), func() {
-	var tfs vfs.FS
 	var s *sys.System
-	var cleanup func()
 	BeforeEach(func() {
 		var err error
-		tfs, cleanup, err = sysmock.TestFS(nil)
 		Expect(err).NotTo(HaveOccurred())
 		s, err = sys.NewSystem(
-			sys.WithFS(tfs), sys.WithLogger(log.New(log.WithDiscardAll())),
+			sys.WithLogger(log.New(log.WithDiscardAll())),
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(vfs.MkdirAll(tfs, "/tmp/elemental_unpack", vfs.DirPerm)).To(Succeed())
-		Expect(tfs.WriteFile("/tmp/elemental_unpack/datafile", []byte("data"), vfs.FilePerm)).To(Succeed())
-		Expect(vfs.MkdirAll(tfs, "/target/dir", vfs.DirPerm)).To(Succeed())
-	})
-	AfterEach(func() {
-		cleanup()
 	})
 	It("Successsfully creates a new bootloader", func() {
 		for _, name := range []string{"none", "grub"} {

--- a/pkg/bootloader/bootloader_test.go
+++ b/pkg/bootloader/bootloader_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootloader_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/bootloader"
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+func TestBootloaderSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bootloader test suite")
+}
+
+var _ = Describe("Bootloader tests", Label("bootloader", "grub", "none"), func() {
+	var tfs vfs.FS
+	var s *sys.System
+	var cleanup func()
+	BeforeEach(func() {
+		var err error
+		tfs, cleanup, err = sysmock.TestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs), sys.WithLogger(log.New(log.WithDiscardAll())),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vfs.MkdirAll(tfs, "/tmp/elemental_unpack", vfs.DirPerm)).To(Succeed())
+		Expect(tfs.WriteFile("/tmp/elemental_unpack/datafile", []byte("data"), vfs.FilePerm)).To(Succeed())
+		Expect(vfs.MkdirAll(tfs, "/target/dir", vfs.DirPerm)).To(Succeed())
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	It("Successsfully creates a new bootloader", func() {
+		for _, name := range []string{"none", "grub"} {
+			b, err := bootloader.New(name, s)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b).NotTo(BeNil())
+		}
+	})
+	It("New() returns unsupported error for unknown bootloader", func() {
+		b, err := bootloader.New("bogus", s)
+		Expect(b).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, errors.ErrUnsupported)).To(BeTrue(), err.Error())
+	})
+})

--- a/pkg/bootloader/grub.go
+++ b/pkg/bootloader/grub.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootloader
+
+import (
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+type Grub struct {
+	s *sys.System
+}
+
+func NewGrub(s *sys.System) *Grub {
+	return &Grub{s}
+}
+
+// Install installs the bootloader to the specified root.
+func (g *Grub) Install(rootPath string) error {
+	g.s.Logger().Info("Installing GRUB bootloader")
+
+	// InstallElementalEFI()
+	// CopyKernelInitrd()
+	// UpdateBootEntries()
+	return nil
+}

--- a/pkg/bootloader/grub.go
+++ b/pkg/bootloader/grub.go
@@ -191,7 +191,10 @@ func (g *Grub) installKernelInitrd(rootPath string, esp *deployment.Partition) (
 
 	displayName, ok := osVars["PRETTY_NAME"]
 	if !ok {
-		displayName = osVars["NAME"]
+		displayName, ok = osVars["VARIANT"]
+		if !ok {
+			displayName = osVars["NAME"]
+		}
 	}
 
 	return grubBootEntry{

--- a/pkg/bootloader/grub.go
+++ b/pkg/bootloader/grub.go
@@ -180,7 +180,7 @@ func (g *Grub) installKernelInitrd(rootPath string, esp *deployment.Partition) (
 
 	expectedInitrdPath := filepath.Join(filepath.Dir(kernel), Initrd)
 	if exists, _ := vfs.Exists(g.s.FS(), expectedInitrdPath); !exists {
-		return grubBootEntry{}, fmt.Errorf("Initrd not found")
+		return grubBootEntry{}, fmt.Errorf("initrd not found")
 	}
 
 	err = vfs.CopyFile(g.s.FS(), expectedInitrdPath, targetDir)

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootloader_test
+
+import (
+	"errors"
+	"io/fs"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/bootloader"
+	"github.com/suse/elemental/v3/pkg/deployment"
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
+	var tfs vfs.FS
+	var s *sys.System
+	var cleanup func()
+	var grub *bootloader.Grub
+	var esp *deployment.Partition
+	BeforeEach(func() {
+		var err error
+		tfs, cleanup, err = sysmock.TestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs), sys.WithLogger(log.New(log.WithDiscardAll())),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		esp = &deployment.Partition{
+			Role:       deployment.EFI,
+			MountPoint: "/boot/efi",
+		}
+
+		grub = bootloader.NewGrub(s)
+
+		Expect(vfs.MkdirAll(tfs, "/target/dir/usr/share/efi/x86_64", vfs.DirPerm)).To(Succeed())
+		Expect(vfs.MkdirAll(tfs, "/target/dir/usr/share/efi/aarch64", vfs.DirPerm)).To(Succeed())
+		Expect(vfs.MkdirAll(tfs, "/target/dir/usr/share/grub2/x86_64-efi", vfs.DirPerm)).To(Succeed())
+		Expect(vfs.MkdirAll(tfs, "/target/dir/usr/share/grub2/arm64-efi", vfs.DirPerm)).To(Succeed())
+
+		Expect(tfs.WriteFile("/target/dir/usr/share/efi/x86_64/shim-opensuse.efi", []byte("x86_64 shim-opensuse.efi"), vfs.FilePerm)).To(Succeed())
+		Expect(tfs.WriteFile("/target/dir/usr/share/efi/x86_64/MokManager.efi", []byte("x86_64 MokManager.efi"), vfs.FilePerm)).To(Succeed())
+		Expect(tfs.WriteFile("/target/dir/usr/share/grub2/x86_64-efi/grub.efi", []byte("x86_64 grub.efi"), vfs.FilePerm)).To(Succeed())
+
+		Expect(tfs.Symlink("/target/dir/usr/share/efi/x86_64/shim-opensuse.efi", "/target/dir/usr/share/efi/x86_64/shim.efi")).To(Succeed())
+		Expect(tfs.Symlink("/target/dir/usr/share/grub2/x86_64-efi/grub.efi", "/target/dir/usr/share/efi/x86_64/grub.efi")).To(Succeed())
+
+		Expect(vfs.MkdirAll(tfs, "/target/dir", vfs.DirPerm)).To(Succeed())
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	It("Fails installing bootloader to System partition", func() {
+		sysPart := &deployment.Partition{
+			Role: deployment.System,
+		}
+		err := grub.Install("/target/dir", sysPart)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, errors.ErrUnsupported)).To(BeTrue())
+	})
+	It("Copies EFI applications to ESP", func() {
+		err := grub.Install("/target/dir", esp)
+		Expect(err).ToNot(HaveOccurred())
+
+		// shim should not be a symlink
+		file, err := tfs.Lstat("/target/dir/boot/efi/EFI/ELEMENTAL/shim.efi")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(file.Mode() & fs.ModeSymlink).To(Equal(fs.FileMode(0)))
+
+		// Shim, MokManager and grub.efi should exist.
+		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/shim.efi")).To(BeTrue())
+		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/MokManager.efi")).To(BeTrue())
+		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/grub.efi")).To(BeTrue())
+	})
+})

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -73,6 +73,10 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 				_, err := tfs.Create(filepath.Join("/target/dir", initrdPath))
 				Expect(err).NotTo(HaveOccurred())
 				return nil, nil
+			case "grub2-editenv":
+				_, err := tfs.Create(args[0])
+				Expect(err).NotTo(HaveOccurred())
+				return nil, nil
 			}
 
 			return nil, fmt.Errorf("command '%s', %w", command, errors.ErrUnsupported)
@@ -100,7 +104,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 
 		// Setup /etc/os-release file with openSUSE tumbleweed ID
 		Expect(vfs.MkdirAll(tfs, "/target/dir/etc", vfs.DirPerm)).To(Succeed())
-		Expect(tfs.WriteFile("/target/dir/etc/os-release", []byte("ID=opensuse-tumbleweed"), vfs.FilePerm)).To(Succeed())
+		Expect(tfs.WriteFile("/target/dir/etc/os-release", []byte("ID=opensuse-tumbleweed\nNAME=openSUSE Tumbleweed"), vfs.FilePerm)).To(Succeed())
 		// Setup kernel dirs
 		Expect(vfs.MkdirAll(tfs, "/target/dir/usr/lib/modules/6.14.4-1-default", vfs.DirPerm)).To(Succeed())
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/vmlinuz", []byte("6.14.4-1-default vmlinux.xz"), vfs.FilePerm)).To(Succeed())
@@ -130,8 +134,12 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/MokManager.efi")).To(BeTrue())
 		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/grub.efi")).To(BeTrue())
 
-		// Kernel and initrd exists
+		// Kernel and initrd exist
 		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/opensuse-tumbleweed/6.14.4-1-default/vmlinuz")).To(BeTrue())
 		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/opensuse-tumbleweed/6.14.4-1-default/initrd")).To(BeTrue())
+
+		// Grub env and loader entries files exist
+		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/grubenv")).To(BeTrue())
+		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/loader/entries/active")).To(BeTrue())
 	})
 })

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -77,6 +77,8 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 				_, err := tfs.Create(args[0])
 				Expect(err).NotTo(HaveOccurred())
 				return nil, nil
+			case "rsync":
+				return nil, nil
 			}
 
 			return nil, fmt.Errorf("command '%s', %w", command, errors.ErrUnsupported)

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -20,7 +20,6 @@ package bootloader_test
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -139,13 +138,8 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		err := grub.Install("/target/dir", d)
 		Expect(err).ToNot(HaveOccurred())
 
-		// shim must not be a symlink
-		file, err := tfs.Lstat("/target/dir/boot/efi/EFI/ELEMENTAL/shim.efi")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(file.Mode() & fs.ModeSymlink).To(Equal(fs.FileMode(0)))
-
 		// Shim, MokManager and grub.efi should exist.
-		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/shim.efi")).To(BeTrue())
+		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/bootx64.efi")).To(BeTrue())
 		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/MokManager.efi")).To(BeTrue())
 		Expect(vfs.Exists(tfs, "/target/dir/boot/efi/EFI/ELEMENTAL/grub.efi")).To(BeTrue())
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -192,7 +192,8 @@ type Disk struct {
 }
 
 type BootConfig struct {
-	Bootloader string `json:"name"`
+	Bootloader    string `json:"name"`
+	KernelCmdline string `json:"kernelCmdline"`
 }
 
 // MarshalJSON on disks omits the device name as this is a runtime information
@@ -373,7 +374,8 @@ func DefaultDeployment() *Deployment {
 		}},
 		Firmware: &FirmwareConfig{},
 		BootConfig: &BootConfig{
-			Bootloader: "none",
+			Bootloader:    "none",
+			KernelCmdline: fmt.Sprintf("root=LABEL=%s rw", SystemLabel),
 		},
 	}
 }

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -191,6 +191,10 @@ type Disk struct {
 	StartSector uint       `json:"startSector,omitempty"`
 }
 
+type BootConfig struct {
+	Bootloader string `json:"name"`
+}
+
 // MarshalJSON on disks omits the device name as this is a runtime information
 // which might not be consistent across reboots, there is no need to store it.
 func (d Disk) MarshalJSON() ([]byte, error) {
@@ -205,9 +209,10 @@ type FirmwareConfig struct {
 }
 
 type Deployment struct {
-	SourceOS *ImageSource    `json:"sourceOS"`
-	Disks    []*Disk         `json:"disks"`
-	Firmware *FirmwareConfig `json:"firmware"`
+	SourceOS   *ImageSource    `json:"sourceOS"`
+	Disks      []*Disk         `json:"disks"`
+	Firmware   *FirmwareConfig `json:"firmware"`
+	BootConfig *BootConfig     `json:"bootloader"`
 	// Consider adding a systemd-sysext list here
 	// All of them would extracted in the RO context, so only
 	// additions to the RWVolumes would succeed.
@@ -354,6 +359,9 @@ func DefaultDeployment() *Deployment {
 			},
 		}},
 		Firmware: &FirmwareConfig{},
+		BootConfig: &BootConfig{
+			Bootloader: "none",
+		},
 	}
 }
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -268,6 +268,19 @@ func (d Deployment) GetSystemDisk() *Disk {
 	return nil
 }
 
+// GetEfiSystemPartition gets the data of the system partition.
+// returns nil if not found
+func (d Deployment) GetEfiSystemPartition() *Partition {
+	for _, disk := range d.Disks {
+		for _, part := range disk.Partitions {
+			if part.Role == EFI {
+				return part
+			}
+		}
+	}
+	return nil
+}
+
 // Sanitize checks the consistency of the current Disk structure
 func (d *Deployment) Sanitize(s *sys.System) error {
 	for _, sanitize := range sanitizers {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -128,8 +128,6 @@ func (i Installer) Install(d *deployment.Deployment) (err error) {
 		return err
 	}
 
-	err = d.WriteDeploymentFile(i.s, trans.Path)
-
 	if d.OverlayTree != nil && !d.OverlayTree.IsEmpty() {
 		unpacker, err := unpack.NewUnpacker(i.s, d.OverlayTree)
 		if err != nil {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -122,7 +122,7 @@ func (i Installer) Install(d *deployment.Deployment) (err error) {
 		return err
 	}
 
-	err = i.b.Install(trans.Path, d.GetEfiSystemPartition())
+	err = i.b.Install(trans.Path, d)
 	if err != nil {
 		i.s.Logger().Error("installation failed, could not install bootloader: %s", err.Error())
 		return err

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -122,12 +122,6 @@ func (i Installer) Install(d *deployment.Deployment) (err error) {
 		return err
 	}
 
-	err = i.b.Install(trans.Path, d)
-	if err != nil {
-		i.s.Logger().Error("installation failed, could not install bootloader: %s", err.Error())
-		return err
-	}
-
 	if d.OverlayTree != nil && !d.OverlayTree.IsEmpty() {
 		unpacker, err := unpack.NewUnpacker(i.s, d.OverlayTree)
 		if err != nil {
@@ -147,6 +141,12 @@ func (i Installer) Install(d *deployment.Deployment) (err error) {
 			i.s.Logger().Error("installation failed, configuration hook error")
 			return err
 		}
+	}
+
+	err = i.b.Install(trans.Path, d)
+	if err != nil {
+		i.s.Logger().Error("installation failed, could not install bootloader: %s", err.Error())
+		return err
 	}
 
 	err = i.t.Commit(trans)

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -122,7 +122,7 @@ func (i Installer) Install(d *deployment.Deployment) (err error) {
 		return err
 	}
 
-	err = i.b.Install(trans.Path)
+	err = i.b.Install(trans.Path, d.GetEfiSystemPartition())
 	if err != nil {
 		i.s.Logger().Error("installation failed, could not install bootloader: %s", err.Error())
 		return err

--- a/pkg/transaction/snapper.go
+++ b/pkg/transaction/snapper.go
@@ -220,8 +220,6 @@ func (sn snapperT) Commit(trans *Transaction) (err error) {
 		return err
 	}
 
-	// TODO bootloader installation/upgrade could be handled here: efivars, shim image install, esp partition sync
-
 	// We are ignoring these errors as the default snapshot is already changed
 	// so rebooting is expected to succeed to the new system already
 	iErr := sn.snap.Cleanup(sn.rootDir, sn.maxSnapshots)


### PR DESCRIPTION
This PR adds the bootloader package which is responsible for installing the bootloader.

The 'none' bootloader does nothing and leaves the bootloader implementation to the OCI image. (anything in /boot/efi will be copied to the ESP and used as a bootloader).

The default 'grub' bootloader install grub and tries to emulate the BLS specification by placing grub-env files in `$ESP/grubenv` and `$ESP/loader/entries`. 
It will also install shim/mokmanager/grub.efi into `/EFI/ELEMENTAL` and the fallback `/EFI/BOOT` directories and sync `/usr/share/grub2` to `$ESP/grub2`.
After all that it will copy the kernel and generate an initrd in `$ESP/<os-variant>/<kernel-version>/`