### PR TITLE
Refactor elemental install command line flags

### DIFF
--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -72,13 +72,13 @@ func Install(ctx *cli.Context) error { //nolint:dupl
 
 func digestInstallSetup(s *sys.System, flags *cmd.InstallFlags) (*deployment.Deployment, error) {
 	d := deployment.DefaultDeployment()
-	if flags.ConfigFile != "" {
-		if ok, _ := vfs.Exists(s.FS(), flags.ConfigFile); !ok {
-			return nil, fmt.Errorf("config file '%s' not found", flags.ConfigFile)
+	if flags.Description != "" {
+		if ok, _ := vfs.Exists(s.FS(), flags.Description); !ok {
+			return nil, fmt.Errorf("config file '%s' not found", flags.Description)
 		}
-		data, err := s.FS().ReadFile(flags.ConfigFile)
+		data, err := s.FS().ReadFile(flags.Description)
 		if err != nil {
-			return nil, fmt.Errorf("could not read config file '%s': %w", flags.ConfigFile, err)
+			return nil, fmt.Errorf("could not read config file '%s': %w", flags.Description, err)
 		}
 		err = yaml.Unmarshal(data, d)
 		if err != nil {
@@ -95,6 +95,18 @@ func digestInstallSetup(s *sys.System, flags *cmd.InstallFlags) (*deployment.Dep
 			return nil, fmt.Errorf("failed parsing OS source URI ('%s'): %w", flags.OperatingSystemImage, err)
 		}
 		d.SourceOS = srcOS
+	}
+
+	if flags.Overlay != "" {
+		overlay, err := deployment.NewSrcFromURI(flags.Overlay)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing overlay source URI ('%s'): %w", flags.Overlay, err)
+		}
+		d.OverlayTree = overlay
+	}
+
+	if flags.ConfigScript != "" {
+		d.CfgScript = flags.ConfigScript
 	}
 
 	err := d.Sanitize(s)

--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -78,7 +78,7 @@ func digestInstallSetup(s *sys.System, flags *cmd.InstallFlags) (*deployment.Dep
 		}
 		data, err := s.FS().ReadFile(flags.Description)
 		if err != nil {
-			return nil, fmt.Errorf("could not read config file '%s': %w", flags.Description, err)
+			return nil, fmt.Errorf("could not read description file '%s': %w", flags.Description, err)
 		}
 		err = yaml.Unmarshal(data, d)
 		if err != nil {

--- a/internal/cli/elemental-toolkit/action/install_test.go
+++ b/internal/cli/elemental-toolkit/action/install_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Install action", Label("install"), func() {
 	It("fails to start installing if the configuration file can't be read", func() {
 		cmd.InstallArgs.Target = "/dev/device"
 		cmd.InstallArgs.OperatingSystemImage = "my.registry.org/my/image:test"
-		cmd.InstallArgs.ConfigFile = "doesntexist"
+		cmd.InstallArgs.Description = "doesntexist"
 		err = action.Install(ctx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("config file 'doesntexist' not found"))
@@ -103,7 +103,7 @@ var _ = Describe("Install action", Label("install"), func() {
 	It("fails if the setup is inconsistent", func() {
 		cmd.InstallArgs.Target = "/dev/device"
 		cmd.InstallArgs.OperatingSystemImage = "my.registry.org/my/image:test"
-		cmd.InstallArgs.ConfigFile = "/configDir/bad_config.yaml"
+		cmd.InstallArgs.Description = "/configDir/bad_config.yaml"
 		err = action.Install(ctx)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("inconsistent deployment"))

--- a/internal/cli/elemental-toolkit/cmd/install.go
+++ b/internal/cli/elemental-toolkit/cmd/install.go
@@ -26,7 +26,9 @@ import (
 type InstallFlags struct {
 	OperatingSystemImage string
 	Target               string
-	ConfigFile           string
+	Description          string
+	ConfigScript         string
+	Overlay              string
 }
 
 var InstallArgs InstallFlags
@@ -40,13 +42,24 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "config",
-				Usage:       "Config file to read installation details",
-				Destination: &InstallArgs.ConfigFile,
+				Usage:       "Configuration script path to execute after committing os-image",
+				Destination: &InstallArgs.ConfigScript,
+			},
+			&cli.StringFlag{
+				Name:        "description",
+				Aliases:     []string{"d"},
+				Usage:       "Description file to read installation details",
+				Destination: &InstallArgs.Description,
 			},
 			&cli.StringFlag{
 				Name:        "os-image",
-				Usage:       "OCI image containing the operating system",
+				Usage:       "URI to the image containing the operating system",
 				Destination: &InstallArgs.OperatingSystemImage,
+			},
+			&cli.StringFlag{
+				Name:        "overlay",
+				Usage:       "URI to the content overlaid over the OS image",
+				Destination: &InstallArgs.Overlay,
 			},
 			&cli.StringFlag{
 				Name:        "target",


### PR DESCRIPTION
This commit introduces the overlay and description flags. The overlay flag is to point to a source to overlay on top of the deployed OS image (e.g. a tarball containing some extra utilities that are not part of the OS image). Note the overlayed content is already included once the OS snapshot is defined as read-only, hence it is only possible to overlay on top of RW portions of the system.

The description flag is what the former config flag used to be. It is used to set the local path of the deployment description yaml file.

Finally the former config flag is repurposed to be set the local path of the configuration script that is called in chroot during the transaction. It is executed just after extracting the overlay content, if any. So the script is only expected to modify RW parts of the deployment.