### PR TITLE
Introduce release manifest resolution logic

### DIFF
--- a/internal/manifest/extractor/extractor.go
+++ b/internal/manifest/extractor/extractor.go
@@ -1,0 +1,221 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extractor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/unpack"
+)
+
+// Default glob pattern used to search for a release manifest in an OCI image
+const globPattern = "release_manifest*.yaml"
+
+type OCIUnpacker interface {
+	// Unpack unpacks the file system of a given OCI image to the specified destination
+	// and returns its digest
+	Unpack(ctx context.Context, uri, dest string) (digest string, err error)
+}
+
+type ociUnpacker struct {
+	system *sys.System
+}
+
+func (o *ociUnpacker) Unpack(ctx context.Context, uri, dest string) (digest string, err error) {
+	remoteUnpacker := unpack.NewOCIUnpacker(o.system, uri)
+	return remoteUnpacker.Unpack(ctx, dest)
+}
+
+type OCIReleaseManifestExtractor struct {
+	// Location to search for the release manifest;
+	// both globs (e.g. "/foo/release_manifest*.yaml")
+	// and absolute paths (e.g. "/foo/release_manifest.yaml")
+	// are supported.
+	//
+	// Defaults to '/release_manifest*.yaml' and '/etc/release-manifest/release_manifest*.yaml'.
+	searchPath []string
+	// Location where all extracted release manifests will be stored.
+	// Each manifest will be stored in a separate directory within
+	// this root store path.
+	//
+	// Defaults to the OS temporary directory.
+	store    string
+	unpacker OCIUnpacker
+	ctx      context.Context
+}
+
+type Opts func(o *OCIReleaseManifestExtractor)
+
+func WithOCIUnpacker(u OCIUnpacker) Opts {
+	return func(r *OCIReleaseManifestExtractor) {
+		r.unpacker = u
+	}
+}
+
+func WithStore(store string) Opts {
+	return func(r *OCIReleaseManifestExtractor) {
+		r.store = store
+	}
+}
+
+func WithSearchPaths(globs []string) Opts {
+	return func(r *OCIReleaseManifestExtractor) {
+		r.searchPath = globs
+	}
+}
+
+func WithContext(ctx context.Context) Opts {
+	return func(r *OCIReleaseManifestExtractor) {
+		r.ctx = ctx
+	}
+}
+
+func New(opts ...Opts) (*OCIReleaseManifestExtractor, error) {
+	extr := &OCIReleaseManifestExtractor{
+		searchPath: []string{
+			globPattern,
+			filepath.Join("etc", "release-manifest", globPattern),
+		},
+		store: filepath.Join(os.TempDir(), "release-manifests"),
+		ctx:   context.Background(),
+	}
+
+	for _, o := range opts {
+		o(extr)
+	}
+
+	if extr.unpacker == nil {
+		s, err := sys.NewSystem()
+		if err != nil {
+			return nil, fmt.Errorf("setting up default system: %w", err)
+		}
+
+		extr.unpacker = &ociUnpacker{
+			system: s,
+		}
+	}
+
+	return extr, nil
+}
+
+// ExtractFrom locates and extracts a release manifest file from the given OCI image.
+// The first located release manifest will be extracted to the configured store directory
+// and its path will be returned, or an error if the manifest was not found.
+// The underlying OCI image is not retained.
+func (o *OCIReleaseManifestExtractor) ExtractFrom(uri string) (path string, err error) {
+	unpackDir, err := os.MkdirTemp("", "release-manifest-unpack-")
+	if err != nil {
+		return "", fmt.Errorf("creating oci image unpack directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(unpackDir)
+	}()
+
+	digest, err := o.unpacker.Unpack(o.ctx, uri, unpackDir)
+	if err != nil {
+		return "", fmt.Errorf("unpacking oci image: %w", err)
+	}
+
+	manifestInOCI, err := o.locateManifest(unpackDir)
+	if err != nil {
+		return "", fmt.Errorf("locating release manifest at unpacked OCI filesystem: %w", err)
+	}
+
+	manifestStorePath, err := o.generateManifestStorePath(digest)
+	if err != nil {
+		return "", fmt.Errorf("generating manifest store based on digest: %w", err)
+	}
+
+	if err := os.MkdirAll(manifestStorePath, 0700); err != nil {
+		return "", fmt.Errorf("creating manifest store directory '%s': %w", manifestStorePath, err)
+	}
+
+	manifestInStore := filepath.Join(manifestStorePath, filepath.Base(manifestInOCI))
+	if err := copyFile(manifestInOCI, manifestInStore); err != nil {
+		return "", fmt.Errorf("copying release manifest to store: %w", err)
+	}
+
+	return manifestInStore, nil
+}
+
+func (o *OCIReleaseManifestExtractor) locateManifest(dest string) (path string, err error) {
+	for _, globPath := range o.searchPath {
+		matches, globErr := filepath.Glob(filepath.Join(dest, globPath))
+		if globErr != nil {
+			return "", fmt.Errorf("matching files with pattern '%s': %w", globPath, err)
+		}
+
+		size := len(matches)
+		switch {
+		case size == 1:
+			return matches[0], nil
+		case size > 1:
+			return "", fmt.Errorf("expected a single release manifest at '%s', got '%v'", filepath.Dir(globPath), size)
+		}
+	}
+
+	return "", fmt.Errorf("release manifest not found at paths: %v", o.searchPath)
+}
+
+func (o *OCIReleaseManifestExtractor) generateManifestStorePath(digest string) (string, error) {
+	const maxHashLen = 64
+	digestSplit := strings.Split(digest, ":")
+	if len(digestSplit) != 2 || digestSplit[0] == "" || digestSplit[1] == "" {
+		return "", fmt.Errorf("invalid digest format '%s', expected '<algorithm>:<hash>'", digest)
+	}
+
+	hash := digestSplit[1]
+	if len(hash) > maxHashLen {
+		hash = hash[:maxHashLen]
+	}
+	return filepath.Join(o.store, hash), nil
+}
+
+func copyFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening file at '%s': %w", src, err)
+	}
+	defer func() {
+		_ = in.Close()
+	}()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("creating file at '%s': %w", dest, err)
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copying from '%s' to '%s': %w", src, dest, err)
+	}
+
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dest, info.Mode())
+}

--- a/pkg/manifest/api/core/manifest.go
+++ b/pkg/manifest/api/core/manifest.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/suse/elemental/v3/pkg/manifest/api"
+	"sigs.k8s.io/yaml"
+)
+
+type ReleaseManifest struct {
+	MetaData   *api.MetaData `yaml:"metadata"`
+	Components *Components   `yaml:"components"`
+}
+
+type Components struct {
+	OperatingSystem *OperatingSystem `yaml:"operatingSystem"`
+	Kubernetes      *Kubernetes      `yaml:"kubernetes"`
+	Helm            *api.Helm        `yaml:"helm,omitempty"`
+}
+
+type OperatingSystem struct {
+	Version string `yaml:"version"`
+	Image   string `yaml:"image"`
+}
+
+type Kubernetes struct {
+	RKE2 *RKE2 `yaml:"rke2"`
+}
+
+type RKE2 struct {
+	Version string `yaml:"version"`
+	Image   string `yaml:"image"`
+}
+
+func Parse(data []byte) (*ReleaseManifest, error) {
+	rm := &ReleaseManifest{}
+	if err := yaml.UnmarshalStrict(data, rm); err != nil {
+		return nil, fmt.Errorf("unmarshaling 'core' release manifest: %w", err)
+	}
+
+	return rm, nil
+}

--- a/pkg/manifest/api/product/manifest.go
+++ b/pkg/manifest/api/product/manifest.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package product
+
+import (
+	"fmt"
+
+	"github.com/suse/elemental/v3/pkg/manifest/api"
+	"sigs.k8s.io/yaml"
+)
+
+type ReleaseManifest struct {
+	MetaData     *api.MetaData `yaml:"metadata,omitempty"`
+	CorePlatform *CorePlatform `yaml:"corePlatform"`
+	Components   *Components   `yaml:"components,omitempty"`
+}
+
+type CorePlatform struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type Components struct {
+	Helm *api.Helm `yaml:"helm,omitempty"`
+}
+
+func Parse(data []byte) (*ReleaseManifest, error) {
+	rm := &ReleaseManifest{}
+	if err := yaml.UnmarshalStrict(data, rm); err != nil {
+		return nil, fmt.Errorf("unmarshaling 'product' release manifest: %w", err)
+	}
+
+	if rm.CorePlatform == nil {
+		return nil, fmt.Errorf("missing 'corePlatform' field")
+	}
+
+	return rm, nil
+}

--- a/pkg/manifest/api/shared.go
+++ b/pkg/manifest/api/shared.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+type MetaData struct {
+	Name             string   `yaml:"name"`
+	Version          string   `yaml:"version"`
+	UpgradePathsFrom []string `yaml:"upgradePathsFrom,omitempty"`
+	CreationDate     string   `yaml:"creationDate,omitempty"`
+}
+
+type Helm struct {
+	Charts     []HelmChart  `yaml:"charts"`
+	Repository []Repository `yaml:"repository"`
+}
+
+type HelmChart struct {
+	Name       string       `yaml:"name,omitempty"`
+	Chart      string       `yaml:"chart"`
+	Version    string       `yaml:"version"`
+	Namespace  string       `yaml:"namespace,omitempty"`
+	Repository string       `yaml:"repository"`
+	Values     string       `yaml:"values,omitempty"`
+	DependsOn  []string     `yaml:"dependsOn,omitempty"`
+	Images     []ChartImage `yaml:"images,omitempty"`
+}
+
+type ChartImage struct {
+	Name  string `yaml:"name"`
+	Image string `yaml:"image"`
+}
+
+type Repository struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}

--- a/pkg/manifest/resolver/resolver.go
+++ b/pkg/manifest/resolver/resolver.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/suse/elemental/v3/pkg/manifest/api/core"
+	"github.com/suse/elemental/v3/pkg/manifest/api/product"
+	"github.com/suse/elemental/v3/pkg/manifest/source"
+)
+
+type ResolvedManifest struct {
+	// Release manifest for the core platform
+	CorePlatform *core.ReleaseManifest
+	// Product release manifest that extends the core platform
+	ProductExtension *product.ReleaseManifest
+}
+
+type SourceReader interface {
+	// Read reads a release manifest from the given source and returns the file contents
+	Read(m *source.ReleaseManifestSource) ([]byte, error)
+}
+
+type Resolver struct {
+	sourceReader           SourceReader
+	coreReleaseManifestRef string
+}
+
+func New(reader SourceReader, coreReleaseManifestRef string) *Resolver {
+	return &Resolver{
+		sourceReader:           reader,
+		coreReleaseManifestRef: coreReleaseManifestRef,
+	}
+}
+
+// Resolve resolves a release manifest at a given uri to its
+// underlying component parts (i.e. product and core platform)
+func (r *Resolver) Resolve(uri string) (*ResolvedManifest, error) {
+	resolved := &ResolvedManifest{}
+	if err := r.resolveRecursive(uri, resolved); err != nil {
+		return nil, err
+	}
+
+	return resolved, nil
+}
+
+func (r *Resolver) resolveRecursive(uri string, rm *ResolvedManifest) error {
+	rmSrc, err := source.ParseFromURI(uri)
+	if err != nil {
+		return fmt.Errorf("unable to convert uri '%s' to manifest source: %w", uri, err)
+	}
+
+	data, err := r.sourceReader.Read(rmSrc)
+	if err != nil {
+		return fmt.Errorf("reading manifest from source '%s': %w", rmSrc.URI(), err)
+	}
+
+	if len(data) == 0 {
+		return fmt.Errorf("empty file passed as release manifest: '%s'", rmSrc.URI())
+	}
+
+	productManifest, prodErr := product.Parse(data)
+	if prodErr != nil {
+		coreManifest, coreErr := core.Parse(data)
+		if coreErr != nil {
+			combinedErr := errors.Join(prodErr, coreErr)
+			return fmt.Errorf("unable to parse '%s' as a valid release manifest: %w", rmSrc.URI(), combinedErr)
+		}
+
+		rm.CorePlatform = coreManifest
+		return nil
+	}
+	rm.ProductExtension = productManifest
+
+	coreReleseManifestOCI := fmt.Sprintf("%s://%s:%s", source.OCI, r.coreReleaseManifestRef, rm.ProductExtension.CorePlatform.Version)
+	return r.resolveRecursive(coreReleseManifestOCI, rm)
+}

--- a/pkg/manifest/source/reader.go
+++ b/pkg/manifest/source/reader.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"fmt"
+	"os"
+)
+
+type OCIFileExtractor interface {
+	// ExtractFrom extracts a file from a given OCI image and
+	// returns the path to the extracted file.
+	ExtractFrom(uri string) (path string, err error)
+}
+
+type ReleaseManifestReader struct {
+	rmExtractor OCIFileExtractor
+}
+
+func NewReader(ociFileExtractor OCIFileExtractor) *ReleaseManifestReader {
+	return &ReleaseManifestReader{rmExtractor: ociFileExtractor}
+}
+
+func (r *ReleaseManifestReader) Read(src *ReleaseManifestSource) ([]byte, error) {
+	switch src.Type() {
+	case File:
+		return r.readLocal(src.URI())
+	case OCI:
+		filepath, err := r.rmExtractor.ExtractFrom(src.URI())
+		if err != nil {
+			return nil, fmt.Errorf("extracting file from OCI image '%s': %w", src.URI(), err)
+		}
+		return r.readLocal(filepath)
+	default:
+		return nil, fmt.Errorf("unsupported source type: '%s'", src.Type())
+	}
+}
+
+func (r *ReleaseManifestReader) readLocal(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/pkg/manifest/source/source.go
+++ b/pkg/manifest/source/source.go
@@ -1,0 +1,104 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+type ReleaseManifestSourceType int
+
+const (
+	File ReleaseManifestSourceType = iota + 1
+	OCI
+)
+
+func (r ReleaseManifestSourceType) String() string {
+	switch r {
+	case File:
+		return "file"
+	case OCI:
+		return "oci"
+	default:
+		return "unknown"
+	}
+}
+
+func ParseType(str string) (ReleaseManifestSourceType, error) {
+	switch str {
+	case File.String():
+		return File, nil
+	case OCI.String():
+		return OCI, nil
+	default:
+		return ReleaseManifestSourceType(0), fmt.Errorf("manifest source type '%s' is not supported. Supported source types: '%s', '%s'", str, File, OCI)
+	}
+}
+
+type ReleaseManifestSource struct {
+	uri     string
+	srcType ReleaseManifestSourceType
+}
+
+// ParseFromURI validates the given URI and parses it to a release manfiest source
+func ParseFromURI(uri string) (*ReleaseManifestSource, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("parsing manifest source uri: %w", err)
+	}
+
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("missing scheme in source uri: '%s'", uri)
+	}
+
+	srcType, err := ParseType(u.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("parsing manifest source type: %w", err)
+	}
+
+	source := u.Opaque
+	if source == "" {
+		source = filepath.Join(u.Host, u.Path)
+	}
+
+	switch srcType {
+	case File:
+		source = filepath.Clean(source)
+	case OCI:
+		if _, err := name.ParseReference(source); err != nil {
+			return nil, fmt.Errorf("invalid OCI image reference: %w", err)
+		}
+	}
+
+	return &ReleaseManifestSource{
+		uri:     source,
+		srcType: srcType,
+	}, nil
+}
+
+func (r *ReleaseManifestSource) URI() string {
+	return r.uri
+}
+
+func (r *ReleaseManifestSource) Type() ReleaseManifestSourceType {
+	return r.srcType
+}


### PR DESCRIPTION
This commit introduces the release manifest resolution logic that will be used by the `elemental` tool during the `elemental build` command. To reduce the size of this PR, unit tests will come in a separate PR once this one has been reviewed and merged.

Review entry point - [resolver.go](https://github.com/SUSE/elemental/pull/89/files#diff-97772d0b7c29df5038c7d3233a80ecad7b5827ca88c4ac2da678cd9e3d5dc753)

Changes from the `Release Manifest Design Doc`:

- `basePlatform` configuration in `product` manifest was renamed to `corePlatform` for consistency.

Key points of the release manifest resolution logic:

1. Release manifest is parsed to a `ResolvedReleaseManifest` struct that holds both `product` and `core` release manifest data that will be used to retrieve the necessary data during `elemental build`.
2. Can parse both `core` and `product` release manifests.
3. Release manifest sources are provided in URI format. Currently `oci` and `file` are supported:
    * `oci://registry.com/foo/bar/release-manifest:0.0.1`
    * `fiile:///foo/bar/release-manifest.yaml`
4. `Core` manifests are referred only by version in the `product` release manifests - the construction of the valid OCI image for the `core` manifest is done in-code. This limits the chance for a user to provide an OCI image or file that points to a not supported/tested set of core component versions. For testing purposes, the default value of the `core` manifest registry will be configurable during the build step. The specifics of this will be handled during the integration of this logic and the `build` command.

Manifest resolution process:
```
-> Parse URI to 'ReleaseManifestSource'
-> Read manifest data from 'ReleaseManifestSource'
  -> [OCI source] -> Unpack OCI FS -> Locate manifest -> Move manifest to store (can be later used as cache) -> Remove OCI FS -> Read manifest from store
-> Try to parse data:
  -> To 'product' manifest -> To 'core' manifest -> Fail
-> [product manifest] Construct `core` manifest OCI image and repeat resolution 
-> [core manifest] Return the resolved manifest in the form of 'ResolvedReleaseManifest' struct.
```

Enhacements post-POC:

1. Validation of manifest API
2. OCI caching mechanism based on the `store` logic introduced in the `OCIReleaseManifestExtractor`
3. Local OCI image handling