### PR TITLE
Introduce release manifest unit tests

### DIFF
--- a/internal/manifest/extractor/extractor_test.go
+++ b/internal/manifest/extractor/extractor_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extractor_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/internal/manifest/extractor"
+)
+
+const (
+	unpackDirPrefix     = "release-manifest-unpack-"
+	dummyContent        = "dummy"
+	dummyOCI            = "registry.com/dummy/release-manifest:0.0.1"
+	releaseManifestName = "release_manifest.yaml"
+)
+
+func TestOCIReleaseManifestExtractor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Release Manifest OCI Extractor test suite")
+}
+
+var _ = Describe("OCIReleaseManifestExtractor", Label("release-manifest"), func() {
+	var customStoreRoot string
+	var unpacker *unpackerMock
+	BeforeEach(func() {
+		var err error
+		customStoreRoot, err = os.MkdirTemp("", "extractor-custom-store-")
+		Expect(err).ToNot(HaveOccurred())
+
+		unpacker = &unpackerMock{
+			manifestAtPath: releaseManifestName,
+			digest:         "sha256:" + randomDigestEnc(64),
+		}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(customStoreRoot)).To(Succeed())
+	})
+
+	It("extracts release manifest to default store", func() {
+		digestEnc := randomDigestEnc(64)
+		unpacker.digest = "sha256:" + digestEnc
+		expectedDefaultStoreRoot := filepath.Join(os.TempDir(), "release-manifests")
+		expectedManifestStore := filepath.Join(expectedDefaultStoreRoot, digestEnc)
+
+		defaultStoreExtr, err := extractor.New(extractor.WithOCIUnpacker(unpacker))
+		Expect(err).ToNot(HaveOccurred())
+
+		extractedManifest, err := defaultStoreExtr.ExtractFrom(dummyOCI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.HasPrefix(extractedManifest, expectedDefaultStoreRoot)).To(BeTrue())
+		Expect(filepath.Dir(extractedManifest)).To(Equal(expectedManifestStore))
+		validateExtractedManifestContent(extractedManifest)
+		Expect(os.RemoveAll(expectedDefaultStoreRoot)).To(Succeed())
+	})
+
+	It("extracts release manifest to custom store", func() {
+		digestEnc := randomDigestEnc(128)
+		manifestStoreName := digestEnc[:64]
+		unpacker.digest = "sha512:" + digestEnc
+		expectedManifestStore := filepath.Join(customStoreRoot, manifestStoreName)
+
+		customStoreExtr, err := extractor.New(extractor.WithStore(customStoreRoot), extractor.WithOCIUnpacker(unpacker))
+		Expect(err).ToNot(HaveOccurred())
+
+		extractedManifest, err := customStoreExtr.ExtractFrom(dummyOCI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.HasPrefix(extractedManifest, customStoreRoot)).To(BeTrue())
+		Expect(filepath.Dir(extractedManifest)).To(Equal(expectedManifestStore))
+		validateExtractedManifestContent(extractedManifest)
+	})
+
+	It("extracts release manifest using custom search paths", func() {
+		customManifestName := "release_manifest_foo.yaml"
+		searchPaths := []string{filepath.Join("dummy", "release_manifest*.yaml")}
+		unpacker.manifestAtPath = filepath.Join("dummy", customManifestName)
+
+		customSearchPathExtr, err := extractor.New(extractor.WithSearchPaths(searchPaths), extractor.WithStore(customStoreRoot), extractor.WithOCIUnpacker(unpacker))
+		Expect(err).ToNot(HaveOccurred())
+
+		extractedManifest, err := customSearchPathExtr.ExtractFrom(dummyOCI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(filepath.Base(extractedManifest)).To(Equal(customManifestName))
+		validateExtractedManifestContent(extractedManifest)
+	})
+
+	It("fails when unpacking an OCI image", func() {
+		unpacker.fail = true
+		expErr := "unpacking oci image: unpack failure"
+
+		defaultExtr, err := extractor.New(extractor.WithOCIUnpacker(unpacker), extractor.WithStore(customStoreRoot))
+		Expect(err).ToNot(HaveOccurred())
+
+		manifest, err := defaultExtr.ExtractFrom(dummyOCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErr))
+		Expect(manifest).To(BeEmpty())
+	})
+
+	It("fails when release manifest is missing in the unpacked image", func() {
+		customSearchPath := filepath.Join("dummy", "release_manifest*.yaml")
+		expErr := "locating release manifest at unpacked OCI filesystem: release manifest not found at paths: [dummy/release_manifest*.yaml]"
+
+		extr, err := extractor.New(extractor.WithSearchPaths([]string{customSearchPath}), extractor.WithOCIUnpacker(unpacker), extractor.WithStore(customStoreRoot))
+		Expect(err).ToNot(HaveOccurred())
+
+		manifest, err := extr.ExtractFrom(dummyOCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErr))
+		Expect(manifest).To(BeEmpty())
+	})
+
+	It("fails when there is more than one release manfiest at the search path", func() {
+		unpacker.multipleManifest = true
+		unpacker.manifestAtPath = filepath.Join("etc", "release-manifest", releaseManifestName)
+		expErr := "locating release manifest at unpacked OCI filesystem: expected a single release manifest at 'etc/release-manifest', got '2'"
+
+		extr, err := extractor.New(extractor.WithOCIUnpacker(unpacker), extractor.WithStore(customStoreRoot))
+		Expect(err).ToNot(HaveOccurred())
+
+		manifest, err := extr.ExtractFrom(dummyOCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErr))
+		Expect(manifest).To(BeEmpty())
+	})
+
+	It("fails when produced digest is not in an OCI format", func() {
+		unpacker.digest = "d41d8cd98f00b204e9800998ecf8427e"
+		expErr := fmt.Sprintf("generating manifest store based on digest: invalid digest format '%s', expected '<algorithm>:<hash>'", unpacker.digest)
+
+		extr, err := extractor.New(extractor.WithOCIUnpacker(unpacker), extractor.WithStore(customStoreRoot))
+		Expect(err).ToNot(HaveOccurred())
+
+		manifest, err := extr.ExtractFrom(dummyOCI)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErr))
+		Expect(manifest).To(BeEmpty())
+	})
+})
+
+func validateExtractedManifestContent(manifest string) {
+	data, err := os.ReadFile(manifest)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(string(data)).To(Equal(dummyContent))
+}
+
+type unpackerMock struct {
+	manifestAtPath   string
+	fail             bool
+	digest           string
+	multipleManifest bool
+}
+
+func (u unpackerMock) Unpack(ctx context.Context, uri, dest string) (digest string, err error) {
+	if u.fail {
+		return "", fmt.Errorf("unpack failure")
+	}
+
+	dir := filepath.Dir(filepath.Join(dest, u.manifestAtPath))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(filepath.Join(dest, u.manifestAtPath), []byte(dummyContent), 0644); err != nil {
+		return "", err
+	}
+
+	if u.multipleManifest {
+		secondManifest := filepath.Join(filepath.Dir(u.manifestAtPath), "release_manifest2.yaml")
+		if err := os.WriteFile(filepath.Join(dest, secondManifest), []byte(dummyContent), 0644); err != nil {
+			return "", err
+		}
+	}
+
+	return u.digest, nil
+}
+
+func randomDigestEnc(n int) string {
+	const letters = "0123456789abcdef"
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/pkg/manifest/api/core/manifest_test.go
+++ b/pkg/manifest/api/core/manifest_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/manifest/api/core"
+)
+
+const invalidManifest = `
+metadata:
+  name: "suse-core"
+  version: "0.0.1"
+  upgradePathsFrom: 
+  - "0.0.1-rc"
+  creationDate: "2000-01-01"
+corePlatform:
+  name: "suse-edge"
+  version: "0.0.0"
+`
+
+func TestCoreManifestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Core Release Manifest API test suite")
+}
+
+var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
+	It("is parsed correctly", func() {
+		data, err := os.ReadFile(filepath.Join("..", "..", "testdata", "full_core_release_manifest.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		rm, err := core.Parse(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rm).ToNot(BeNil())
+
+		Expect(rm.MetaData).ToNot(BeNil())
+		Expect(rm.MetaData.Name).To(Equal("suse-core"))
+		Expect(rm.MetaData.Version).To(Equal("1.0"))
+		Expect(len(rm.MetaData.UpgradePathsFrom)).To(Equal(1))
+		Expect(rm.MetaData.UpgradePathsFrom[0]).To(Equal("0.0.1"))
+		Expect(rm.MetaData.CreationDate).To(Equal("2000-01-01"))
+
+		Expect(rm.Components).ToNot(BeNil())
+		Expect(rm.Components.OperatingSystem).ToNot(BeNil())
+		Expect(rm.Components.OperatingSystem.Version).To(Equal("6.2"))
+		Expect(rm.Components.OperatingSystem.Image).To(Equal("registry.com/foo/bar/sl-micro:6.2"))
+
+		Expect(rm.Components.Kubernetes).ToNot(BeNil())
+		Expect(rm.Components.Kubernetes.RKE2).ToNot(BeNil())
+		Expect(rm.Components.Kubernetes.RKE2.Version).To(Equal("1.32"))
+		Expect(rm.Components.Kubernetes.RKE2.Image).To(Equal("registry.com/foo/bar/rke2:1.32"))
+
+		Expect(rm.Components.Helm).ToNot(BeNil())
+		Expect(len(rm.Components.Helm.Charts)).To(Equal(1))
+		Expect(rm.Components.Helm.Charts[0].Name).To(Equal("Foo"))
+		Expect(rm.Components.Helm.Charts[0].Chart).To(Equal("foo"))
+		Expect(rm.Components.Helm.Charts[0].Version).To(Equal("0.0.0"))
+		Expect(rm.Components.Helm.Charts[0].Namespace).To(Equal("foo-system"))
+		Expect(rm.Components.Helm.Charts[0].Values).To(Equal("image:\n  tag: latest"))
+		Expect(len(rm.Components.Helm.Charts[0].DependsOn)).To(Equal(1))
+		Expect(rm.Components.Helm.Charts[0].DependsOn[0]).To(Equal("baz"))
+		Expect(len(rm.Components.Helm.Charts[0].Images)).To(Equal(1))
+		Expect(rm.Components.Helm.Charts[0].Images[0].Name).To(Equal("foo"))
+		Expect(rm.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/foo/foo:0.0.0"))
+		Expect(len(rm.Components.Helm.Repository)).To(Equal(1))
+		Expect(rm.Components.Helm.Repository[0].Name).To(Equal("foo-charts"))
+		Expect(rm.Components.Helm.Repository[0].URL).To(Equal("https://foo.github.io/charts"))
+	})
+
+	It("fails when unknown field is introduced", func() {
+		expErrMsg := "unmarshaling 'core' release manifest: error unmarshaling JSON: while decoding JSON: json: unknown field \"corePlatform\""
+		data := []byte(invalidManifest)
+		rm, err := core.Parse(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErrMsg))
+		Expect(rm).To(BeNil())
+	})
+})

--- a/pkg/manifest/api/product/manifest_test.go
+++ b/pkg/manifest/api/product/manifest_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package product_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/manifest/api/product"
+)
+
+const unknownFieldManifest = `
+metadata:
+  name: "suse-edge"
+  version: "3.2.0"
+  upgradePathsFrom: 
+  - "3.1.2"
+  creationDate: "2025-01-20"
+components:
+  operatingSystem:
+    version: "6.2"
+    image: "registry.com/foo/bar/sl-micro:6.2"
+`
+
+func TestProductManifestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Product Release Manifest API test suite")
+}
+
+var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
+	It("is parsed correctly", func() {
+		data, err := os.ReadFile(filepath.Join("..", "..", "testdata", "full_product_release_manifest.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		rm, err := product.Parse(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rm).ToNot(BeNil())
+
+		Expect(rm.MetaData).ToNot(BeNil())
+		Expect(rm.MetaData.Name).To(Equal("suse-edge"))
+		Expect(rm.MetaData.Version).To(Equal("3.2.0"))
+		Expect(len(rm.MetaData.UpgradePathsFrom)).To(Equal(1))
+		Expect(rm.MetaData.UpgradePathsFrom[0]).To(Equal("3.1.2"))
+		Expect(rm.MetaData.CreationDate).To(Equal("2025-01-20"))
+
+		Expect(rm.CorePlatform).ToNot(BeNil())
+		Expect(rm.CorePlatform.Name).To(Equal("suse-core"))
+		Expect(rm.CorePlatform.Version).To(Equal("1.0"))
+
+		Expect(rm.Components.Helm).ToNot(BeNil())
+		Expect(len(rm.Components.Helm.Charts)).To(Equal(1))
+		Expect(rm.Components.Helm.Charts[0].Name).To(Equal("Bar"))
+		Expect(rm.Components.Helm.Charts[0].Chart).To(Equal("bar"))
+		Expect(rm.Components.Helm.Charts[0].Version).To(Equal("0.0.0"))
+		Expect(rm.Components.Helm.Charts[0].Namespace).To(Equal("bar-system"))
+		Expect(rm.Components.Helm.Charts[0].Values).To(Equal("image:\n  tag: latest"))
+		Expect(len(rm.Components.Helm.Charts[0].DependsOn)).To(Equal(1))
+		Expect(rm.Components.Helm.Charts[0].DependsOn[0]).To(Equal("foo"))
+		Expect(len(rm.Components.Helm.Charts[0].Images)).To(Equal(1))
+		Expect(rm.Components.Helm.Charts[0].Images[0].Name).To(Equal("bar"))
+		Expect(rm.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/bar/bar:0.0.0"))
+		Expect(len(rm.Components.Helm.Repository)).To(Equal(1))
+		Expect(rm.Components.Helm.Repository[0].Name).To(Equal("bar-charts"))
+		Expect(rm.Components.Helm.Repository[0].URL).To(Equal("https://bar.github.io/charts"))
+	})
+
+	It("fails when unknown field is introduced", func() {
+		expErrMsg := "unmarshaling 'product' release manifest: error unmarshaling JSON: while decoding JSON: json: unknown field \"operatingSystem\""
+		data := []byte(unknownFieldManifest)
+		rm, err := product.Parse(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErrMsg))
+		Expect(rm).To(BeNil())
+	})
+
+	It("fails when 'corePlatform' is missing", func() {
+		expErrMsg := "missing 'corePlatform' field"
+		missingBasePlatformManifest := ""
+		data := []byte(missingBasePlatformManifest)
+		rm, err := product.Parse(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErrMsg))
+		Expect(rm).To(BeNil())
+	})
+})

--- a/pkg/manifest/resolver/resolver_test.go
+++ b/pkg/manifest/resolver/resolver_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/manifest/resolver"
+	"github.com/suse/elemental/v3/pkg/manifest/source"
+)
+
+const (
+	corePlatformRef              = "foo.registry.com/bar/release-manifest"
+	corePlatformVersion          = "1.0"
+	expectedCorePlatformImage    = corePlatformRef + ":" + corePlatformVersion
+	expectedProductManifestImage = "prod.registry.com/bar/release-manifest:0.0.1"
+)
+
+var coreManifestPath = filepath.Join("..", "testdata", "full_core_release_manifest.yaml")
+var prodManifestPath = filepath.Join("..", "testdata", "full_product_release_manifest.yaml")
+
+func TestResolverSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Release Manifest Resolver test suite")
+}
+
+var _ = Describe("Resolver", Label("release-manifest"), func() {
+	var reader *SourceReaderMock
+	var res *resolver.Resolver
+	BeforeEach(func() {
+		reader = &SourceReaderMock{}
+		res = resolver.New(reader, corePlatformRef)
+	})
+
+	It("resolves a 'product' release manifest correctly", func() {
+		By("reading the manifest source from a local file")
+		prodManifestFile := fmt.Sprintf("%s://%s", source.File, prodManifestPath)
+		resolvedManifest, err := res.Resolve(prodManifestFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolvedManifest).ToNot(BeNil())
+		validateResolvedManifest(resolvedManifest, false)
+
+		By("reading the manifest source from an OCI image")
+		prodManifestOCI := fmt.Sprintf("%s://%s", source.OCI, expectedProductManifestImage)
+		resolvedManifest, err = res.Resolve(prodManifestOCI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolvedManifest).ToNot(BeNil())
+		validateResolvedManifest(resolvedManifest, false)
+	})
+
+	It("resolves a 'core' release manifest correctly", func() {
+		By("reading the manifest source from a local file")
+		coreManifestFile := fmt.Sprintf("%s://%s", source.File, coreManifestPath)
+		resolvedManifest, err := res.Resolve(coreManifestFile)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolvedManifest).ToNot(BeNil())
+		validateResolvedManifest(resolvedManifest, true)
+
+		By("reading the manifest source from an OCI image")
+		coreManifestOCI := fmt.Sprintf("%s://%s", source.OCI, expectedCorePlatformImage)
+		resolvedManifest, err = res.Resolve(coreManifestOCI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolvedManifest).ToNot(BeNil())
+		validateResolvedManifest(resolvedManifest, true)
+	})
+
+	It("fails to convert to a manifest source", func() {
+		By("referring an invalid file")
+		invalidFile := fmt.Sprintf("%s://foo /invalid/file.yaml", source.File)
+		expErrSub := "unable to convert uri 'file://foo /invalid/file.yaml' to manifest source"
+		r, err := res.Resolve(invalidFile)
+		Expect(err).ToNot(BeNil())
+		Expect(err).To(MatchError(ContainSubstring(expErrSub)))
+		Expect(r).To(BeNil())
+
+		By("referring an invalid OCI")
+		invalidOCI := fmt.Sprintf("%s://registry.com /invalid/release-manifest:0.0.1", source.OCI)
+		expErrSub = "unable to convert uri 'oci://registry.com /invalid/release-manifest:0.0.1' to manifest source"
+		r, err = res.Resolve(invalidOCI)
+		Expect(err).ToNot(BeNil())
+		Expect(err).To(MatchError(ContainSubstring(expErrSub)))
+		Expect(r).To(BeNil())
+	})
+
+	It("fails when the release manifest is missing", func() {
+		missingFile := fmt.Sprintf("%s://missing/file.yaml", source.File)
+		expErrSub := "reading manifest from source 'missing/file.yaml'"
+		r, err := res.Resolve(missingFile)
+		Expect(err).ToNot(BeNil())
+		Expect(err).To(MatchError(ContainSubstring(expErrSub)))
+		Expect(r).To(BeNil())
+	})
+
+	It("fails when the release manifest is empty", func() {
+		reader.returnEmpty = true
+		dummyFileURI := fmt.Sprintf("%s://%s", source.File, "dummy.txt")
+		expErrSub := "empty file passed as release manifest: 'dummy.txt'"
+		r, err := res.Resolve(dummyFileURI)
+		Expect(err).ToNot(BeNil())
+		Expect(err).To(MatchError(ContainSubstring(expErrSub)))
+		Expect(r).To(BeNil())
+	})
+
+	It("fails when the content is not actually a release manfiest", func() {
+		reader.returnNonReleaseManifest = true
+		wrongFileURI := fmt.Sprintf("%s://%s", source.File, "wrong.txt")
+		expErrSub := "unable to parse 'wrong.txt' as a valid release manifest"
+		r, err := res.Resolve(wrongFileURI)
+		Expect(err).ToNot(BeNil())
+		Expect(err).To(MatchError(ContainSubstring(expErrSub)))
+		Expect(r).To(BeNil())
+	})
+
+	It("fails when the release manifest cannot be extracted from the OCI image", func() {
+		reader.failOCIExtract = true
+		missingOCI := fmt.Sprintf("%s://%s", source.OCI, "registry.com/missing/release-manifest:0.0.1")
+		expErr := "reading manifest from source 'registry.com/missing/release-manifest:0.0.1': oci extract error"
+		r, err := res.Resolve(missingOCI)
+		Expect(err).ToNot(BeNil())
+		Expect(err).To(MatchError(expErr))
+		Expect(r).To(BeNil())
+	})
+})
+
+func validateResolvedManifest(rm *resolver.ResolvedManifest, coreOnly bool) {
+	Expect(rm.CorePlatform).ToNot(BeNil())
+
+	Expect(rm.CorePlatform.MetaData).ToNot(BeNil())
+	Expect(rm.CorePlatform.MetaData.Name).To(Equal("suse-core"))
+	Expect(rm.CorePlatform.MetaData.Version).To(Equal("1.0"))
+	Expect(len(rm.CorePlatform.MetaData.UpgradePathsFrom)).To(Equal(1))
+	Expect(rm.CorePlatform.MetaData.UpgradePathsFrom[0]).To(Equal("0.0.1"))
+	Expect(rm.CorePlatform.MetaData.CreationDate).To(Equal("2000-01-01"))
+
+	Expect(rm.CorePlatform.Components).ToNot(BeNil())
+	Expect(rm.CorePlatform.Components.OperatingSystem).ToNot(BeNil())
+	Expect(rm.CorePlatform.Components.OperatingSystem.Version).To(Equal("6.2"))
+	Expect(rm.CorePlatform.Components.OperatingSystem.Image).To(Equal("registry.com/foo/bar/sl-micro:6.2"))
+
+	Expect(rm.CorePlatform.Components.Kubernetes).ToNot(BeNil())
+	Expect(rm.CorePlatform.Components.Kubernetes.RKE2).ToNot(BeNil())
+	Expect(rm.CorePlatform.Components.Kubernetes.RKE2.Version).To(Equal("1.32"))
+	Expect(rm.CorePlatform.Components.Kubernetes.RKE2.Image).To(Equal("registry.com/foo/bar/rke2:1.32"))
+
+	Expect(rm.CorePlatform.Components.Helm).ToNot(BeNil())
+	Expect(len(rm.CorePlatform.Components.Helm.Charts)).To(Equal(1))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Name).To(Equal("Foo"))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Chart).To(Equal("foo"))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Version).To(Equal("0.0.0"))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Namespace).To(Equal("foo-system"))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Values).To(Equal("image:\n  tag: latest"))
+	Expect(len(rm.CorePlatform.Components.Helm.Charts[0].DependsOn)).To(Equal(1))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].DependsOn[0]).To(Equal("baz"))
+	Expect(len(rm.CorePlatform.Components.Helm.Charts[0].Images)).To(Equal(1))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Images[0].Name).To(Equal("foo"))
+	Expect(rm.CorePlatform.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/foo/foo:0.0.0"))
+	Expect(len(rm.CorePlatform.Components.Helm.Repository)).To(Equal(1))
+	Expect(rm.CorePlatform.Components.Helm.Repository[0].Name).To(Equal("foo-charts"))
+	Expect(rm.CorePlatform.Components.Helm.Repository[0].URL).To(Equal("https://foo.github.io/charts"))
+
+	if !coreOnly {
+		Expect(rm.ProductExtension).ToNot(BeNil())
+
+		Expect(rm.ProductExtension.MetaData).ToNot(BeNil())
+		Expect(rm.ProductExtension.MetaData.Name).To(Equal("suse-edge"))
+		Expect(rm.ProductExtension.MetaData.Version).To(Equal("3.2.0"))
+		Expect(len(rm.ProductExtension.MetaData.UpgradePathsFrom)).To(Equal(1))
+		Expect(rm.ProductExtension.MetaData.UpgradePathsFrom[0]).To(Equal("3.1.2"))
+		Expect(rm.ProductExtension.MetaData.CreationDate).To(Equal("2025-01-20"))
+
+		Expect(rm.ProductExtension.CorePlatform).ToNot(BeNil())
+		Expect(rm.ProductExtension.CorePlatform.Name).To(Equal("suse-core"))
+		Expect(rm.ProductExtension.CorePlatform.Version).To(Equal("1.0"))
+
+		Expect(rm.ProductExtension.Components.Helm).ToNot(BeNil())
+		Expect(len(rm.ProductExtension.Components.Helm.Charts)).To(Equal(1))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Name).To(Equal("Bar"))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Chart).To(Equal("bar"))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Version).To(Equal("0.0.0"))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Namespace).To(Equal("bar-system"))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Values).To(Equal("image:\n  tag: latest"))
+		Expect(len(rm.ProductExtension.Components.Helm.Charts[0].DependsOn)).To(Equal(1))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].DependsOn[0]).To(Equal("foo"))
+		Expect(len(rm.ProductExtension.Components.Helm.Charts[0].Images)).To(Equal(1))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Images[0].Name).To(Equal("bar"))
+		Expect(rm.ProductExtension.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/bar/bar:0.0.0"))
+		Expect(len(rm.ProductExtension.Components.Helm.Repository)).To(Equal(1))
+		Expect(rm.ProductExtension.Components.Helm.Repository[0].Name).To(Equal("bar-charts"))
+		Expect(rm.ProductExtension.Components.Helm.Repository[0].URL).To(Equal("https://bar.github.io/charts"))
+	} else {
+		Expect(rm.ProductExtension).To(BeNil())
+	}
+}
+
+type SourceReaderMock struct {
+	failOCIExtract           bool
+	returnEmpty              bool
+	returnNonReleaseManifest bool
+}
+
+func (s SourceReaderMock) Read(m *source.ReleaseManifestSource) ([]byte, error) {
+	if s.returnEmpty {
+		return []byte{}, nil
+	}
+
+	if s.returnNonReleaseManifest {
+		return []byte("this is not a release manifest"), nil
+	}
+
+	if m.Type() == source.OCI {
+		if s.failOCIExtract {
+			return nil, fmt.Errorf("oci extract error")
+		}
+
+		switch {
+		case m.URI() == expectedCorePlatformImage:
+			return os.ReadFile(coreManifestPath)
+		case m.URI() == expectedProductManifestImage:
+			return os.ReadFile(prodManifestPath)
+		default:
+			return nil, fmt.Errorf("unexpected image uri '%s'", m.URI())
+		}
+	}
+	return os.ReadFile(m.URI())
+}

--- a/pkg/manifest/source/reader_test.go
+++ b/pkg/manifest/source/reader_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/manifest/source"
+)
+
+const (
+	testFile     = "test-file.yaml"
+	dummyContent = "dummy"
+)
+
+var _ = Describe("ReleaseManifestReader", Ordered, Label("release-manifest"), func() {
+	var testDir string
+	var testFilePath string
+	var fileExtr *OCIFileExtractorMock
+	var reader *source.ReleaseManifestReader
+	BeforeAll(func() {
+		var err error
+		testDir, err = os.MkdirTemp("", "elemental-manifest-source-*")
+		Expect(err).ToNot(HaveOccurred())
+
+		testFilePath = filepath.Join(testDir, testFile)
+		Expect(os.WriteFile(testFilePath, []byte(dummyContent), 0644)).To(Succeed())
+
+		fileExtr = &OCIFileExtractorMock{manifestPath: testFilePath}
+		reader = source.NewReader(fileExtr)
+	})
+
+	AfterAll(func() {
+		Expect(os.RemoveAll(testDir)).To(Succeed())
+	})
+
+	It("reads from a local manifest source", func() {
+		data, err := reader.Read(getSource(source.File, testFilePath))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(data)).ToNot(Equal(0))
+		Expect(data).To(Equal([]byte(dummyContent)))
+	})
+	It("fails to read from a local manifest source", func() {
+		data, err := reader.Read(getSource(source.File, testFilePath+"missing"))
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+		Expect(len(data)).To(Equal(0))
+	})
+	It("reads from an oci manifest source", func() {
+		data, err := reader.Read(getSource(source.OCI, "registry.com/foo/bar/test:0.0.1"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(data)).ToNot(Equal(0))
+		Expect(data).To(Equal([]byte(dummyContent)))
+	})
+	It("fails to read from an oci manifest source", func() {
+		failingExtr := &OCIFileExtractorMock{fail: true}
+		failingReader := source.NewReader(failingExtr)
+		data, err := failingReader.Read(getSource(source.OCI, "registry.com/foo/bar/test:0.0.1"))
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("extracting file from OCI image 'registry.com/foo/bar/test:0.0.1': failed extract"))
+		Expect(len(data)).To(Equal(0))
+	})
+})
+
+func getSource(srcType source.ReleaseManifestSourceType, location string) *source.ReleaseManifestSource {
+	sourceURI := fmt.Sprintf("%s://%s", srcType, location)
+	rmSrc, err := source.ParseFromURI(sourceURI)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(rmSrc).ToNot(BeNil())
+	return rmSrc
+}
+
+type OCIFileExtractorMock struct {
+	manifestPath string
+	fail         bool
+}
+
+func (o OCIFileExtractorMock) ExtractFrom(uri string) (path string, err error) {
+	if o.fail {
+		return "", fmt.Errorf("failed extract")
+	}
+	return o.manifestPath, nil
+}

--- a/pkg/manifest/source/source_suite_test.go
+++ b/pkg/manifest/source/source_suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReleaseManifestSourceSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Release Manifest Source test suite")
+}

--- a/pkg/manifest/source/source_test.go
+++ b/pkg/manifest/source/source_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/pkg/manifest/source"
+)
+
+var _ = Describe("ReleaseManifestSourceType", Label("release-manifest"), func() {
+	It("is parsed correctly as 'File' source type", func() {
+		srcType, err := source.ParseType("file")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(srcType).To(Equal(source.File))
+	})
+
+	It("is parsed correctly as 'OCI' source type", func() {
+		srcType, err := source.ParseType("oci")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(srcType).To(Equal(source.OCI))
+	})
+
+	It("fails for an unexpected source type", func() {
+		expErrMsg := "manifest source type 'unknown' is not supported. Supported source types: 'file', 'oci'"
+		_, err := source.ParseType("unknown")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(expErrMsg))
+	})
+})
+
+var _ = Describe("ReleaseManifestSource", Label("release-manifest"), func() {
+	It("is initialised correctly from a 'file' type source", func() {
+		fileURI := "file:///foo/../bar///release_manifest.yaml"
+		normalisedURI := "/bar/release_manifest.yaml"
+
+		rmSource, err := source.ParseFromURI(fileURI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rmSource).ToNot(BeNil())
+		Expect(rmSource.URI()).To(Equal(normalisedURI))
+		Expect(rmSource.Type()).To(Equal(source.File))
+	})
+
+	It("is initialised correctly from an 'oci' type source", func() {
+		src := "foo.registry.com/bar/release-manifest:0.0.1"
+		ociURI := fmt.Sprintf("%s://%s", source.OCI, src)
+
+		rmSource, err := source.ParseFromURI(ociURI)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rmSource).ToNot(BeNil())
+		Expect(rmSource.URI()).To(Equal(src))
+		Expect(rmSource.Type()).To(Equal(source.OCI))
+	})
+
+	It("initialization fails", func() {
+		By("throwing a parse error")
+		brokenURI := "file:// /foo/bar/release_manifest.yaml"
+		expErr := "parsing manifest source uri: parse \"file:// /foo/bar/release_manifest.yaml\": invalid character \" \" in host name"
+		validateInitialisationErr(brokenURI, expErr)
+
+		By("throwing a 'missing scheme' error")
+		missingSchemeURI := "/foo/bar/release_manifest.yaml"
+		expErr = "missing scheme in source uri: '/foo/bar/release_manifest.yaml'"
+		validateInitialisationErr(missingSchemeURI, expErr)
+
+		By("throwing an 'unknown source' error")
+		src := "unknown"
+		unknownSrc := fmt.Sprintf("%s:///foo/bar/release_manifest.yaml", src)
+		expErr = fmt.Sprintf("parsing manifest source type: manifest source type '%s' is not supported. Supported source types: 'file', 'oci'", src)
+		validateInitialisationErr(unknownSrc, expErr)
+
+		By("throwing an 'invalid OCI image' error")
+		invalidOCI := "oci://foo.registry.com/bar:00|11"
+		expErr = "invalid OCI image reference: could not parse reference: foo.registry.com/bar:00|11"
+		validateInitialisationErr(invalidOCI, expErr)
+	})
+})
+
+func validateInitialisationErr(uri, errMsg string) {
+	rmSource, err := source.ParseFromURI(uri)
+	Expect(err).ToNot(BeNil())
+	Expect(err).To(MatchError(errMsg))
+	Expect(rmSource).To(BeNil())
+}

--- a/pkg/manifest/testdata/full_core_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_core_release_manifest.yaml
@@ -1,0 +1,47 @@
+# Copyright © 2025 SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  name: "suse-core"
+  version: "1.0"
+  upgradePathsFrom: 
+  - "0.0.1"
+  creationDate: "2000-01-01"
+components:
+  operatingSystem:
+    version: "6.2"
+    image: "registry.com/foo/bar/sl-micro:6.2"
+  kubernetes:
+    rke2:
+      version: "1.32"
+      image: "registry.com/foo/bar/rke2:1.32"
+  helm:
+    charts:
+    - name: "Foo"
+      chart: "foo"
+      version: "0.0.0"
+      namespace: "foo-system"
+      repository: "foo-charts"
+      values: |-
+        image:
+          tag: latest
+      dependsOn:
+      - "baz"
+      images:
+      - name: "foo"
+        image: "registry.com/foo/foo:0.0.0"
+    repository:
+    - name: "foo-charts"
+      url: "https://foo.github.io/charts"

--- a/pkg/manifest/testdata/full_product_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_product_release_manifest.yaml
@@ -1,0 +1,43 @@
+# Copyright © 2025 SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  name: "suse-edge"
+  version: "3.2.0"
+  upgradePathsFrom: 
+  - "3.1.2"
+  creationDate: "2025-01-20"
+corePlatform:
+  name: "suse-core"
+  version: "1.0"
+components:
+  helm:
+    charts:
+    - name: "Bar"
+      chart: "bar"
+      version: "0.0.0"
+      namespace: "bar-system"
+      repository: "bar-charts"
+      values: |-
+        image:
+          tag: latest
+      dependsOn:
+      - "foo"
+      images:
+      - name: "bar"
+        image: "registry.com/bar/bar:0.0.0"
+    repository:
+    - name: "bar-charts"
+      url: "https://bar.github.io/charts"


### PR DESCRIPTION
This commit introduces test for the release manifest resolution logic that came with #89.