### PR TITLE
Make unpack configurable

### DIFF
--- a/internal/cli/elemental-toolkit/action/unpack.go
+++ b/internal/cli/elemental-toolkit/action/unpack.go
@@ -40,9 +40,9 @@ func Unpack(ctx *cli.Context) error {
 	s.Logger().Info("Starting unpack action with args: %+v", args)
 
 	unpacker := unpack.NewOCIUnpacker(s, args.Image,
-		unpack.WithLocal(args.Local),
-		unpack.WithPlatformRef(args.Platform),
-		unpack.WithVerify(args.Verify))
+		unpack.WithLocalOCI(args.Local),
+		unpack.WithPlatformRefOCI(args.Platform),
+		unpack.WithVerifyOCI(args.Verify))
 
 	ctxSignal, stop := signal.NotifyContext(ctx.Context, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()

--- a/pkg/rsync/sync.go
+++ b/pkg/rsync/sync.go
@@ -39,7 +39,9 @@ type Opts func(r *Rsync)
 
 func WithFlags(flags ...string) Opts {
 	return func(r *Rsync) {
-		r.flags = flags
+		if len(flags) != 0 {
+			r.flags = flags
+		}
 	}
 }
 

--- a/pkg/unpack/oci.go
+++ b/pkg/unpack/oci.go
@@ -44,31 +44,32 @@ type OCI struct {
 	local       bool
 	verify      bool
 	imageRef    string
+	rsyncFlags  []string
 }
 
 type OCIOpt func(*OCI)
 
-func WithLocal(local bool) OCIOpt {
+func WithLocalOCI(local bool) OCIOpt {
 	return func(o *OCI) {
 		o.local = local
 	}
 }
 
-func WithVerify(verify bool) OCIOpt {
+func WithVerifyOCI(verify bool) OCIOpt {
 	return func(o *OCI) {
 		o.verify = verify
 	}
 }
 
-func WithPlatformRef(platform string) OCIOpt {
+func WithPlatformRefOCI(platform string) OCIOpt {
 	return func(o *OCI) {
 		o.platformRef = platform
 	}
 }
 
-func WithImageRef(imageRef string) OCIOpt {
+func WithRsyncFlagsOCI(flags ...string) OCIOpt {
 	return func(o *OCI) {
-		o.imageRef = imageRef
+		o.rsyncFlags = flags
 	}
 }
 
@@ -107,7 +108,7 @@ func (o OCI) SynchedUnpack(ctx context.Context, destination string, excludes []s
 	if err != nil {
 		return "", err
 	}
-	unpackD := NewDirectoryUnpacker(o.s, tempDir)
+	unpackD := NewDirectoryUnpacker(o.s, tempDir, WithRsyncFlagsDir(o.rsyncFlags...))
 	_, err = unpackD.SynchedUnpack(ctx, destination, excludes, deleteExcludes)
 	if err != nil {
 		return "", err

--- a/pkg/unpack/oci_test.go
+++ b/pkg/unpack/oci_test.go
@@ -51,7 +51,7 @@ var _ = Describe("OCIUnpacker", Label("oci", "rootlesskit"), func() {
 		cleanup()
 	})
 	It("Unpacks a remote alpine image", func() {
-		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRef("linux/amd64"), unpack.WithLocal(false))
+		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRefOCI("linux/amd64"), unpack.WithLocalOCI(false))
 		Expect(vfs.MkdirAll(tfs, "/target/root", vfs.DirPerm)).To(Succeed())
 		digest, err := unpacker.Unpack(context.Background(), "/target/root")
 		Expect(err).NotTo(HaveOccurred())
@@ -63,7 +63,7 @@ var _ = Describe("OCIUnpacker", Label("oci", "rootlesskit"), func() {
 		Expect(digest).To(Equal("sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474"))
 	})
 	It("Fails to unpacks a remote bogus image", func() {
-		unpacker := unpack.NewOCIUnpacker(s, bogusImageRef, unpack.WithPlatformRef("linux/amd64"), unpack.WithLocal(false))
+		unpacker := unpack.NewOCIUnpacker(s, bogusImageRef, unpack.WithPlatformRefOCI("linux/amd64"), unpack.WithLocalOCI(false))
 		Expect(vfs.MkdirAll(tfs, "/target/root", vfs.DirPerm)).To(Succeed())
 		digest, err := unpacker.Unpack(context.Background(), "/target/root")
 		Expect(err).To(HaveOccurred())
@@ -72,7 +72,7 @@ var _ = Describe("OCIUnpacker", Label("oci", "rootlesskit"), func() {
 		Expect(digest).To(BeEmpty())
 	})
 	It("Unpacks a local alpine image", func() {
-		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRef("linux/amd64"), unpack.WithLocal(true))
+		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRefOCI("linux/amd64"), unpack.WithLocalOCI(true))
 		_, err := s.Runner().Run("docker", "pull", alpineImageRef)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(vfs.MkdirAll(tfs, "/target/root", vfs.DirPerm)).To(Succeed())
@@ -86,7 +86,7 @@ var _ = Describe("OCIUnpacker", Label("oci", "rootlesskit"), func() {
 		Expect(digest).To(Equal("sha256:16849e7bf3d46ea5065178bfd35d4ce828d184392212d2690733206eacf20d0d"))
 	})
 	It("Fails to unpacks a local bogus image", func() {
-		unpacker := unpack.NewOCIUnpacker(s, bogusImageRef, unpack.WithPlatformRef("linux/amd64"), unpack.WithLocal(true))
+		unpacker := unpack.NewOCIUnpacker(s, bogusImageRef, unpack.WithPlatformRefOCI("linux/amd64"), unpack.WithLocalOCI(true))
 		Expect(vfs.MkdirAll(tfs, "/target/root", vfs.DirPerm)).To(Succeed())
 		digest, err := unpacker.Unpack(context.Background(), "/target/root")
 		Expect(err).To(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("OCIUnpacker", Label("oci", "rootlesskit"), func() {
 		Expect(digest).To(BeEmpty())
 	})
 	It("Syncs a remote alpine image to destination, excludes paths and keeps protected ones", func() {
-		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRef("linux/amd64"), unpack.WithLocal(false))
+		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRefOCI("linux/amd64"), unpack.WithLocalOCI(false))
 		Expect(vfs.MkdirAll(tfs, "/target/root/protected", vfs.DirPerm)).To(Succeed())
 		digest, err := unpacker.SynchedUnpack(context.Background(), "/target/root", []string{"/etc/os-release"}, []string{"/protected"})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This commit makes unpacker factory configurable. It maps the configuration options of the underlaying implementations to the factory method.

The end goal of this change is to facilitate mapping OCI extractor options such as the local flag to upper layers in the code such as the command line interface.

In addition it also allows to set a different set of rsync flags during the overlay tree extraction which is required in order to use dir:// sources.