### PR TITLE
Upgrade refactor

### DIFF
--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -32,6 +32,7 @@ import (
 	"github.com/suse/elemental/v3/pkg/install"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"github.com/suse/elemental/v3/pkg/upgrade"
 )
 
 func Install(ctx *cli.Context) error { //nolint:dupl
@@ -61,14 +62,9 @@ func Install(ctx *cli.Context) error { //nolint:dupl
 	}()
 
 	manager := firmware.NewEfiBootManager(s)
+	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootManager(manager))
+	installer := install.New(ctxCancel, s, install.WithUpgrader(upgrader))
 
-	boot, err := bootloader.New(d.BootConfig.Bootloader, s)
-	if err != nil {
-		s.Logger().Error("Failed to parse boot config: %s", err.Error())
-		return err
-	}
-
-	installer := install.New(ctxCancel, s, install.WithBootloader(boot), install.WithBootManager(manager))
 	err = installer.Install(d)
 	if err != nil {
 		s.Logger().Error("installation failed: %v", err)

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -217,8 +217,19 @@ type Deployment struct {
 	// Consider adding a systemd-sysext list here
 	// All of them would extracted in the RO context, so only
 	// additions to the RWVolumes would succeed.
-	OverlayTree *ImageSource `json:"overlayTree"`
-	CfgScript   string       `json:"configScript"`
+	OverlayTree *ImageSource `json:"overlayTree,omitempty"`
+	CfgScript   string       `json:"configScript,omitempty"`
+}
+
+// MarshalJSON on deploy omits the overlay tree and the configuration script
+// as these are install|ugrade time information which is no longer guaranteed
+// to be (re)aplicable on a deployed system as those are not kept aside.
+func (d Deployment) MarshalJSON() ([]byte, error) {
+	type deployAlias Deployment
+	deploy := deployAlias(d)
+	deploy.CfgScript = ""
+	deploy.OverlayTree = nil
+	return json.Marshal(deploy)
 }
 
 // GetSnapshottedVolumes returns a list of snapshotted rw volumes defined in the

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/suse/elemental/v3/pkg/sys"
 	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
-	"github.com/suse/elemental/v3/pkg/transaction"
-	transmock "github.com/suse/elemental/v3/pkg/transaction/mock"
 )
 
 func TestInstallSuite(t *testing.T) {
@@ -85,42 +83,41 @@ const lsblkJson = `{
 	]
  }`
 
+type upgraderMock struct {
+	Error error
+}
+
+func (u upgraderMock) Upgrade(_ *deployment.Deployment) error {
+	return u.Error
+}
+
 var _ = Describe("Install", Label("install"), func() {
 	var runner *sysmock.Runner
 	var mounter *sysmock.Mounter
-	var syscall *sysmock.Syscall
 	var fs vfs.FS
 	var cleanup func()
 	var s *sys.System
 	var d *deployment.Deployment
 	var i *install.Installer
-	var t *transmock.Transactioner
-	var trans *transaction.Transaction
+	var upgrader *upgraderMock
 	var table string
 	var sideEffects map[string]func(...string) ([]byte, error)
 	BeforeEach(func() {
 		var err error
-		t = &transmock.Transactioner{}
+		upgrader = &upgraderMock{}
 		runner = sysmock.NewRunner()
 		mounter = sysmock.NewMounter()
-		syscall = &sysmock.Syscall{}
 		sideEffects = map[string]func(...string) ([]byte, error){}
 
 		fs, cleanup, err = sysmock.TestFS(map[string]any{
-			"/dev/device":     []byte{},
-			"/dev/device1":    []byte{},
-			"/dev/device2":    []byte{},
-			"/dev/pts/empty":  []byte{},
-			"/proc/empty":     []byte{},
-			"/sys/empty":      []byte{},
-			"/opt/config.sh":  []byte{},
-			"/opt/tree/empty": []byte{},
+			"/dev/device":  []byte{},
+			"/dev/device1": []byte{},
+			"/dev/device2": []byte{},
 		})
 		Expect(err).ToNot(HaveOccurred())
 		s, err = sys.NewSystem(
 			sys.WithMounter(mounter), sys.WithRunner(runner),
 			sys.WithFS(fs), sys.WithLogger(log.New(log.WithDiscardAll())),
-			sys.WithSyscall(syscall),
 		)
 		Expect(err).NotTo(HaveOccurred())
 		d = deployment.DefaultDeployment()
@@ -128,10 +125,8 @@ var _ = Describe("Install", Label("install"), func() {
 		d.Disks[0].Partitions[0].UUID = "34A8-ABB8"
 		d.Disks[0].Partitions[1].UUID = "34a8abb8-ddb3-48a2-8ecc-2443e92c7510"
 		d.SourceOS = deployment.NewDirSrc("/some/dir")
-		d.CfgScript = "/opt/config.sh"
-		d.OverlayTree = deployment.NewDirSrc("/opt/tree")
 		Expect(d.Sanitize(s)).To(Succeed())
-		i = install.New(context.Background(), s, install.WithTransaction(t))
+		i = install.New(context.Background(), s, install.WithUpgrader(upgrader))
 		table = sgdiskEmpty
 
 		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
@@ -155,63 +150,29 @@ var _ = Describe("Install", Label("install"), func() {
 		sideEffects["lsblk"] = func(args ...string) ([]byte, error) {
 			return []byte(lsblkJson), runner.ReturnError
 		}
-		trans = &transaction.Transaction{
-			ID:   1,
-			Path: "/snapshot/path",
-		}
-		t.Trans = trans
-		t.SrcDigest = "imagedigest"
 	})
 	AfterEach(func() {
 		cleanup()
 	})
 	It("installs the given deployment", func() {
 		Expect(i.Install(d)).To(Succeed())
-		Expect(d.SourceOS.GetDigest()).To(Equal("imagedigest"))
-		Expect(runner.MatchMilestones([][]string{{
-			"/etc/config.sh",
-		}}))
+		Expect(runner.MatchMilestones([][]string{
+			{"sgdisk", "--zap-all", "/dev/device"},
+			{"mkfs.vfat", "-n", "EFI"},
+			{"mkfs.btrfs", "-L", "SYSTEM"},
+			{"btrfs", "subvolume", "create"},
+		}))
 	})
-	It("fails on transaction initalization", func() {
-		t.InitErr = fmt.Errorf("init failed")
+	It("fails if upgrader errors out", func() {
+		upgrader.Error = fmt.Errorf("transaction failed")
 		err := i.Install(d)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("init failed"))
-		Expect(t.RollbackCalled()).To(BeFalse())
-	})
-	It("fails on transaction start", func() {
-		t.StartErr = fmt.Errorf("start failed")
-		err := i.Install(d)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("start failed"))
-		Expect(t.RollbackCalled()).To(BeFalse())
-	})
-	It("fails on transaction update", func() {
-		t.UpdateErr = fmt.Errorf("update failed")
-		err := i.Install(d)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("update failed"))
-		Expect(t.RollbackCalled()).To(BeTrue())
-	})
-	It("fails on transaction hook", func() {
-		syscall.ErrorOnChroot = true
-		err := i.Install(d)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("chroot error"))
-	})
-	It("fails on config hook", func() {
-		sideEffects["/etc/elemental/config.sh"] = func(_ ...string) ([]byte, error) {
-			return []byte{}, fmt.Errorf("failed config")
-		}
-		err := i.Install(d)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed config"))
-	})
-	It("fails on transaction commit", func() {
-		t.CommitErr = fmt.Errorf("commit failed")
-		err := i.Install(d)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("commit failed"))
-		Expect(t.RollbackCalled()).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("transaction failed"))
+		Expect(runner.MatchMilestones([][]string{
+			{"sgdisk", "--zap-all", "/dev/device"},
+			{"mkfs.vfat", "-n", "EFI"},
+			{"mkfs.btrfs", "-L", "SYSTEM"},
+			{"btrfs", "subvolume", "create"},
+		}))
 	})
 })

--- a/pkg/transaction/snapper_update_helper.go
+++ b/pkg/transaction/snapper_update_helper.go
@@ -1,0 +1,302 @@
+/*
+Copyright © 2022-2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transaction
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/suse/elemental/v3/pkg/btrfs"
+	"github.com/suse/elemental/v3/pkg/chroot"
+	"github.com/suse/elemental/v3/pkg/deployment"
+	"github.com/suse/elemental/v3/pkg/fstab"
+	"github.com/suse/elemental/v3/pkg/rsync"
+	"github.com/suse/elemental/v3/pkg/snapper"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"github.com/suse/elemental/v3/pkg/unpack"
+)
+
+func (sc snapperContext) SyncImageContent(imgSrc *deployment.ImageSource, trans *Transaction, fullSync bool) (err error) {
+	defer func() { err = sc.checkCancelled(err) }()
+	if trans.status != started {
+		return fmt.Errorf("given transaction '%d' is not started", trans.ID)
+	}
+	var unpacker unpack.Interface
+
+	sc.s.Logger().Info("Unpacking image source: %s", imgSrc.String())
+	unpacker, err = unpack.NewUnpacker(sc.s, imgSrc)
+	if err != nil {
+		sc.s.Logger().Error("failed initatin image unpacker")
+		return err
+	}
+	digest, err := unpacker.SynchedUnpack(sc.ctx, trans.Path, sc.syncSnapshotExcludes(fullSync), sc.syncSnapshotDeleteExcludes())
+	if err != nil {
+		sc.s.Logger().Error("failed unpacking image to '%s'", trans.Path)
+		return err
+	}
+	imgSrc.SetDigest(digest)
+
+	return nil
+}
+
+func (sc snapperContext) Merge(trans *Transaction) (err error) {
+	defer func() { err = sc.checkCancelled(err) }()
+	if trans.status != started {
+		return fmt.Errorf("given transaction '%d' is not started", trans.ID)
+	}
+
+	sc.s.Logger().Info("Configure snapper")
+	err = sc.configureSnapper(trans)
+	if err != nil {
+		sc.s.Logger().Error("failed configuring snapper")
+		return err
+	}
+
+	sc.s.Logger().Info("Starting 3 way merge of snapshotted rw volumes")
+	err = sc.merge(trans)
+	if err != nil {
+		sc.s.Logger().Error("failed merging content of snapshotted rw volumes")
+	}
+	return err
+}
+
+func (sc snapperContext) UpdateFstab(trans *Transaction) (err error) {
+	defer func() { err = sc.checkCancelled(err) }()
+	if trans.status != started {
+		return fmt.Errorf("given transaction '%d' is not started", trans.ID)
+	}
+
+	sc.s.Logger().Info("Update fstab")
+	if ok, _ := vfs.Exists(sc.s.FS(), filepath.Join(trans.Path, fstab.File)); ok {
+		err = sc.updateFstab(trans)
+		if err != nil {
+			sc.s.Logger().Error("failed updating fstab file")
+
+		}
+		return err
+	}
+	err = sc.createFstab(trans)
+	if err != nil {
+		sc.s.Logger().Error("failed creatingpdating fstab file")
+
+	}
+	return err
+}
+
+func (sc snapperContext) Lock(trans *Transaction) (err error) {
+	defer func() { err = sc.checkCancelled(err) }()
+	if trans.status != started {
+		return fmt.Errorf("given transaction '%d' is not started", trans.ID)
+	}
+
+	sc.s.Logger().Info("Setting new snapshot as read-only")
+	err = sc.snap.SetPermissions(trans.Path, trans.ID, false)
+	if err != nil {
+		sc.s.Logger().Error("failed setting new snapshot as RO")
+	}
+	return err
+}
+
+// syncSnapshotExcludes sets the excluded directories for the image source sync.
+// non snapshotted rw volumes are excluded on upgrades, but included for the very first
+// snapshots at installation time.
+func (sc snapperContext) syncSnapshotExcludes(fullSync bool) []string {
+	excludes := []string{filepath.Join("/", snapper.SnapshotsPath)}
+	for _, part := range sc.partitions {
+		if !fullSync && part.Role != deployment.System && part.MountPoint != "" {
+			excludes = append(excludes, part.MountPoint)
+		}
+		for _, rwVol := range part.RWVolumes {
+			if rwVol.Snapshotted {
+				excludes = append(excludes, filepath.Join(rwVol.Path, snapper.SnapshotsPath))
+			} else if !fullSync {
+				excludes = append(excludes, rwVol.Path)
+			}
+		}
+	}
+	return excludes
+}
+
+// syncSnapshotDeleteExcludes sets the protected paths at sync destination. RW volume
+// paths can't be deleted as part of sync, as they are likely to be mountpoints.
+func (sc snapperContext) syncSnapshotDeleteExcludes() []string {
+	excludes := []string{filepath.Join("/", snapper.SnapshotsPath)}
+	for _, part := range sc.partitions {
+		if part.Role != deployment.System && part.MountPoint != "" {
+			excludes = append(excludes, part.MountPoint)
+		}
+		for _, rwVol := range part.RWVolumes {
+			excludes = append(excludes, rwVol.Path)
+		}
+	}
+	return excludes
+}
+
+// configureSnapper sets the snapper configuration for root and any snapshotted
+// volume.
+func (sc snapperContext) configureSnapper(trans *Transaction) error {
+	err := sc.snap.ConfigureRoot(trans.Path, sc.maxSnapshots)
+	if err != nil {
+		sc.s.Logger().Error("failed setting root configuration for snapper")
+		return err
+	}
+	src := filepath.Join(trans.Path, "../../")
+	target := filepath.Join(trans.Path, snapper.SnapshotsPath)
+	err = vfs.MkdirAll(sc.s.FS(), target, vfs.DirPerm)
+	if err != nil {
+		sc.s.Logger().Error("failed creating snapshots folder into the new root")
+		return err
+	}
+	err = sc.s.Mounter().Mount(src, target, "", []string{"bind"})
+	if err != nil {
+		sc.s.Logger().Error("failed bind mounting snapshots volume to the new root")
+		return err
+	}
+	sc.cleanStack.Push(func() error { return sc.s.Mounter().Unmount(target) })
+	err = sc.configureRWVolumes(trans)
+	if err != nil {
+		sc.s.Logger().Error("failed setting snapshotted subvolumes for snapper")
+		return err
+	}
+	return nil
+}
+
+// configureRWVolumes sets the configuration for the nested snapshotted paths
+func (sc snapperContext) configureRWVolumes(trans *Transaction) error {
+	callback := func() error {
+		for _, rwVol := range sc.partitions.GetSnapshottedVolumes() {
+			err := sc.snap.CreateConfig("/", rwVol.Path)
+			if err != nil {
+				return err
+			}
+			_, err = sc.snap.CreateSnapshot(
+				"/", snapper.ConfigName(rwVol.Path), 0, false,
+				fmt.Sprintf("stock %s contents", rwVol.Path),
+				map[string]string{"stock": "true"},
+			)
+			if err != nil {
+				return err
+			}
+			if _, ok := trans.Merges[rwVol.Path]; ok {
+				trans.Merges[rwVol.Path].New = filepath.Join(
+					trans.Path, rwVol.Path,
+				)
+			}
+		}
+		return nil
+	}
+	return chroot.ChrootedCallback(sc.s, trans.Path, nil, callback, chroot.WithoutDefaultBinds())
+}
+
+// merge runs a 3 way merge for snapshotted RW volumes
+// Current implemementation is dumb, there is no check on potential conflicts
+func (sc snapperContext) merge(trans *Transaction) (err error) {
+	for _, rwVol := range sc.partitions.GetSnapshottedVolumes() {
+		m := trans.Merges[rwVol.Path]
+		if m == nil {
+			continue
+		}
+		r := rsync.NewRsync(sc.s, rsync.WithContext(sc.ctx))
+		err = r.SyncData(m.Modified, m.New, snapper.SnapshotsPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateFstab updates the fstab file with the given transaction data
+func (sc snapperContext) updateFstab(trans *Transaction) error {
+	var oldLines, newLines []fstab.Line
+	for _, part := range sc.partitions {
+		for _, rwVol := range part.RWVolumes {
+			if !rwVol.Snapshotted {
+				continue
+			}
+			subVol := filepath.Join(btrfs.TopSubVol, fmt.Sprintf(snapshotPathTmpl, trans.ID), rwVol.Path)
+			opts := rwVol.MountOpts
+			oldLines = append(oldLines, fstab.Line{MountPoint: rwVol.Path})
+			newLines = append(newLines, fstab.Line{
+				Device:     fmt.Sprintf("UUID=%s", part.UUID),
+				MountPoint: rwVol.Path,
+				Options:    append(opts, fmt.Sprintf("subvol=%s", subVol)),
+				FileSystem: part.FileSystem.String(),
+			})
+		}
+	}
+	fstabFile := filepath.Join(trans.Path, fstab.File)
+	return fstab.UpdateFstab(sc.s, fstabFile, oldLines, newLines)
+}
+
+// createFstab creates the fstab file with the given transaction data
+func (sc snapperContext) createFstab(trans *Transaction) (err error) {
+	var fstabLines []fstab.Line
+	for _, part := range sc.partitions {
+		if part.MountPoint != "" {
+			var line fstab.Line
+
+			opts := part.MountOpts
+			if part.Role == deployment.System {
+				opts = append([]string{"ro"}, opts...)
+				line.FsckOrder = 1
+			} else {
+				line.FsckOrder = 2
+			}
+			if len(opts) == 0 {
+				opts = []string{"defaults"}
+			}
+			line.Device = fmt.Sprintf("UUID=%s", part.UUID)
+			line.MountPoint = part.MountPoint
+			line.Options = opts
+			line.FileSystem = part.FileSystem.String()
+			fstabLines = append(fstabLines, line)
+		}
+		for _, rwVol := range part.RWVolumes {
+			var subVol string
+			var line fstab.Line
+
+			if rwVol.Snapshotted {
+				subVol = filepath.Join(btrfs.TopSubVol, fmt.Sprintf(snapshotPathTmpl, trans.ID), rwVol.Path)
+			} else {
+				subVol = filepath.Join(btrfs.TopSubVol, rwVol.Path)
+			}
+			opts := rwVol.MountOpts
+			opts = append(opts, fmt.Sprintf("subvol=%s", subVol))
+			line.Device = fmt.Sprintf("UUID=%s", part.UUID)
+			line.MountPoint = rwVol.Path
+			line.Options = opts
+			line.FileSystem = part.FileSystem.String()
+			fstabLines = append(fstabLines, line)
+		}
+		if part.Role == deployment.System {
+			var line fstab.Line
+			subVol := filepath.Join(btrfs.TopSubVol, snapper.SnapshotsPath)
+			line.Device = fmt.Sprintf("UUID=%s", part.UUID)
+			line.MountPoint = filepath.Join("/", snapper.SnapshotsPath)
+			line.Options = []string{fmt.Sprintf("subvol=%s", subVol)}
+			line.FileSystem = part.FileSystem.String()
+			fstabLines = append(fstabLines, line)
+		}
+	}
+	err = fstab.WriteFstab(sc.s, filepath.Join(trans.Path, fstab.File), fstabLines)
+	if err != nil {
+		sc.s.Logger().Error("failed writing fstab file")
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is a follow up from https://github.com/SUSE/elemental/pull/74#issuecomment-2865752659 , basically removes the `Update` method from the transaction interface and breaks it into smaller pieces as part of a new `UpgradeHelper` interface. Basically the upgrade helper interface implements the upgrades steps that are coupled to the transaction implementation details (snapper snapshots in this particular case).

Since both interfaces are coupled to its particular implementation an UpgradeHelper instance is returned as part of the `Init` method of the transaction interface. This way it is the transaction implementation who provides a matching helper instance.

Both interfaces implementations are kept together into the same package as they are strictly coupled, in fact, both implementations use the same underlying struct to track internal metadata.

In addition this also collects the upgrade steps into an `Upgrader` object which is is called as part of the upgrade and install processes. So that installation partitions the disk and after that _upgrades_ to the required image.

