### PR TITLE
Set relaxed rsync flags for overlay tree sync

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -138,7 +138,9 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 	}
 
 	if d.OverlayTree != nil && !d.OverlayTree.IsEmpty() {
-		unpacker, err := unpack.NewUnpacker(u.s, d.OverlayTree)
+		unpacker, err := unpack.NewUnpacker(
+			u.s, d.OverlayTree, unpack.WithRsyncFlags(overlayTreeSyncFlags()...),
+		)
 		if err != nil {
 			u.s.Logger().Error("could not initialize unpacker")
 			return err
@@ -201,4 +203,18 @@ func logOutput(s *sys.System, stdOut, stdErr string) {
 	output += stdErr
 	output += "----------------------\n"
 	s.Logger().Debug("Install config hook output:\n%s", output)
+}
+
+// overlayTreeSyncFlags provides the rsync flags that are used to sync directories or raw images
+// during the overlay tree extraction. It does not keep permissions on pre-existing files or
+// directories and it does not keep ownership of files and directories.
+func overlayTreeSyncFlags() []string {
+	return []string{
+		"--recursive",
+		"--hard-links",
+		"--links",
+		"--info=progress2",
+		"--human-readable",
+		"--partial",
+	}
 }


### PR DESCRIPTION
This PR is to enable using `dir://` sources for the `--overlay` flag in install procedures. It basically follows a similar criteria as it is done for tarball sources. Original ownership is not kept and in case of overwrites it does not change pre-existing permissions in target destination.