### PR TITLE
Set default ESP mount-opts to x-systemd.automount

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -368,6 +368,7 @@ func DefaultDeployment() *Deployment {
 					MountPoint: EfiMnt,
 					FileSystem: VFat,
 					Size:       EfiSize,
+					MountOpts:  []string{"defaults", "x-systemd.automount"},
 				}, {
 					Label:      SystemLabel,
 					Role:       System,


### PR DESCRIPTION
This adds an automount unit for the /boot mountpoint which will mount
the ESP when used.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
