### PR TITLE
Introduce Helm chart and Kubernetes manifest deployment logic

### DIFF
--- a/examples/elemental/build/kubernetes.yaml
+++ b/examples/elemental/build/kubernetes.yaml
@@ -1,0 +1,16 @@
+
+manifests:
+  - https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml
+helm:
+  charts:
+    - name: cert-manager
+      chart: cert-manager
+      version: v1.17.2
+      namespace: cert-manager
+      repository: cert-manager-repo
+      values: |-
+        crds:
+          enabled: true
+  repositories:
+    - name: cert-manager-repo
+      url: https://charts.jetstack.io

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -69,7 +69,7 @@ func Run(ctx context.Context, d *image.Definition, buildDir string, system *sys.
 	if needsHelmChartsSetup(&d.Kubernetes, m) {
 		relativeHelmPath := filepath.Join(relativeK8sPath, "helm")
 		if runtimeHelmCharts, err = setupHelmCharts(d, m, overlaysPath, relativeHelmPath); err != nil {
-			logger.Error("Setting up HelmChart resoruces")
+			logger.Error("Setting up Helm charts failed")
 			return err
 		}
 	}
@@ -79,7 +79,7 @@ func Run(ctx context.Context, d *image.Definition, buildDir string, system *sys.
 		relativeManfiestsPath := filepath.Join(relativeK8sPath, "manifests")
 		manifestsOverlayPath := filepath.Join(overlaysPath, relativeManfiestsPath)
 		if err = setupManifests(ctx, system.FS(), &d.Kubernetes, manifestsOverlayPath); err != nil {
-			logger.Error("Setting up Kubernetes manifests")
+			logger.Error("Setting up Kubernetes manifests failed")
 			return err
 		}
 
@@ -91,7 +91,7 @@ func Run(ctx context.Context, d *image.Definition, buildDir string, system *sys.
 		kubernetesOverlayPath := filepath.Join(overlaysPath, relativeK8sPath)
 		scriptInOverlay, err := writeK8sResDeployScript(kubernetesOverlayPath, runtimeManifestsDir, runtimeHelmCharts)
 		if err != nil {
-			logger.Error("Writing Kubernetes resource deployment script")
+			logger.Error("Setting up Kuberentes resource deployment script failed")
 			return err
 		}
 		runtimeK8sResDeployScript = filepath.Join(string(os.PathSeparator), relativeK8sPath, filepath.Base(scriptInOverlay))

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, d *image.Definition, buildDir string, system *sys.
 	}
 
 	var runtimeHelmCharts []string
-	relativeK8sPath := filepath.Join("var", "lib", "unified-core", "kubernetes")
+	relativeK8sPath := filepath.Join("var", "lib", "elemental", "kubernetes")
 	if needsHelmChartsSetup(&d.Kubernetes, m) {
 		relativeHelmPath := filepath.Join(relativeK8sPath, "helm")
 		if runtimeHelmCharts, err = setupHelmCharts(d, m, overlaysPath, relativeHelmPath); err != nil {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -322,7 +322,7 @@ func needsHelmChartsSetup(k *image.Kubernetes, rm *resolver.ResolvedManifest) bo
 }
 
 func needsManifestsSetup(k *image.Kubernetes) bool {
-	return len(k.RemoteManifests) > 0 || len(k.LocalManifest) > 0
+	return len(k.RemoteManifests) > 0 || len(k.LocalManifests) > 0
 }
 
 func setupHelmCharts(d *image.Definition, rm *resolver.ResolvedManifest, overlaysPath, relativeHelmPath string) (runtimeHelmCharts []string, err error) {
@@ -393,7 +393,7 @@ func setupManifests(ctx context.Context, fs vfs.FS, k *image.Kubernetes, manifes
 		}
 	}
 
-	for _, manifest := range k.LocalManifest {
+	for _, manifest := range k.LocalManifests {
 		overlayPath := filepath.Join(manifestsDir, filepath.Base(manifest))
 		if err := vfs.CopyFile(fs, manifest, overlayPath); err != nil {
 			return fmt.Errorf("copying local manifest '%s' to '%s': %w", manifest, overlayPath, err)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -176,13 +176,20 @@ func resolveManifest(manifestURI, storeDir string) (*resolver.ResolvedManifest, 
 	return m, nil
 }
 
-func writeConfigScript(d *image.Definition, dest string) (string, error) {
+func writeConfigScript(d *image.Definition, dest, runtimeK8sResDeployScript string) (string, error) {
 	const configScriptName = "config.sh"
 
 	values := struct {
-		Users []image.User
+		Users                []image.User
+		KubernetesDir        string
+		ManifestDeployScript string
 	}{
 		Users: d.OperatingSystem.Users,
+	}
+
+	if runtimeK8sResDeployScript != "" {
+		values.KubernetesDir = filepath.Dir(runtimeK8sResDeployScript)
+		values.ManifestDeployScript = runtimeK8sResDeployScript
 	}
 
 	data, err := template.Parse(configScriptName, configScriptTpl, &values)

--- a/internal/build/templates/config.sh.tpl
+++ b/internal/build/templates/config.sh.tpl
@@ -7,3 +7,52 @@ set -e
 useradd -m {{ .Username }} || true
 echo '{{ .Username }}:{{ .Password }}' | chpasswd
 {{ end }}
+
+
+{{- if and .KubernetesDir .ManifestDeployScript }}
+cat <<- END > /etc/systemd/system/ensure-sysext.service
+[Unit]
+BindsTo=systemd-sysext.service
+After=systemd-sysext.service
+DefaultDependencies=no
+# Keep in sync with systemd-sysext.service
+ConditionDirectoryNotEmpty=|/etc/extensions
+ConditionDirectoryNotEmpty=|/run/extensions
+ConditionDirectoryNotEmpty=|/var/lib/extensions
+ConditionDirectoryNotEmpty=|/usr/local/lib/extensions
+ConditionDirectoryNotEmpty=|/usr/lib/extensions
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/systemctl daemon-reload
+ExecStart=/usr/bin/systemctl restart --no-block sockets.target timers.target multi-user.target
+[Install]
+WantedBy=sysinit.target
+END
+
+cat << EOF > /etc/systemd/system/k8s-resource-installer.service
+[Unit]
+Description=Kubernetes Resources Installer
+Requires=rke2-server.service
+After=rke2-server.service
+ConditionPathExists=/var/lib/rancher/rke2/bin/kubectl
+ConditionPathExists=/etc/rancher/rke2/rke2.yaml
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=oneshot
+TimeoutSec=900
+Restart=on-failure
+RestartSec=60
+ExecStartPre=/bin/sh -c 'until [ "\$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done'
+ExecStart="{{ .ManifestDeployScript }}"
+ExecStartPost=/bin/sh -c "systemctl disable k8s-resource-installer.service"
+ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-resource-installer.service"
+ExecStartPost=/bin/sh -c 'rm -rf "{{ .KubernetesDir }}"'
+EOF
+
+systemctl enable ensure-sysext.service
+systemctl enable k8s-resource-installer.service
+{{- end }}

--- a/internal/build/templates/k8s_res_deploy.sh.tpl
+++ b/internal/build/templates/k8s_res_deploy.sh.tpl
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KUBE_SYSTEM_NS="kube-system"
+
+kubectl_cmd() {
+  KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl "$@"
+}
+
+waitForHelmChart() {
+  local name="$1"
+  local namespace="${2:-$KUBE_SYSTEM_NS}"
+  local wait="${3:-900s}"
+
+  chart_job=""
+  for i in {1..10}; do
+    chart_job=$(kubectl_cmd get helmcharts "$name" -n "$namespace" -o go-template='{{"{{.status.jobName}}"}}')
+    if [ "$chart_job" != "<no value>" ] && [ -n "$chart_job" ]; then
+      break
+    fi
+
+    echo "[$i/10] '.status.jobName' is not yet present in $name HelmChart. Retrying.."
+    sleep 3
+  done
+
+  if [ -z "$chart_job" ]; then
+    echo "Could not get Job for $name HelmChart"
+    return 1
+  fi
+
+  echo "Waiting for $chart_job HelmChart Job.."
+  if ! kubectl_cmd wait --for=condition=complete --timeout="$wait" job/"$chart_job" -n "$namespace"; then
+    echo "Job $chart_job failed to complete on time"
+    return 1
+  fi
+
+  return 0
+}
+
+{{- if .HelmCharts }}
+deployHelmCharts() {
+  local helmCharts=(
+{{- range .HelmCharts }}
+"{{ . }}"
+{{- end }}
+)
+  local failed=false
+  echo "Deploying HelmCharts.."
+  for chart in "${helmCharts[@]}"; do
+    chart_name=$(kubectl_cmd create --dry-run=client -f "$chart" -o jsonpath='{.metadata.name}')
+    output=$(kubectl_cmd create -f "$chart" 2>&1)
+    if [[ $? -ne 0 ]]; then
+      if ! grep -q "AlreadyExists" <<< "$output"; then
+      failed=true
+      fi
+    fi
+
+    echo "$output"
+    echo "Waiting for $chart_name HelmChart to be available.."
+    if ! waitForHelmChart "$chart_name" "$KUBE_SYSTEM_NS"; then
+        failed=true
+    fi
+  done
+
+  if [ "$failed" = true ]; then
+    exit 1
+  fi
+}
+{{- end }}
+
+{{- if .ManifestsDir }}
+deployManifests() {
+  local failed=false
+  echo "Deploying Kubernetes manifests.."
+  for manifest in {{ .ManifestsDir }}/*.yaml; do
+    output=$(kubectl_cmd create -f "$manifest" 2>&1)
+    if [[ $? -ne 0 ]]; then
+      if ! grep -q "AlreadyExists" <<< "$output"; then
+      failed=true
+      fi
+    fi
+    echo "$output"
+  done
+
+  if [ "$failed" = true ]; then
+    exit 1
+  fi
+}
+{{- end }}
+
+waitForCoreRKE2Charts() {
+  # A running rke2-server.service does not mean that the Helm Controller is ready.
+  # Wait for the Helm Controller to start creating the core RKE2 HelmChart resources.
+  until [[ $(kubectl_cmd get helmcharts -n "$KUBE_SYSTEM_NS" --no-headers 2>/dev/null | wc -l) -gt 0 ]]; do
+    sleep 10
+  done
+
+  local rke2_manifests_dir="/var/lib/rancher/rke2/server/manifests"
+  local rke2_chart_names=""
+  for rke2_file in $rke2_manifests_dir/*.yaml; do
+    # Make sure file is a valid K8s resource
+    if kubectl_cmd create --dry-run=client -f "$rke2_file" > /dev/null 2>&1; then
+      kind=$(kubectl_cmd create --dry-run=client -f "$rke2_file" -o jsonpath="{.kind}" 2>&1)
+      name=$(kubectl_cmd create --dry-run=client -f "$rke2_file" -o jsonpath="{.metadata.name}" 2>&1)
+      if [ "$kind" = "HelmChart" ]; then
+          rke2_chart_names="$rke2_chart_names $name"
+      fi
+    fi
+  done
+
+  echo "Waiting for RKE2 core helm charts"
+  for name in $rke2_chart_names; do
+    if ! waitForHelmChart "$name" "$KUBE_SYSTEM_NS"; then
+      exit 1
+    fi
+  done
+}
+
+waitForCoreRKE2Charts
+
+{{- if .HelmCharts }}
+deployHelmCharts
+{{- end }}
+
+{{- if .ManifestsDir }}
+deployManifests
+{{- end }}

--- a/internal/cli/elemental/action/build.go
+++ b/internal/cli/elemental/action/build.go
@@ -175,7 +175,7 @@ func parseKubernetesDir(configDir image.ConfigDir, k *image.Kubernetes) error {
 
 	for _, entry := range entries {
 		localManifestPath := filepath.Join(configDir.KubernetesManifestsDir(), entry.Name())
-		k.LocalManifest = append(k.LocalManifest, localManifestPath)
+		k.LocalManifests = append(k.LocalManifests, localManifestPath)
 	}
 
 	return nil

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -29,43 +29,36 @@ const (
 )
 
 type CRD struct {
-	APIVersion string `yaml:"apiVersion"`
-	Kind       string `yaml:"kind"`
-	Metadata   struct {
-		Name      string `yaml:"name"`
-		Namespace string `yaml:"namespace,omitempty"`
-	} `yaml:"metadata"`
-	Spec struct {
-		Chart           string `yaml:"chart"`
-		Version         string `yaml:"version"`
-		Repo            string `yaml:"repo,omitempty"`
-		ValuesContent   string `yaml:"valuesContent,omitempty"`
-		TargetNamespace string `yaml:"targetNamespace,omitempty"`
-		CreateNamespace bool   `yaml:"createNamespace,omitempty"`
-		BackOffLimit    int    `yaml:"backOffLimit"`
-	} `yaml:"spec"`
+	APIVersion string   `yaml:"apiVersion"`
+	Kind       string   `yaml:"kind"`
+	Metadata   Metadata `yaml:"metadata"`
+	Spec       CRDSpec  `yaml:"spec"`
+}
+
+type Metadata struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace,omitempty"`
+}
+
+type CRDSpec struct {
+	Chart           string `yaml:"chart"`
+	Version         string `yaml:"version"`
+	Repo            string `yaml:"repo,omitempty"`
+	ValuesContent   string `yaml:"valuesContent,omitempty"`
+	TargetNamespace string `yaml:"targetNamespace,omitempty"`
+	CreateNamespace bool   `yaml:"createNamespace,omitempty"`
+	BackOffLimit    int    `yaml:"backOffLimit"`
 }
 
 func NewHelmCRD(chart *api.HelmChart, repositoryURL string) *CRD {
 	return &CRD{
 		APIVersion: helmChartAPIVersion,
 		Kind:       helmChartKind,
-		Metadata: struct {
-			Name      string `yaml:"name"`
-			Namespace string `yaml:"namespace,omitempty"`
-		}{
+		Metadata: Metadata{
 			Name:      chart.Chart,
 			Namespace: kubeSystemNamespace,
 		},
-		Spec: struct {
-			Chart           string `yaml:"chart"`
-			Version         string `yaml:"version"`
-			Repo            string `yaml:"repo,omitempty"`
-			ValuesContent   string `yaml:"valuesContent,omitempty"`
-			TargetNamespace string `yaml:"targetNamespace,omitempty"`
-			CreateNamespace bool   `yaml:"createNamespace,omitempty"`
-			BackOffLimit    int    `yaml:"backOffLimit"`
-		}{
+		Spec: CRDSpec{
 			Chart:           chart.Chart,
 			Version:         chart.Version,
 			Repo:            repositoryURL,

--- a/internal/image/config.go
+++ b/internal/image/config.go
@@ -38,6 +38,18 @@ func (dir ConfigDir) ReleaseFilepath() string {
 	return filepath.Join(string(dir), "release.yaml")
 }
 
+func (dir ConfigDir) KubernetesFilepath() string {
+	return filepath.Join(string(dir), "kubernetes.yaml")
+}
+
+func (dir ConfigDir) KubernetesDir() string {
+	return filepath.Join(string(dir), "kubernetes")
+}
+
+func (dir ConfigDir) KubernetesManifestsDir() string {
+	return filepath.Join(dir.KubernetesDir(), "manifests")
+}
+
 func ParseConfig(data []byte, target any) error {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)

--- a/internal/image/definition.go
+++ b/internal/image/definition.go
@@ -20,6 +20,8 @@ package image
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/suse/elemental/v3/pkg/manifest/api"
 )
 
 const (
@@ -48,6 +50,7 @@ type Definition struct {
 	Installation    Installation
 	OperatingSystem OperatingSystem
 	Release         Release
+	Kubernetes      Kubernetes
 }
 
 type Image struct {
@@ -80,4 +83,12 @@ type Installation struct {
 type Release struct {
 	Name        string `yaml:"name,omitempty"`
 	ManifestURI string `yaml:"manifestURI"`
+}
+
+type Kubernetes struct {
+	// RemoteManifests - manifest URLs specified under config/kubernetes.yaml
+	RemoteManifests []string  `yaml:"manifests,omitempty"`
+	Helm            *api.Helm `yaml:"helm,omitempty"`
+	// LocalManifests - local manifest files specified under config/kubernetes/manifests
+	LocalManifest []string
 }

--- a/internal/image/definition.go
+++ b/internal/image/definition.go
@@ -90,5 +90,5 @@ type Kubernetes struct {
 	RemoteManifests []string  `yaml:"manifests,omitempty"`
 	Helm            *api.Helm `yaml:"helm,omitempty"`
 	// LocalManifests - local manifest files specified under config/kubernetes/manifests
-	LocalManifest []string
+	LocalManifests []string
 }

--- a/pkg/manifest/api/core/manifest.go
+++ b/pkg/manifest/api/core/manifest.go
@@ -26,12 +26,12 @@ import (
 
 type ReleaseManifest struct {
 	MetaData   *api.MetaData `yaml:"metadata"`
-	Components *Components   `yaml:"components"`
+	Components Components    `yaml:"components"`
 }
 
 type Components struct {
 	OperatingSystem *OperatingSystem `yaml:"operatingSystem"`
-	Kubernetes      *Kubernetes      `yaml:"kubernetes"`
+	Kubernetes      Kubernetes       `yaml:"kubernetes"`
 	Helm            *api.Helm        `yaml:"helm,omitempty"`
 }
 

--- a/pkg/manifest/api/core/manifest_test.go
+++ b/pkg/manifest/api/core/manifest_test.go
@@ -82,9 +82,9 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		Expect(len(rm.Components.Helm.Charts[0].Images)).To(Equal(1))
 		Expect(rm.Components.Helm.Charts[0].Images[0].Name).To(Equal("foo"))
 		Expect(rm.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/foo/foo:0.0.0"))
-		Expect(len(rm.Components.Helm.Repository)).To(Equal(1))
-		Expect(rm.Components.Helm.Repository[0].Name).To(Equal("foo-charts"))
-		Expect(rm.Components.Helm.Repository[0].URL).To(Equal("https://foo.github.io/charts"))
+		Expect(len(rm.Components.Helm.Repositories)).To(Equal(1))
+		Expect(rm.Components.Helm.Repositories[0].Name).To(Equal("foo-charts"))
+		Expect(rm.Components.Helm.Repositories[0].URL).To(Equal("https://foo.github.io/charts"))
 	})
 
 	It("fails when unknown field is introduced", func() {

--- a/pkg/manifest/api/product/manifest.go
+++ b/pkg/manifest/api/product/manifest.go
@@ -27,7 +27,7 @@ import (
 type ReleaseManifest struct {
 	MetaData     *api.MetaData `yaml:"metadata,omitempty"`
 	CorePlatform *CorePlatform `yaml:"corePlatform"`
-	Components   *Components   `yaml:"components,omitempty"`
+	Components   Components    `yaml:"components,omitempty"`
 }
 
 type CorePlatform struct {

--- a/pkg/manifest/api/product/manifest_test.go
+++ b/pkg/manifest/api/product/manifest_test.go
@@ -77,9 +77,9 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		Expect(len(rm.Components.Helm.Charts[0].Images)).To(Equal(1))
 		Expect(rm.Components.Helm.Charts[0].Images[0].Name).To(Equal("bar"))
 		Expect(rm.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/bar/bar:0.0.0"))
-		Expect(len(rm.Components.Helm.Repository)).To(Equal(1))
-		Expect(rm.Components.Helm.Repository[0].Name).To(Equal("bar-charts"))
-		Expect(rm.Components.Helm.Repository[0].URL).To(Equal("https://bar.github.io/charts"))
+		Expect(len(rm.Components.Helm.Repositories)).To(Equal(1))
+		Expect(rm.Components.Helm.Repositories[0].Name).To(Equal("bar-charts"))
+		Expect(rm.Components.Helm.Repositories[0].URL).To(Equal("https://bar.github.io/charts"))
 	})
 
 	It("fails when unknown field is introduced", func() {

--- a/pkg/manifest/api/shared.go
+++ b/pkg/manifest/api/shared.go
@@ -25,8 +25,8 @@ type MetaData struct {
 }
 
 type Helm struct {
-	Charts     []HelmChart  `yaml:"charts"`
-	Repository []Repository `yaml:"repository"`
+	Charts       []HelmChart  `yaml:"charts"`
+	Repositories []Repository `yaml:"repositories"`
 }
 
 type HelmChart struct {
@@ -34,7 +34,7 @@ type HelmChart struct {
 	Chart      string       `yaml:"chart"`
 	Version    string       `yaml:"version"`
 	Namespace  string       `yaml:"namespace,omitempty"`
-	Repository string       `yaml:"repository"`
+	Repository string       `yaml:"repository,omitempty"`
 	Values     string       `yaml:"values,omitempty"`
 	DependsOn  []string     `yaml:"dependsOn,omitempty"`
 	Images     []ChartImage `yaml:"images,omitempty"`

--- a/pkg/manifest/resolver/resolver_test.go
+++ b/pkg/manifest/resolver/resolver_test.go
@@ -174,9 +174,9 @@ func validateResolvedManifest(rm *resolver.ResolvedManifest, coreOnly bool) {
 	Expect(len(rm.CorePlatform.Components.Helm.Charts[0].Images)).To(Equal(1))
 	Expect(rm.CorePlatform.Components.Helm.Charts[0].Images[0].Name).To(Equal("foo"))
 	Expect(rm.CorePlatform.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/foo/foo:0.0.0"))
-	Expect(len(rm.CorePlatform.Components.Helm.Repository)).To(Equal(1))
-	Expect(rm.CorePlatform.Components.Helm.Repository[0].Name).To(Equal("foo-charts"))
-	Expect(rm.CorePlatform.Components.Helm.Repository[0].URL).To(Equal("https://foo.github.io/charts"))
+	Expect(len(rm.CorePlatform.Components.Helm.Repositories)).To(Equal(1))
+	Expect(rm.CorePlatform.Components.Helm.Repositories[0].Name).To(Equal("foo-charts"))
+	Expect(rm.CorePlatform.Components.Helm.Repositories[0].URL).To(Equal("https://foo.github.io/charts"))
 
 	if !coreOnly {
 		Expect(rm.ProductExtension).ToNot(BeNil())
@@ -204,9 +204,9 @@ func validateResolvedManifest(rm *resolver.ResolvedManifest, coreOnly bool) {
 		Expect(len(rm.ProductExtension.Components.Helm.Charts[0].Images)).To(Equal(1))
 		Expect(rm.ProductExtension.Components.Helm.Charts[0].Images[0].Name).To(Equal("bar"))
 		Expect(rm.ProductExtension.Components.Helm.Charts[0].Images[0].Image).To(Equal("registry.com/bar/bar:0.0.0"))
-		Expect(len(rm.ProductExtension.Components.Helm.Repository)).To(Equal(1))
-		Expect(rm.ProductExtension.Components.Helm.Repository[0].Name).To(Equal("bar-charts"))
-		Expect(rm.ProductExtension.Components.Helm.Repository[0].URL).To(Equal("https://bar.github.io/charts"))
+		Expect(len(rm.ProductExtension.Components.Helm.Repositories)).To(Equal(1))
+		Expect(rm.ProductExtension.Components.Helm.Repositories[0].Name).To(Equal("bar-charts"))
+		Expect(rm.ProductExtension.Components.Helm.Repositories[0].URL).To(Equal("https://bar.github.io/charts"))
 	} else {
 		Expect(rm.ProductExtension).To(BeNil())
 	}

--- a/pkg/manifest/testdata/full_core_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_core_release_manifest.yaml
@@ -42,6 +42,6 @@ components:
       images:
       - name: "foo"
         image: "registry.com/foo/foo:0.0.0"
-    repository:
+    repositories:
     - name: "foo-charts"
       url: "https://foo.github.io/charts"

--- a/pkg/manifest/testdata/full_product_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_product_release_manifest.yaml
@@ -38,6 +38,6 @@ components:
       images:
       - name: "bar"
         image: "registry.com/bar/bar:0.0.0"
-    repository:
+    repositories:
     - name: "bar-charts"
       url: "https://bar.github.io/charts"


### PR DESCRIPTION
**Important: This is not the final logic, but a quick implementation that can be showcased as a PoC. As such, most of this code will be reworked/transformed during the Lifecycle Manager implementation.**

This PR introduces the PoC logic for deploying Helm charts and Kubernetes resources. It utilises existing tools in RKE2 such as the [Helm controller](https://github.com/k3s-io/helm-controller) and allows for the following functionality: 
1. Deploy all Helm charts defined in either the `core` or `product` release manifests. 
2. Deploy any Helm chart defined by the user - user defines Helm charts in a file called `kubernetes.yaml`, located inside of the config directory.
3. Deploy both locally and remotely defined Kubernetes manifests:
   * Remote Kubernetes manifests are defined in the `kubernetes.yaml` file.
   * Local Kubernetes manifests are defined in the `<config_dir>/kubernetes/manifests` directory.

The separation of the local/remote manifest definition was done in order to have a distinction between local and remote configurations and also to lay the grounds around unburdening the `kubernetes.yaml` file. If we bundle all configuration inside a file, this file will have the potential to become unmanageable.

Helm/Manifest operation flow during `elemental build`:
1. Parse `kubernetes.yaml` and `kubernetes` local directory
2. Determine whether deployment of Helm charts/K8s manifests is needed at all - only setup necessary resources if `kubernetes.yaml` or `<config>/kubernetes/manifests` are defined
3. For each Helm configuration create a HelmChart CRD under `<build_dir>/overlays/var/lib/elemental/kubernetes/helm`
4. Based on (3), produce an ordered HelmChart deployment list (`core -> product -> user`) - this is a very primitive "depends on" solution that at least ensures that the `core` charts are deployed before the `product` charts, which in turn are deployed before the `user` charts.
5. For remote Kubernetes manifests - download each manifest under `<build_dir>/overlays/var/lib/elemental/kubernetes/manifests`.
6. For local Kubernetes manifests - move each manifest under `<build_dir>/overlays/var/lib/elemental/kubernetes/manifests`.
7. Pass both the Helm chart deployment list and K8s manifests directory (both as seen at runtime) to the new `k8s_res_deploy.sh` script, which is created under  `<build_dir>/overlays/var/lib/elemental/kubernetes`
8. Pass the `k8s_res_deploy.sh` path (as seen in runtime) to the `config.sh` script - the `config.sh` script will create a `k8s-resource-installer.service` that will run `k8s_res_deploy.sh`.

`k8s-resource-installer.service` flow at runtime:
1. Wait for the `rke2-server.service` to be started and become in a "running" state.
2. Wait for the RKE2 Helm controller to begin to create the core RKE2 Helm charts.
3. Wait for all core RKE2 Helm charts to be successfully deployed.
4. Start deploying HelmCharts - operation is sequential, where the service waits for each chart to be successfully deployed, before moving onto the next one.
5.  Start deploying Kubernetes manifests  - here, all manifests are deployed without wait, as it is very hard to know for what to wait for.
6. Cleanup:
  * Disable `k8s-resource-installer.service`
  * Remove `k8s-resource-installer.service` file
  * Remove `<build_dir>/overlays/var/lib/elemental/kubernetes` directory

Limitations:
- Works only on non-air-gapped setups.
