### PR TITLE
Simple 3 way merge for upgrades

### DIFF
--- a/pkg/snapper/snapper.go
+++ b/pkg/snapper/snapper.go
@@ -323,6 +323,23 @@ func (sn Snapper) ConfigureRoot(snapshotPath string, maxSnapshots int) error {
 	return nil
 }
 
+func (sn Snapper) Status(root, config, output string, num1, num2 int) error {
+	args := []string{"--no-dbus"}
+
+	if root != "" && root != "/" {
+		args = append(args, "--root", root)
+	}
+	if config == "" {
+		config = rootConfig
+	}
+	args = append(args, "-c", config, "status", "--output", output, fmt.Sprintf("%d..%d", num1, num2))
+	_, err := sn.s.Runner().RunEnv("snapper", []string{env.CLocale}, args...)
+	if err != nil {
+		return fmt.Errorf("snapper failed to produce status file (%s) between snapshots %d and %d: %w", output, num1, num2, err)
+	}
+	return nil
+}
+
 func unmarshalSnapperList(snapperOut []byte, config string) (Snapshots, error) {
 	var objmap map[string]*json.RawMessage
 	err := json.Unmarshal(snapperOut, &objmap)

--- a/pkg/snapper/snapper_test.go
+++ b/pkg/snapper/snapper_test.go
@@ -212,6 +212,23 @@ var _ = Describe("Snapper", Label("snapper"), func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("snapper modify failed"))
 	})
+	It("runs snapper status and writes to a file", func() {
+		Expect(snap.Status("/some/root", "", "/status_file", 3, 4)).To(Succeed())
+
+		runner.ReturnError = fmt.Errorf("snapper status failed")
+		err := snap.Status("", "etc", "/status_file", 3, 4)
+		Expect(err).To(HaveOccurred())
+
+		Expect(runner.CmdsMatch([][]string{
+			{
+				"snapper", "--no-dbus", "--root", "/some/root",
+				"-c", "root", "status", "--output", "/status_file", "3..4",
+			}, {
+				"snapper", "--no-dbus", "-c", "etc",
+				"status", "--output", "/status_file", "3..4",
+			},
+		})).To(Succeed())
+	})
 	Describe("ListSnapshots", func() {
 		It("gets the list of snapshots", func() {
 			runner.SideEffect = func(_ string, _ ...string) ([]byte, error) {


### PR DESCRIPTION
This commit implements a simple 3 way merge for the snapshotted rw volumes (like it happens for /etc). The current implementation feeds the volume with the contents of the new image and on top of that it applies any modified file comparing former image content versus the current content before the upgrade.

The implementation is based on snapper status reports to list modified and deleted files. Any files listed as a deletion is deleted in target and any modified file is rsynced to the target. So local modifications of mutable files will always "win" vs modifications provided by an upgrade image.

For instance, when you change the contents of /etc in a host, any added, modified or removed files will be applied to the new snapshot on upgrades.