### PR TITLE
Add verify flag to install and upgrade command

### DIFF
--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -32,6 +32,7 @@ import (
 	"github.com/suse/elemental/v3/pkg/install"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"github.com/suse/elemental/v3/pkg/unpack"
 	"github.com/suse/elemental/v3/pkg/upgrade"
 )
 
@@ -68,7 +69,7 @@ func Install(ctx *cli.Context) error { //nolint:dupl
 	}
 
 	manager := firmware.NewEfiBootManager(s)
-	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootManager(manager), upgrade.WithBootloader(bootloader))
+	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootManager(manager), upgrade.WithBootloader(bootloader), upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify)))
 	installer := install.New(ctxCancel, s, install.WithUpgrader(upgrader))
 
 	err = installer.Install(d)

--- a/internal/cli/elemental-toolkit/action/upgrade.go
+++ b/internal/cli/elemental-toolkit/action/upgrade.go
@@ -27,8 +27,8 @@ import (
 	"github.com/suse/elemental/v3/internal/cli/elemental-toolkit/cmd"
 	"github.com/suse/elemental/v3/pkg/bootloader"
 	"github.com/suse/elemental/v3/pkg/deployment"
-	"github.com/suse/elemental/v3/pkg/firmware"
 	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/unpack"
 	"github.com/suse/elemental/v3/pkg/upgrade"
 )
 
@@ -64,8 +64,7 @@ func Upgrade(ctx *cli.Context) error { //nolint:dupl
 		return err
 	}
 
-	manager := firmware.NewEfiBootManager(s)
-	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootManager(manager), upgrade.WithBootloader(bootloader))
+	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootloader(bootloader), upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify)))
 
 	err = upgrader.Upgrade(d)
 	if err != nil {

--- a/internal/cli/elemental-toolkit/cmd/install.go
+++ b/internal/cli/elemental-toolkit/cmd/install.go
@@ -32,6 +32,7 @@ type InstallFlags struct {
 	CreateBootEntry      bool
 	Bootloader           string
 	KernelCmdline        string
+	Verify               bool
 }
 
 var InstallArgs InstallFlags
@@ -87,6 +88,12 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Value:       "",
 				Usage:       "Kernel cmdline for installed system",
 				Destination: &InstallArgs.KernelCmdline,
+			},
+			&cli.BoolFlag{
+				Name:        "verify",
+				Value:       true,
+				Usage:       "Verify OCI ssl",
+				Destination: &InstallArgs.Verify,
 			},
 		},
 	}

--- a/internal/cli/elemental-toolkit/cmd/upgrade.go
+++ b/internal/cli/elemental-toolkit/cmd/upgrade.go
@@ -27,6 +27,7 @@ type UpgradeFlags struct {
 	OperatingSystemImage string
 	ConfigScript         string
 	Overlay              string
+	Verify               bool
 }
 
 var UpgradeArgs UpgradeFlags
@@ -53,6 +54,12 @@ func NewUpgradeCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Name:        "overlay",
 				Usage:       "URI of the overlay content for the OS image",
 				Destination: &UpgradeArgs.Overlay,
+			},
+			&cli.BoolFlag{
+				Name:        "verify",
+				Value:       true,
+				Usage:       "Verify OCI ssl",
+				Destination: &UpgradeArgs.Verify,
 			},
 		},
 	}

--- a/pkg/transaction/mock/snapper.go
+++ b/pkg/transaction/mock/snapper.go
@@ -20,6 +20,7 @@ package mock
 import (
 	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/transaction"
+	"github.com/suse/elemental/v3/pkg/unpack"
 )
 
 type Transactioner struct {
@@ -42,7 +43,7 @@ type UpgradeHelper struct {
 	kernelCmdline string
 }
 
-func (u UpgradeHelper) SyncImageContent(imgSrc *deployment.ImageSource, _ *transaction.Transaction) error {
+func (u UpgradeHelper) SyncImageContent(imgSrc *deployment.ImageSource, _ *transaction.Transaction, _ ...unpack.Opt) error {
 	imgSrc.SetDigest(u.srcDigest)
 	return u.SyncError
 }

--- a/pkg/transaction/snapper_upgrade_helper.go
+++ b/pkg/transaction/snapper_upgrade_helper.go
@@ -39,7 +39,7 @@ import (
 // SyncImageContent syncs the given image tree to given transaction. For the first transaction all content
 // is synced regardless if some paths are under a persistent path or not. On upgrades it only syncs the immutable
 // content and snapshotted paths.
-func (sc snapperContext) SyncImageContent(imgSrc *deployment.ImageSource, trans *Transaction) (err error) {
+func (sc snapperContext) SyncImageContent(imgSrc *deployment.ImageSource, trans *Transaction, opts ...unpack.Opt) (err error) {
 	defer func() { err = sc.checkCancelled(err) }()
 	if trans.status != started {
 		return fmt.Errorf("given transaction '%d' is not started", trans.ID)
@@ -47,7 +47,7 @@ func (sc snapperContext) SyncImageContent(imgSrc *deployment.ImageSource, trans 
 	var unpacker unpack.Interface
 
 	sc.s.Logger().Info("Unpacking image source: %s", imgSrc.String())
-	unpacker, err = unpack.NewUnpacker(sc.s, imgSrc)
+	unpacker, err = unpack.NewUnpacker(sc.s, imgSrc, opts...)
 	if err != nil {
 		return fmt.Errorf("initializing unpacker: %w", err)
 	}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -19,6 +19,7 @@ package transaction
 
 import (
 	"github.com/suse/elemental/v3/pkg/deployment"
+	"github.com/suse/elemental/v3/pkg/unpack"
 )
 
 type transactionState int
@@ -53,7 +54,7 @@ type Interface interface {
 }
 
 type UpgradeHelper interface {
-	SyncImageContent(*deployment.ImageSource, *Transaction) error
+	SyncImageContent(*deployment.ImageSource, *Transaction, ...unpack.Opt) error
 	Merge(*Transaction) error
 	UpdateFstab(*Transaction) error
 	Lock(*Transaction) error


### PR DESCRIPTION
The verify flag is true by default, but can be set to false to enable
pulling images from registries that do not pass ssl verification.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
