### PR TITLE
Add CreateBootEntry flag for upgrade

### DIFF
--- a/internal/cli/elemental-toolkit/action/upgrade.go
+++ b/internal/cli/elemental-toolkit/action/upgrade.go
@@ -27,6 +27,7 @@ import (
 	"github.com/suse/elemental/v3/internal/cli/elemental-toolkit/cmd"
 	"github.com/suse/elemental/v3/pkg/bootloader"
 	"github.com/suse/elemental/v3/pkg/deployment"
+	"github.com/suse/elemental/v3/pkg/firmware"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/unpack"
 	"github.com/suse/elemental/v3/pkg/upgrade"
@@ -101,6 +102,15 @@ func digestUpgradeSetup(s *sys.System, flags *cmd.UpgradeFlags) (*deployment.Dep
 
 	if flags.ConfigScript != "" {
 		d.CfgScript = flags.ConfigScript
+	}
+
+	if flags.CreateBootEntry {
+		if d.Firmware == nil {
+			d.Firmware = &deployment.FirmwareConfig{}
+		}
+		d.Firmware.BootEntries = []*firmware.EfiBootEntry{
+			firmware.DefaultBootEntry(s.Platform(), d.Disks[0].Device),
+		}
 	}
 
 	err = d.Sanitize(s)

--- a/internal/cli/elemental-toolkit/cmd/upgrade.go
+++ b/internal/cli/elemental-toolkit/cmd/upgrade.go
@@ -28,6 +28,7 @@ type UpgradeFlags struct {
 	ConfigScript         string
 	Overlay              string
 	Verify               bool
+	CreateBootEntry      bool
 }
 
 var UpgradeArgs UpgradeFlags
@@ -60,6 +61,11 @@ func NewUpgradeCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Value:       true,
 				Usage:       "Verify OCI ssl",
 				Destination: &UpgradeArgs.Verify,
+			},
+			&cli.BoolFlag{
+				Name:        "create-boot-entry",
+				Usage:       "Create EFI boot entry",
+				Destination: &UpgradeArgs.CreateBootEntry,
 			},
 		},
 	}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -170,6 +170,13 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 		return fmt.Errorf("installing bootloader: %w", err)
 	}
 
+	if d.Firmware != nil {
+		err = u.bm.CreateBootEntries(d.Firmware.BootEntries)
+		if err != nil {
+			return fmt.Errorf("creating EFI boot entries: %w", err)
+		}
+	}
+
 	err = u.t.Commit(trans)
 	if err != nil {
 		return fmt.Errorf("committing transaction: %w", err)


### PR DESCRIPTION
The actual call to bootmanager.CreateBootEntries was never added in the
original firmware PR, add it now and add CreateBootEntry flag to Upgrade
command.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
