### PR TITLE
grub: Check if SLE theme directory exists

### DIFF
--- a/pkg/bootloader/grub.cfg
+++ b/pkg/bootloader/grub.cfg
@@ -95,13 +95,16 @@ done
 
 insmod part_gpt
 insmod gfxmenu
-loadfont ($root)/grub2/themes/SLE/DejaVuSans-Bold14.pf2
-loadfont ($root)/grub2/themes/SLE/DejaVuSans10.pf2
-loadfont ($root)/grub2/themes/SLE/DejaVuSans12.pf2
-loadfont ($root)/grub2/themes/SLE/ascii.pf2
 insmod png
-set theme=($root)/grub2/themes/SLE/theme.txt
-export theme
+
+if [ -d "($root)/grub2/themes/SLE" ]; then
+  loadfont ($root)/grub2/themes/SLE/DejaVuSans-Bold14.pf2
+  loadfont ($root)/grub2/themes/SLE/DejaVuSans10.pf2
+  loadfont ($root)/grub2/themes/SLE/DejaVuSans12.pf2
+  loadfont ($root)/grub2/themes/SLE/ascii.pf2
+  set theme=($root)/grub2/themes/SLE/theme.txt
+  export theme
+fi
 
 set default_timeout=10
 if [ ! -z "${timeout}" ]; then


### PR DESCRIPTION
Check that the ($root)/grub2/themes/SLE directory exists before trying
to load fonts and themes.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
