### PR TITLE
Restructure build package

### DIFF
--- a/internal/build/config.go
+++ b/internal/build/config.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	_ "embed"
+	"fmt"
+	"path/filepath"
+
+	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/os"
+	"github.com/suse/elemental/v3/internal/template"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+//go:embed templates/config.sh.tpl
+var configScriptTpl string
+
+func writeConfigScript(fs vfs.FS, def *image.Definition, destDir, k8sResourceDeployScript string) (string, error) {
+	const configScriptName = "config.sh"
+
+	values := struct {
+		Users                []os.User
+		KubernetesDir        string
+		ManifestDeployScript string
+	}{
+		Users: def.OperatingSystem.Users,
+	}
+
+	if k8sResourceDeployScript != "" {
+		// TODO: Ensure passing a plain filename is not allowed as the KubernetesDir is used for a cleanup
+		values.KubernetesDir = filepath.Dir(k8sResourceDeployScript)
+		values.ManifestDeployScript = k8sResourceDeployScript
+	}
+
+	data, err := template.Parse(configScriptName, configScriptTpl, &values)
+	if err != nil {
+		return "", fmt.Errorf("parsing config script template: %w", err)
+	}
+
+	filename := filepath.Join(destDir, configScriptName)
+	if err = fs.WriteFile(filename, []byte(data), 0o744); err != nil {
+		return "", fmt.Errorf("writing config script: %w", err)
+	}
+	return filename, nil
+}

--- a/internal/build/config_test.go
+++ b/internal/build/config_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/os"
+	"github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+var _ = Describe("Config tests", func() {
+	const buildDir = "/_build"
+
+	var fs vfs.FS
+	var cleanup func()
+	var err error
+
+	BeforeEach(func() {
+		fs, cleanup, err = mock.TestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(vfs.MkdirAll(fs, buildDir, vfs.DirPerm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("Fails writing config script to the FS", func() {
+		fs, err = mock.ReadOnlyTestFS(fs)
+		Expect(err).NotTo(HaveOccurred())
+
+		definition := &image.Definition{}
+
+		script, err := writeConfigScript(fs, definition, buildDir, "")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("writing config script: WriteFile /_build/config.sh: operation not permitted"))
+		Expect(script).To(BeEmpty())
+	})
+
+	It("Succeeds writing config script to the filesystem without Kubernetes manifests", func() {
+		definition := &image.Definition{
+			OperatingSystem: os.OperatingSystem{
+				Users: []os.User{
+					{Username: "root", Password: "linux"},
+					{Username: "suse", Password: "suse"},
+				},
+			},
+		}
+
+		script, err := writeConfigScript(fs, definition, buildDir, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(script).To(Equal("/_build/config.sh"))
+
+		info, err := fs.Stat(script)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(int(info.Mode())).To(Equal(0o744), "Verifying permissions")
+
+		b, err := fs.ReadFile(script)
+		Expect(err).NotTo(HaveOccurred(), "Reading contents")
+
+		contents := string(b)
+
+		// Users
+		Expect(contents).To(ContainSubstring("useradd -m root || true"))
+		Expect(contents).To(ContainSubstring("echo 'root:linux' | chpasswd"))
+		Expect(contents).To(ContainSubstring("useradd -m suse || true"))
+		Expect(contents).To(ContainSubstring("echo 'suse:suse' | chpasswd"))
+
+		// Kubernetes
+		Expect(contents).NotTo(ContainSubstring("/etc/systemd/system/k8s-resource-installer.service"))
+	})
+
+	It("Succeeds writing config script to the filesystem with Kubernetes manifests", func() {
+		definition := &image.Definition{
+			OperatingSystem: os.OperatingSystem{
+				Users: []os.User{
+					{Username: "root", Password: "linux"},
+					{Username: "suse", Password: "suse"},
+				},
+			},
+		}
+
+		script, err := writeConfigScript(fs, definition, buildDir, "/var/lib/elemental/k8s-resources.sh")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(script).To(Equal("/_build/config.sh"))
+
+		info, err := fs.Stat(script)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(int(info.Mode())).To(Equal(0o744), "Verifying permissions")
+
+		b, err := fs.ReadFile(script)
+		Expect(err).NotTo(HaveOccurred(), "Reading contents")
+
+		contents := string(b)
+
+		// Users
+		Expect(contents).To(ContainSubstring("useradd -m root || true"))
+		Expect(contents).To(ContainSubstring("echo 'root:linux' | chpasswd"))
+		Expect(contents).To(ContainSubstring("useradd -m suse || true"))
+		Expect(contents).To(ContainSubstring("echo 'suse:suse' | chpasswd"))
+
+		// Kubernetes
+		Expect(contents).To(ContainSubstring("/etc/systemd/system/k8s-resource-installer.service"))
+		Expect(contents).To(ContainSubstring("ExecStart=\"/var/lib/elemental/k8s-resources.sh\""))
+		Expect(contents).To(ContainSubstring("ExecStartPost=/bin/sh -c 'rm -rf \"/var/lib/elemental\""))
+	})
+})

--- a/internal/build/helm.go
+++ b/internal/build/helm.go
@@ -53,6 +53,16 @@ type Helm struct {
 	Logger         log.Logger
 }
 
+func NewHelm(fs vfs.FS, valuesResolver helmValuesResolver, logger log.Logger, destinationDir string) *Helm {
+	return &Helm{
+		FS:             fs,
+		RelativePath:   image.HelmPath(),
+		DestinationDir: destinationDir,
+		ValuesResolver: valuesResolver,
+		Logger:         logger,
+	}
+}
+
 func needsHelmChartsSetup(def *image.Definition) bool {
 	return len(def.Release.Core.Helm) > 0 || len(def.Release.Product.Helm) > 0 || def.Kubernetes.Helm != nil
 }

--- a/internal/build/kubernetes_test.go
+++ b/internal/build/kubernetes_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/kubernetes"
+	"github.com/suse/elemental/v3/internal/image/release"
+)
+
+var _ = Describe("Kubernetes tests", func() {
+	Describe("Resources trigger", func() {
+		It("Skips manifests setup if manifests are not provided", func() {
+			k := &kubernetes.Kubernetes{}
+			Expect(needsManifestsSetup(k)).To(BeFalse())
+		})
+
+		It("Requires manifests setup if local manifests are provided", func() {
+			k := &kubernetes.Kubernetes{
+				LocalManifests: []string{"/apache.yaml"},
+			}
+			Expect(needsManifestsSetup(k)).To(BeTrue())
+		})
+
+		It("Requires manifests setup if remote manifests are provided", func() {
+			k := &kubernetes.Kubernetes{
+				RemoteManifests: []string{"https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml"},
+			}
+			Expect(needsManifestsSetup(k)).To(BeTrue())
+		})
+
+		It("Skips Helm setup if charts are not provided", func() {
+			def := &image.Definition{}
+			Expect(needsHelmChartsSetup(def)).To(BeFalse())
+		})
+
+		It("Requires Helm setup if user charts are provided", func() {
+			def := &image.Definition{
+				Kubernetes: kubernetes.Kubernetes{
+					Helm: &kubernetes.Helm{
+						Charts: []*kubernetes.HelmChart{
+							{Name: "apache", RepositoryName: "apache-repo"},
+						},
+					},
+				},
+			}
+			Expect(needsHelmChartsSetup(def)).To(BeTrue())
+		})
+
+		It("Requires Helm setup if core charts are provided", func() {
+			def := &image.Definition{
+				Release: release.Release{
+					Core: release.Components{
+						Helm: []release.HelmChart{
+							{
+								Name: "metallb",
+							},
+						},
+					},
+				},
+			}
+
+			Expect(needsHelmChartsSetup(def)).To(BeTrue())
+		})
+
+		It("Requires Helm setup if product charts are provided", func() {
+			def := &image.Definition{
+				Release: release.Release{
+					Product: release.Components{
+						Helm: []release.HelmChart{
+							{
+								Name: "rancher",
+							},
+						},
+					},
+				},
+			}
+
+			Expect(needsHelmChartsSetup(def)).To(BeTrue())
+		})
+	})
+})

--- a/internal/cli/elemental/action/build.go
+++ b/internal/cli/elemental/action/build.go
@@ -35,6 +35,7 @@ import (
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/pkg/helm"
+	"github.com/suse/elemental/v3/pkg/http"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/platform"
 )
@@ -78,8 +79,9 @@ func Build(ctx *cli.Context) error {
 	}
 
 	builder := &build.Builder{
-		System: system,
-		Helm:   build.NewHelm(system.FS(), valuesResolver, system.Logger(), buildDir.OverlaysDir()),
+		System:       system,
+		Helm:         build.NewHelm(system.FS(), valuesResolver, system.Logger(), buildDir.OverlaysDir()),
+		DownloadFile: http.DownloadFile,
 	}
 
 	logger.Info("Starting build process for %s %s image", definition.Image.Platform.String(), definition.Image.ImageType)

--- a/internal/image/config.go
+++ b/internal/image/config.go
@@ -64,6 +64,10 @@ func (dir BuildDir) ReleaseManifestsDir() string {
 	return filepath.Join(string(dir), "release-manifests")
 }
 
+func ExtensionsPath() string {
+	return filepath.Join("var", "lib", "extensions")
+}
+
 func KubernetesPath() string {
 	return filepath.Join("var", "lib", "elemental", "kubernetes")
 }

--- a/internal/image/config.go
+++ b/internal/image/config.go
@@ -54,6 +54,28 @@ func (dir ConfigDir) HelmValuesDir() string {
 	return filepath.Join(dir.kubernetesDir(), "helm", "values")
 }
 
+type BuildDir string
+
+func (dir BuildDir) OverlaysDir() string {
+	return filepath.Join(string(dir), "overlays")
+}
+
+func (dir BuildDir) ReleaseManifestsDir() string {
+	return filepath.Join(string(dir), "release-manifests")
+}
+
+func KubernetesPath() string {
+	return filepath.Join("var", "lib", "elemental", "kubernetes")
+}
+
+func KubernetesManifestsPath() string {
+	return filepath.Join(KubernetesPath(), "manifests")
+}
+
+func HelmPath() string {
+	return filepath.Join(KubernetesPath(), "helm")
+}
+
 func ParseConfig(data []byte, target any) error {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)

--- a/pkg/http/download.go
+++ b/pkg/http/download.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+func DownloadFile(ctx context.Context, fs vfs.FS, url, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	httpClient := &http.Client{Timeout: 90 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	file, err := fs.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating file: %w", err)
+	}
+
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		_ = file.Close()
+		return fmt.Errorf("copying file contents: %w", err)
+	}
+
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("closing file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/http/download_test.go
+++ b/pkg/http/download_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/sys/mock"
+)
+
+func TestDownloadSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Download test suite")
+}
+
+var _ = Describe("Invalid download attempts", func() {
+	It("Fails to create a request for nil context", func() {
+		err := DownloadFile(nil, nil, "", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("creating request: net/http: nil Context"))
+	})
+
+	It("Fails to execute a request for invalid URL", func() {
+		err := DownloadFile(context.Background(), nil, "invalid-url", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("executing request: Get \"invalid-url\": unsupported protocol scheme \"\""))
+	})
+
+	It("Fails to download a request due to unexpected status code", func() {
+		url := "https://github.com/suse/elemental3"
+		err := DownloadFile(context.Background(), nil, url, "")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("unexpected status code: 404"))
+	})
+
+	It("Fails to create output file", func() {
+		fs, cleanup, err := mock.TestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanup)
+
+		url := "https://github.com/suse/elemental"
+		err = DownloadFile(context.Background(), fs, url, "downloads/abc")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("creating file: Create downloads/abc: operation not permitted"))
+	})
+})


### PR DESCRIPTION
- Introduces a Builder type in order to simplify the build execution process
- Introduces a Helm type in order to abstract away the functionality around Helm charts
- Introduces an HTTP downloader logic that is going to be used across the various steps of the build process
- Splits up the Kubernetes configuration flow
- Adds wrappers around the build directory and known relative directory usages
- Adds unit tests for the large majority of the build functionality