### PR TITLE
Add --local flag to install, upgrade and build commands

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -33,6 +33,7 @@ import (
 	"github.com/suse/elemental/v3/pkg/manifest/source"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"github.com/suse/elemental/v3/pkg/unpack"
 	"github.com/suse/elemental/v3/pkg/upgrade"
 )
 
@@ -46,6 +47,7 @@ type Builder struct {
 	System       *sys.System
 	Helm         helmConfigurator
 	DownloadFile downloadFunc
+	Local        bool
 }
 
 func (b *Builder) Run(ctx context.Context, d *image.Definition, buildDir image.BuildDir) error {
@@ -113,7 +115,10 @@ func (b *Builder) Run(ctx context.Context, d *image.Definition, buildDir image.B
 	}
 
 	manager := firmware.NewEfiBootManager(b.System)
-	upgrader := upgrade.New(ctx, b.System, upgrade.WithBootManager(manager), upgrade.WithBootloader(boot))
+	upgrader := upgrade.New(
+		ctx, b.System, upgrade.WithBootManager(manager), upgrade.WithBootloader(boot),
+		upgrade.WithUnpackOpts(unpack.WithLocal(b.Local)),
+	)
 	installer := install.New(ctx, b.System, install.WithUpgrader(upgrader))
 
 	logger.Info("Installing OS")

--- a/internal/cli/elemental-toolkit/action/install.go
+++ b/internal/cli/elemental-toolkit/action/install.go
@@ -69,7 +69,10 @@ func Install(ctx *cli.Context) error { //nolint:dupl
 	}
 
 	manager := firmware.NewEfiBootManager(s)
-	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootManager(manager), upgrade.WithBootloader(bootloader), upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify)))
+	upgrader := upgrade.New(
+		ctxCancel, s, upgrade.WithBootManager(manager), upgrade.WithBootloader(bootloader),
+		upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify), unpack.WithLocal(args.Local)),
+	)
 	installer := install.New(ctxCancel, s, install.WithUpgrader(upgrader))
 
 	err = installer.Install(d)

--- a/internal/cli/elemental-toolkit/action/upgrade.go
+++ b/internal/cli/elemental-toolkit/action/upgrade.go
@@ -65,7 +65,10 @@ func Upgrade(ctx *cli.Context) error { //nolint:dupl
 		return err
 	}
 
-	upgrader := upgrade.New(ctxCancel, s, upgrade.WithBootloader(bootloader), upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify)))
+	upgrader := upgrade.New(
+		ctxCancel, s, upgrade.WithBootloader(bootloader),
+		upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify), unpack.WithLocal(args.Local)),
+	)
 
 	err = upgrader.Upgrade(d)
 	if err != nil {

--- a/internal/cli/elemental-toolkit/cmd/install.go
+++ b/internal/cli/elemental-toolkit/cmd/install.go
@@ -33,6 +33,7 @@ type InstallFlags struct {
 	Bootloader           string
 	KernelCmdline        string
 	Verify               bool
+	Local                bool
 }
 
 var InstallArgs InstallFlags
@@ -94,6 +95,11 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Value:       true,
 				Usage:       "Verify OCI ssl",
 				Destination: &InstallArgs.Verify,
+			},
+			&cli.BoolFlag{
+				Name:        "local",
+				Usage:       "Load OCI images from the local container storage instead of a remote registry",
+				Destination: &InstallArgs.Local,
 			},
 		},
 	}

--- a/internal/cli/elemental-toolkit/cmd/upgrade.go
+++ b/internal/cli/elemental-toolkit/cmd/upgrade.go
@@ -29,6 +29,7 @@ type UpgradeFlags struct {
 	Overlay              string
 	Verify               bool
 	CreateBootEntry      bool
+	Local                bool
 }
 
 var UpgradeArgs UpgradeFlags
@@ -66,6 +67,11 @@ func NewUpgradeCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Name:        "create-boot-entry",
 				Usage:       "Create EFI boot entry",
 				Destination: &UpgradeArgs.CreateBootEntry,
+			},
+			&cli.BoolFlag{
+				Name:        "local",
+				Usage:       "Load OCI images from the local container storage instead of a remote registry",
+				Destination: &UpgradeArgs.Local,
 			},
 		},
 	}

--- a/internal/cli/elemental/action/build.go
+++ b/internal/cli/elemental/action/build.go
@@ -82,6 +82,7 @@ func Build(ctx *cli.Context) error {
 		System:       system,
 		Helm:         build.NewHelm(system.FS(), valuesResolver, system.Logger(), buildDir.OverlaysDir()),
 		DownloadFile: http.DownloadFile,
+		Local:        args.Local,
 	}
 
 	logger.Info("Starting build process for %s %s image", definition.Image.Platform.String(), definition.Image.ImageType)

--- a/internal/cli/elemental/cmd/build.go
+++ b/internal/cli/elemental/cmd/build.go
@@ -30,6 +30,7 @@ type BuildFlags struct {
 	ConfigDir  string
 	BuildDir   string
 	OutputPath string
+	Local      bool
 }
 
 var BuildArgs BuildFlags
@@ -71,6 +72,11 @@ func NewBuildCommand(appName string, action func(*cli.Context) error) *cli.Comma
 				Usage:       "Filepath for the output image",
 				Destination: &BuildArgs.OutputPath,
 				DefaultText: "image-<timestamp>.<image-type>",
+			},
+			&cli.BoolFlag{
+				Name:        "local",
+				Usage:       "Load OCI images from the local container storage instead of a remote registry",
+				Destination: &BuildArgs.Local,
 			},
 		},
 	}

--- a/pkg/unpack/oci.go
+++ b/pkg/unpack/oci.go
@@ -160,10 +160,8 @@ func (o OCI) Unpack(ctx context.Context, destination string) (string, error) {
 }
 
 func fetchImage(ctx context.Context, ref name.Reference, platform containerregistry.Platform, local bool) (containerregistry.Image, error) {
-	// Always attempt to fetch the image locally first.
-	image, err := daemon.Image(ref, daemon.WithContext(ctx))
-	if err == nil || local {
-		return image, err
+	if local {
+		return daemon.Image(ref, daemon.WithContext(ctx))
 	}
 
 	return remote.Image(ref,


### PR DESCRIPTION
This flag forces the OCI unpack process to look for the given image in the local container storage. The library expects a daemon accessible through a socket typically defined by the DOCKER_HOST environment variable.

This commit also changes the behavior of attempting to find the image first in the local storage and fallback to remote if not present. With this change there is no fallback logic and pulling a remote or local image is always an explicit choice.

The PR is a follow up according to the discussion in https://github.com/SUSE/elemental/pull/106#pullrequestreview-2900406375