### PR TITLE
Add quick-start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Elemental is a tool for installing, configuring and updating operating system im
 *   **Updates:** Update an existing OS installation from a newer image.
 *   **Extensibility:** Extend the OS installation image with extensions.
 
+## Quick-start
+
+Elemental can be used to convert an OCI image into a bootable disk-image. This requires that the OCI image actually contains a bootloader, kernel, initrd and init-system. In this quick-start we will use the [tumbleweed example](./examples/tumbleweed/Dockerfile).
+
+```sh
+$ make # build elemental binaries
+$ docker build -f ./examples/tumbleweed/Dockerfile -t elemental-tumbleweed:latest ./examples/tumbleweed
+$ qemu-img create -f raw build/elemental-tumbleweed.img 10G
+$ sudo losetup --show -f build/elemental-tumbleweed.img # make a not of the device-name
+$ sudo ./build/elemental3-toolkit install --os-image=elemental-tumbleweed:latest --config=examples/tumbleweed/config.sh --target /dev/loopX # use the loopback-device printed in previous step.
+$ sudo losetup -d /dev/loopX
+```
+
+After the image is built we can boot it using QEMU:
+
+```sh
+qemu-kvm -m 4096 -hda build/elemental-tumbleweed.img -bios /usr/share/qemu/ovmf-x86_64.bin -cpu host
+```
+
 ## Contribution
 
 For contributing to Elemental, please create a fork of the repository and send a Pull Request (PR). A number of GitHub Actions will be triggered on the PR and they need to pass.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Elemental can be used to convert an OCI image into a bootable disk-image. This r
 $ make # build elemental binaries
 $ docker build -f ./examples/tumbleweed/Dockerfile -t elemental-tumbleweed:latest ./examples/tumbleweed
 $ qemu-img create -f raw build/elemental-tumbleweed.img 10G
-$ sudo losetup --show -f build/elemental-tumbleweed.img # make a not of the device-name
+$ sudo losetup --show -f build/elemental-tumbleweed.img # make a note of the device-name
 $ sudo ./build/elemental3-toolkit install --os-image=elemental-tumbleweed:latest --config=examples/tumbleweed/config.sh --target /dev/loopX # use the loopback-device printed in previous step.
 $ sudo losetup -d /dev/loopX
 ```

--- a/examples/tumbleweed/Dockerfile
+++ b/examples/tumbleweed/Dockerfile
@@ -1,0 +1,61 @@
+FROM registry.opensuse.org/opensuse/tumbleweed:latest AS builder
+
+RUN zypper --non-interactive --gpg-auto-import-keys --installroot /target install --no-recommends -- \
+      patterns-base-minimal_base \
+      kernel-default \
+      dbus-broker \
+      device-mapper \
+      dracut \
+      grub2 \
+      grub2-x86_64-efi \
+      haveged \
+      systemd \
+      NetworkManager \
+      openssh-server \
+      openssh-clients \
+      timezone \
+      parted \
+      e2fsprogs \
+      dosfstools \
+      mtools \
+      xorriso \
+      findutils \
+      gptfdisk \
+      rsync \
+      squashfs \
+      lvm2 \
+      tar \
+      gzip \
+      vim \
+      which \
+      less \
+      sudo \
+      shim \
+      curl \
+      sed \
+      iproute2 \
+      btrfsprogs \
+      btrfsmaintenance \
+      snapper \
+      xterm-resize
+
+# make sure /boot is empty, elemental will install artifacts here.
+RUN rm -rf /target/boot && mkdir /target/boot
+
+FROM scratch
+COPY --from=builder /target /
+
+# Enable essential services
+RUN systemctl enable NetworkManager.service && \
+    systemctl enable sshd.service
+
+# Workaround to make sure there are no pending sysusers to be created (boo#1231244)
+RUN systemd-sysusers
+
+# This is for automatic testing purposes, do not do this in production.
+RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
+
+
+# Generate initrd in /usr/lib/modules/*
+RUN kver=$(ls /usr/lib/modules | head -n1) && \ 
+    dracut -f --no-hostonly "/usr/lib/modules/${kver}/initrd" "${kver}"

--- a/examples/tumbleweed/config.sh
+++ b/examples/tumbleweed/config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -x
+
+set -e
+
+# Set root password
+echo "linux" | passwd root --stdin
+
+# Enabling services
+systemctl enable NetworkManager.service
+systemctl enable systemd-sysext.service
+


### PR DESCRIPTION
The quick-start aims to easily build and boot a freely available OS
(openSUSE Tumbleweed) with as few moving parts as possible.

Right now the `build`-command is not flexible enough to generate an
image with only freely available components, so we have to use the
losetup trick to create the image.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
