### PR TITLE
Split mounter compiler targets

### DIFF
--- a/pkg/sys/mounter/mounter.go
+++ b/pkg/sys/mounter/mounter.go
@@ -19,10 +19,6 @@ package mounter
 
 import "k8s.io/mount-utils"
 
-const (
-	Binary = "/usr/bin/mount"
-)
-
 type Interface interface {
 	Mount(source string, target string, fstype string, options []string) error
 	Unmount(target string) error
@@ -45,18 +41,6 @@ type MountPoint struct {
 
 type Mounter struct {
 	mnt mount.Interface
-}
-
-func NewMounter(binary string) Interface {
-	return &Mounter{
-		mnt: mount.NewWithoutSystemd(binary),
-	}
-}
-
-func NewDummyMounter() *Mounter {
-	return &Mounter{
-		mnt: mount.NewFakeMounter([]mount.MountPoint{}),
-	}
 }
 
 func (m Mounter) Mount(source string, target string, fstype string, options []string) error {

--- a/pkg/sys/mounter/mounter_darwin.go
+++ b/pkg/sys/mounter/mounter_darwin.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounter
+
+import "k8s.io/mount-utils"
+
+func NewMounter() *Mounter {
+	return &Mounter{
+		// Darwin systems are not considered to be fully supported.
+		// Use a mock implementation to allow for local development and testing purposes.
+		mnt: mount.NewFakeMounter([]mount.MountPoint{}),
+	}
+}

--- a/pkg/sys/mounter/mounter_linux.go
+++ b/pkg/sys/mounter/mounter_linux.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounter
+
+import "k8s.io/mount-utils"
+
+const binary = "/usr/bin/mount"
+
+func NewMounter() *Mounter {
+	return &Mounter{
+		mnt: mount.NewWithoutSystemd(binary),
+	}
+}

--- a/pkg/sys/system.go
+++ b/pkg/sys/system.go
@@ -105,7 +105,7 @@ func NewSystem(opts ...SystemOpts) (*System, error) {
 		fs:      vfs.New(),
 		logger:  logger,
 		syscall: syscall.Syscall(),
-		mounter: mounter.NewMounter(mounter.Binary),
+		mounter: mounter.NewMounter(),
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
Using macOS for local development is inconvenient as the Mounter type uses Linux-only sources. The creation of Mounter is now split up between a Linux and a Darwin implementations where the latter is using a mock.