### PR TITLE
Add quick-start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ Elemental is a tool for installing, configuring and updating operating system im
 *   **Updates:** Update an existing OS installation from a newer image.
 *   **Extensibility:** Extend the OS installation image with extensions.
 
+## Quick-start
+
+Elemental can be used to convert an OCI image into a bootable disk-image. This requires that the OCI image actually contains a bootloader, kernel, initrd and init-system. In this quick-start we will use the tumbleweed example.
+
+```sh
+$ make # build elemental binaries
+$ qemu-img create -f raw build/elemental-tumbleweed.img 10G
+$ sudo losetup --show -f build/elemental-tumbleweed.img # make a note of the device-name
+$ sudo ./build/elemental3-toolkit install --os-image=registry.opensuse.org/devel/unifiedcore/tumbleweed/containers/uc-base-os-kernel-default:0.0.1 --config=examples/tumbleweed/config.sh --target /dev/loopX # use the loopback-device printed in previous step.
+$ sudo losetup -d /dev/loopX
+```
+
+After the image is built we can boot it using QEMU:
+
+```sh
+qemu-kvm -m 4096 -hda build/elemental-tumbleweed.img -bios /usr/share/qemu/ovmf-x86_64.bin -cpu host
+```
+
 ## Contribution
 
 For contributing to Elemental, please create a fork of the repository and send a Pull Request (PR). A number of GitHub Actions will be triggered on the PR and they need to pass.


### PR DESCRIPTION
New PR to make the modifications requested in the original PR #137 

The quick-start aims to easily build and boot a freely available OS
(openSUSE Tumbleweed) with as few moving parts as possible.

Right now the build-command is not flexible enough to generate an
image with only freely available components, so we have to use the
losetup trick to create the image.