### PR TITLE
Add missing boot manager to the upgrader initialisation

### DIFF
--- a/internal/cli/elemental-toolkit/action/upgrade.go
+++ b/internal/cli/elemental-toolkit/action/upgrade.go
@@ -65,8 +65,9 @@ func Upgrade(ctx *cli.Context) error { //nolint:dupl
 		return err
 	}
 
+	manager := firmware.NewEfiBootManager(s)
 	upgrader := upgrade.New(
-		ctxCancel, s, upgrade.WithBootloader(bootloader),
+		ctxCancel, s, upgrade.WithBootloader(bootloader), upgrade.WithBootManager(manager),
 		upgrade.WithUnpackOpts(unpack.WithVerify(args.Verify), unpack.WithLocal(args.Local)),
 	)
 


### PR DESCRIPTION
## Problem

With the current implementation, the `elemental3-toolkit upgrade` command fails with the following error:

```shell
...
INFO[0197] Setting new snapshot as read-only
INFO[0197] Setting permissions to snapshot
INFO[0197] Installing GRUB bootloader to partition 'EFI'
INFO[0197] Installing EFI applications
INFO[0197] Syncing grub2 directory to ESP...
INFO[0197] Starting rsync...
INFO[0198] Finished syncing
INFO[0198] Installing kernel/initrd
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x64f815]

goroutine 1 [running]:
github.com/suse/elemental/v3/pkg/firmware.(*EfiBootManager).CreateBootEntries(0x0, {0x10b3560, 0x0, 0xb4f89c?})
	/home/opensuse/REPOS/elemental/pkg/firmware/efi_manager.go:56 +0x35
github.com/suse/elemental/v3/pkg/upgrade.Upgrader.Upgrade({{0xc22d40, 0xc0001d6a40}, 0xc00007c4e0, {0xc22de8, 0xc0001f8080}, 0x0, {0xc1d100, 0xc00003c5a8}, {0xc0001f0650, 0x2, ...}}, ...)
	/home/opensuse/REPOS/elemental/pkg/upgrade/upgrade.go:174 +0x10ee
github.com/suse/elemental/v3/internal/cli/elemental-toolkit/action.Upgrade(0xc0001d6280)
	/home/opensuse/REPOS/elemental/internal/cli/elemental-toolkit/action/upgrade.go:73 +0x4e5
github.com/urfave/cli/v2.(*Command).Run(0xc0000ba420, 0xc0001d6280, {0xc0001cb710, 0x3, 0x3})
	/home/opensuse/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/command.go:276 +0x7be
github.com/urfave/cli/v2.(*Command).Run(0xc0000ba9a0, 0xc0001d6180, {0xc000022100, 0x4, 0x4})
	/home/opensuse/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/command.go:269 +0xa45
github.com/urfave/cli/v2.(*App).RunContext(0xc0000cae00, {0xc22d08, 0x10b3560}, {0xc000022100, 0x4, 0x4})
	/home/opensuse/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(0xb577c1?, {0xc000022100?, 0xc000161160?, 0x1?})
	/home/opensuse/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/app.go:307 +0x2f
main.main()
	/home/opensuse/REPOS/elemental/cmd/elemental-toolkit/main.go:41 +0x1d7
```

As far as I understand it, the problem is the following:
1. During OS installation, we define a [default Deployment](https://github.com/SUSE/elemental/blob/main/internal/cli/elemental-toolkit/action/install.go#L90) that sets up a pointer to an [empty Firmware struct](https://github.com/SUSE/elemental/blob/main/pkg/deployment/deployment.go#L399).
2. In relation to the Firmware struct, the upgrade process goes through the following steps:
   1. Check if Firmware is configured as part of the Deployment ([here](https://github.com/SUSE/elemental/blob/main/pkg/upgrade/upgrade.go#L173))
   2. If Firmware is configured, use the upgrader's EfiBootManager to create boot entries ([here](https://github.com/SUSE/elemental/blob/main/pkg/firmware/efi_manager.go#L55)) <- Failure happens here due to the fact that the boot manager is not configured, resulting in the nil error.

## How did our tests miss this?

The upgrader unit tests explicitly set a boot manager - https://github.com/SUSE/elemental/blob/main/pkg/upgrade/upgrade_test.go#L84

## Suggested fix

This PR suggests that we explicitly add the boot manager as part of the initial upgrader initialisation, essentially doing what the unit tests currently run. 

Having a boot manager defined in the upgrader ensures that the above problem is mitigated, resulting in a successful upgrade operation.

## Examples

*Before upgrade:*
<img width="1287" height="260" alt="Screenshot 2025-07-16 at 18 06 29" src="https://github.com/user-attachments/assets/8e8672a1-a869-457a-b155-f4038957ec5d" />

*Upgrade:*
```shell
localhost:~ # elemental3-toolkit upgrade --os-image registry.opensuse.org/devel/unifiedcore/tumbleweed/containers/uc-base-os-kernel-default:latest
...
INFO[0185] Installing kernel/initrd
INFO[0186] Creating 0 boot entries...
INFO[0186] Committing transaction
INFO[0186] Creating post-transaction snapshots
INFO[0186] Creating a new snapshot
INFO[0186] Setting new default snapshot
INFO[0186] Setting default snapshot
INFO[0186] Transaction closed
INFO[0186] Upgrade completed
```

*Snapshots before reboot:*
<img width="1686" height="207" alt="Screenshot 2025-07-16 at 18 12 48" src="https://github.com/user-attachments/assets/79a0d594-57ea-4d5f-9707-3b769eec7839" />

*After reboot:*
<img width="1289" height="194" alt="Screenshot 2025-07-16 at 18 13 07" src="https://github.com/user-attachments/assets/d2798698-4427-477e-a429-fe6732ec4c4c" />

<img width="1693" height="208" alt="Screenshot 2025-07-16 at 18 14 20" src="https://github.com/user-attachments/assets/1d65847a-4586-47d6-b41e-f8606948abc0" />
