### PR TITLE
ci: fix Unit tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,7 +24,8 @@ jobs:
           go-version-file: go.mod
       - name: Install dependencies
         run: |
-          sudo apt-get install rootlesskit
+          sudo apt update
+          sudo apt-get install -y rootlesskit
       - name: Run tests
         env:
           COV_THRESHOLD: "70"


### PR DESCRIPTION
Unit test are failing because we need to update the packages list before trying to install a package.