### PR TITLE
Explicitly state the shell for script execution

### DIFF
--- a/internal/build/config_test.go
+++ b/internal/build/config_test.go
@@ -121,10 +121,10 @@ var _ = Describe("Config tests", func() {
 
 		// Kubernetes
 		Expect(contents).To(ContainSubstring("/etc/systemd/system/k8s-resource-installer.service"))
-		Expect(contents).To(ContainSubstring("ExecStart=\"/var/lib/elemental/k8s-resources.sh\""))
+		Expect(contents).To(ContainSubstring("ExecStart=/bin/bash -c \"/var/lib/elemental/k8s-resources.sh\""))
 		Expect(contents).To(ContainSubstring("ExecStartPost=/bin/sh -c 'rm -rf \"/var/lib/elemental\""))
 
 		// Network
-		Expect(contents).To(ContainSubstring("ExecStart=/var/lib/elemental/configure-network.sh"))
+		Expect(contents).To(ContainSubstring("ExecStart=/bin/bash -c \"/var/lib/elemental/configure-network.sh\""))
 	})
 })

--- a/internal/build/config_test.go
+++ b/internal/build/config_test.go
@@ -121,10 +121,10 @@ var _ = Describe("Config tests", func() {
 
 		// Kubernetes
 		Expect(contents).To(ContainSubstring("/etc/systemd/system/k8s-resource-installer.service"))
-		Expect(contents).To(ContainSubstring("ExecStart=/bin/bash -c \"/var/lib/elemental/k8s-resources.sh\""))
+		Expect(contents).To(ContainSubstring("ExecStart=/bin/bash \"/var/lib/elemental/k8s-resources.sh\""))
 		Expect(contents).To(ContainSubstring("ExecStartPost=/bin/sh -c 'rm -rf \"/var/lib/elemental\""))
 
 		// Network
-		Expect(contents).To(ContainSubstring("ExecStart=/bin/bash -c \"/var/lib/elemental/configure-network.sh\""))
+		Expect(contents).To(ContainSubstring("ExecStart=/bin/bash \"/var/lib/elemental/configure-network.sh\""))
 	})
 })

--- a/internal/build/templates/config.sh.tpl
+++ b/internal/build/templates/config.sh.tpl
@@ -25,7 +25,7 @@ After=network.target NetworkManager.service
 [Service]
 Type=oneshot
 TimeoutStartSec=30
-ExecStart=/bin/bash -c "{{ .NetworkScript }}"
+ExecStart=/bin/bash "{{ .NetworkScript }}"
 
 [Install]
 WantedBy=multi-user.target
@@ -75,7 +75,7 @@ TimeoutSec=900
 Restart=on-failure
 RestartSec=60
 ExecStartPre=/bin/sh -c 'until [ "\$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done'
-ExecStart=/bin/bash -c "{{ .ManifestDeployScript }}"
+ExecStart=/bin/bash "{{ .ManifestDeployScript }}" 
 ExecStartPost=/bin/sh -c "systemctl disable k8s-resource-installer.service"
 ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-resource-installer.service"
 ExecStartPost=/bin/sh -c 'rm -rf "{{ .KubernetesDir }}"'

--- a/internal/build/templates/config.sh.tpl
+++ b/internal/build/templates/config.sh.tpl
@@ -25,7 +25,7 @@ After=network.target NetworkManager.service
 [Service]
 Type=oneshot
 TimeoutStartSec=30
-ExecStart={{ .NetworkScript }}
+ExecStart=/bin/bash -c "{{ .NetworkScript }}"
 
 [Install]
 WantedBy=multi-user.target
@@ -75,7 +75,7 @@ TimeoutSec=900
 Restart=on-failure
 RestartSec=60
 ExecStartPre=/bin/sh -c 'until [ "\$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done'
-ExecStart="{{ .ManifestDeployScript }}"
+ExecStart=/bin/bash -c "{{ .ManifestDeployScript }}"
 ExecStartPost=/bin/sh -c "systemctl disable k8s-resource-installer.service"
 ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-resource-installer.service"
 ExecStartPost=/bin/sh -c 'rm -rf "{{ .KubernetesDir }}"'


### PR DESCRIPTION
Currently the `first-boot-network.service` and `k8s-resource-installer.service` services are failing with the following errors:

```shell
localhost:~ # journalctl -u first-boot-network.service -f
Aug 11 07:19:07 localhost.localdomain systemd[1]: Starting Configure network on first boot...
Aug 11 07:19:07 localhost.localdomain (twork.sh)[1838]: first-boot-network.service: Unable to locate executable '/var/lib/elemental/configure-network.sh': Permission denied
Aug 11 07:19:07 localhost.localdomain (twork.sh)[1838]: first-boot-network.service: Failed at step EXEC spawning /var/lib/elemental/configure-network.sh: Permission denied
Aug 11 07:19:07 localhost.localdomain systemd[1]: first-boot-network.service: Main process exited, code=exited, status=203/EXEC
Aug 11 07:19:07 localhost.localdomain systemd[1]: first-boot-network.service: Failed with result 'exit-code'.
Aug 11 07:19:07 localhost.localdomain systemd[1]: Failed to start Configure network on first boot.
^C
localhost:~ # journalctl -u k8s-resource-installer.service -f
Aug 11 07:19:38 localhost.localdomain systemd[1]: k8s-resource-installer.service: Main process exited, code=exited, status=203/EXEC
Aug 11 07:19:38 localhost.localdomain systemd[1]: k8s-resource-installer.service: Failed with result 'exit-code'.
Aug 11 07:19:38 localhost.localdomain systemd[1]: Failed to start Kubernetes Resources Installer.
Aug 11 07:20:38 localhost.localdomain systemd[1]: k8s-resource-installer.service: Scheduled restart job, restart counter is at 1.
Aug 11 07:20:38 localhost.localdomain systemd[1]: Starting Kubernetes Resources Installer...
Aug 11 07:20:39 localhost.localdomain (eploy.sh)[7952]: k8s-resource-installer.service: Unable to locate executable '/var/lib/elemental/kubernetes/k8s_res_deploy.sh': Permission denied
Aug 11 07:20:39 localhost.localdomain (eploy.sh)[7952]: k8s-resource-installer.service: Failed at step EXEC spawning /var/lib/elemental/kubernetes/k8s_res_deploy.sh: Permission denied
Aug 11 07:20:39 localhost.localdomain systemd[1]: k8s-resource-installer.service: Main process exited, code=exited, status=203/EXEC
Aug 11 07:20:39 localhost.localdomain systemd[1]: k8s-resource-installer.service: Failed with result 'exit-code'.
Aug 11 07:20:39 localhost.localdomain systemd[1]: Failed to start Kubernetes Resources Installer.
```

This seems to be caused by the fact that we do not explicitly state the desired shell when calling the ExecStart command for both scripts ([network](https://github.com/SUSE/elemental/blob/main/internal/build/templates/config.sh.tpl#L28) and [k8s](https://github.com/SUSE/elemental/blob/main/internal/build/templates/config.sh.tpl#L78)). 

This seems to have started happening recently, as when running older OS images, explicitly specifying the shell was not required. Nevertheless, this PR introduces a fix for the issue. If needed we can asynchronously debug the point of time when this started failing.