### PR TITLE
Fix grub error when chosen is not set

### DIFF
--- a/pkg/bootloader/grubtemplates/grub.cfg
+++ b/pkg/bootloader/grubtemplates/grub.cfg
@@ -120,7 +120,10 @@ for entry in ${entries}; do
   load_env --file (${root})/loader/entries/${entry}
 
   menuentry "${display_name}" --id "${entry}" {
-    load_env --file (${root})/loader/entries/${chosen}
+    if test -f "(${root})/loader/entries/${chosen}"; then
+      load_env --file (${root})/loader/entries/${chosen}
+    fi
+
     echo 'Loading Linux...'
     linux "${linux}" ${cmdline}
     echo 'Loading initial ramdisk ...'


### PR DESCRIPTION
After chosing a menu-entry in grub we can see the following error for a
short while before linux is loaded and booted:

```
  Booting a command list

error: ../../grub-core/fs/fshelp.c:307:not a regular file.
Loading Linux...
Loading initial ramdisk ...
```

This seems to show for the load_env call when the ${chosen} variable is
unset.

In this commit we check that the indicated file exists and is a file
before trying to load it.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
