### PR TITLE
Add customize command

### DIFF
--- a/cmd/elemental/main.go
+++ b/cmd/elemental/main.go
@@ -33,6 +33,7 @@ func main() {
 		cmd.GlobalFlags(),
 		cmd.Setup,
 		cmd.NewBuildCommand(appName, action.Build),
+		cmd.NewCustomizeCommand(appName, action.Customize),
 		cmd.NewVersionCommand(appName))
 
 	if err := application.Run(os.Args); err != nil {

--- a/docs/customizing-installers.md
+++ b/docs/customizing-installers.md
@@ -1,0 +1,17 @@
+# Customizing installers
+
+Elemental installer images can be customized using the `elemental3 customize` command.
+
+The following command takes an input (./build/installer.iso) and generates a
+new installer2.iso in the output directory including a new config-script, an
+overlay and some extra kernel cmdline parameters:
+
+```sh
+./build/elemental3 customize \
+    --input ./build/installer.iso
+    --output ./build
+    --name installer2
+    --cmdline="console=ttyS0"
+    --config ./examples/elemental/install/config.sh
+    --overlay tar:./build/overlays.tar.gz
+```

--- a/internal/cli/action/customize.go
+++ b/internal/cli/action/customize.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/suse/elemental/v3/internal/cli/cmd"
+	"github.com/suse/elemental/v3/pkg/deployment"
+	"github.com/suse/elemental/v3/pkg/installermedia"
+	"github.com/suse/elemental/v3/pkg/sys"
+)
+
+func Customize(ctx *cli.Context) error {
+	if ctx.App.Metadata == nil || ctx.App.Metadata["system"] == nil {
+		return fmt.Errorf("error setting up initial configuration")
+	}
+	s := ctx.App.Metadata["system"].(*sys.System)
+	args := &cmd.CustomizeArgs
+	logger := s.Logger()
+
+	ctxCancel, cancelFunc := signal.NotifyContext(ctx.Context, syscall.SIGTERM, syscall.SIGINT)
+	defer cancelFunc()
+
+	logger.Info("Customizing image")
+
+	media := installermedia.NewISO(ctxCancel, s)
+
+	err := digestCustomizeSetup(args, media)
+	if err != nil {
+		return fmt.Errorf("invalid customize setup: %w", err)
+	}
+
+	err = media.Customize()
+	if err != nil {
+		return fmt.Errorf("failed customizing installer media: %w", err)
+	}
+
+	s.Logger().Info("Customize complete")
+
+	return nil
+}
+
+func digestCustomizeSetup(flags *cmd.CustomizeFlags, media *installermedia.ISO) error {
+	if flags.Overlay != "" {
+		src, err := deployment.NewSrcFromURI(flags.Overlay)
+		if err != nil {
+			return fmt.Errorf("invalid overlay data URI (%s) to add into the customization: %w", flags.Overlay, err)
+		}
+		media.OverlayTree = src
+	}
+
+	if flags.ConfigScript != "" {
+		media.CfgScript = flags.ConfigScript
+	}
+
+	if flags.Name != "" {
+		media.Name = flags.Name
+	}
+
+	if flags.OutputDir != "" {
+		media.OutputDir = flags.OutputDir
+	}
+
+	if flags.Label != "" {
+		media.Label = flags.Label
+	}
+
+	if flags.KernelCmdline != "" {
+		media.KernelCmdLine = flags.KernelCmdline
+	}
+
+	if flags.InputFile != "" {
+		media.InputFile = flags.InputFile
+	}
+	return nil
+}

--- a/internal/cli/cmd/customize.go
+++ b/internal/cli/cmd/customize.go
@@ -1,0 +1,80 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+type CustomizeFlags struct {
+	InputFile     string
+	OutputDir     string
+	Name          string
+	Target        string
+	Description   string
+	ConfigScript  string
+	Overlay       string
+	Label         string
+	KernelCmdline string
+}
+
+var CustomizeArgs CustomizeFlags
+
+func NewCustomizeCommand(appName string, action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "customize",
+		Usage:     "Customize installer artifact",
+		UsageText: fmt.Sprintf("%s customize", appName),
+		Action:    action,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "input",
+				Usage:       "Path to local image to customize",
+				Destination: &CustomizeArgs.InputFile,
+			},
+			&cli.StringFlag{
+				Name:        "config",
+				Usage:       "Path to installer media config script",
+				Destination: &CustomizeArgs.ConfigScript,
+			},
+			&cli.StringFlag{
+				Name:        "output",
+				Usage:       "Location for the temporary builtime files and the resulting image",
+				Destination: &CustomizeArgs.OutputDir,
+				Required:    true,
+			},
+			&cli.StringFlag{
+				Name:        "name",
+				Usage:       "Name of the resulting image file",
+				Destination: &CustomizeArgs.Name,
+			},
+			&cli.StringFlag{
+				Name:        "overlay",
+				Usage:       "URI of the data to include in installer media",
+				Destination: &CustomizeArgs.Overlay,
+			},
+			&cli.StringFlag{
+				Name:        "cmdline",
+				Usage:       "Kernel command line to boot the installer media",
+				Destination: &CustomizeArgs.KernelCmdline,
+			},
+		},
+	}
+}

--- a/pkg/bootloader/grubtemplates/grub_live.cfg
+++ b/pkg/bootloader/grubtemplates/grub_live.cfg
@@ -2,9 +2,11 @@ set default=0
 set timeout=5
 set timeout_style=menu
 
+load_env --file (${root})/boot/grub2/grubenv
+
 menuentry "{{.DisplayName}}" --class os --unrestricted {
 	echo Loading kernel...
-	linux ($root){{.Linux}} cdroot {{.CmdLine}}
+	linux ($root){{.Linux}} cdroot {{.CmdLine}} ${extra_cmdline}
 	echo Loading initrd...
 	initrd ($root){{.Initrd}}
 }


### PR DESCRIPTION
The customize command can be used to customize a pre-built installer
image (right now only ISO supported).

The customization process uses xorriso to add config files and overlays into the installer image.