### PR TITLE
Unify docs to say command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Elemental is a tool for installing, configuring and updating operating system im
 make all
 ```
 
-This will produce a `build/` directory containing the `elemental3` and `elemental3-toolkit` command-line clients.
+This will produce a `build/` directory containing the `elemental3` and `elemental3-toolkit` command-line interfaces.
 
 ## Contribution
 

--- a/docs/building-linux-image.md
+++ b/docs/building-linux-image.md
@@ -1,6 +1,6 @@
 # Building a Linux Virtual Machine Image with Elemental
 
-This section provides an overview of how you build a Linux image that can include additional extensions using Elemental and the `elemental3-toolkit` command line client. The image can be used to boot a virtual machine and run a Linux operating system, such as `openSUSE Tumbleweed`, with custom configurations and extensions.
+This section provides an overview of how you build a Linux image that can include additional extensions using Elemental and the `elemental3-toolkit` command-line interface. The image can be used to boot a virtual machine and run a Linux operating system, such as `openSUSE Tumbleweed`, with custom configurations and extensions.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ You can create a system extension from a binary or from a set of packages availa
 
 This example demonstrates how you can create a system extension image and wrap it inside a tarball that will be later provided during OS installation.
 
-The following builds an extension image for the `elemental3-toolkit` command line client.
+The following builds an extension image for the `elemental3-toolkit` command-line interface.
 
 > **NOTE:** The below steps use the `mkosi` tool. For more information on the tool, refer to the [upstream repository](https://github.com/systemd/mkosi).
 

--- a/docs/image-build-and-customization.md
+++ b/docs/image-build-and-customization.md
@@ -1,6 +1,6 @@
 # Image Build and Customization
 
-This section provides an overview of how the `elemental3` command-line client enables users to build ready to boot images that are customized, extended and based on a specific set of components defined in a [release manifest](release-manifest.md).
+This section provides an overview of how the `elemental3` command-line interface enables users to build ready to boot images that are customized, extended and based on a specific set of components defined in a [release manifest](release-manifest.md).
 
 ## elemental3 build
 
@@ -90,7 +90,7 @@ This section provides a high-level overview of the steps that Elemental's toolin
 
 ## Example
 
-This section provides an example on how users can leverage the `elemental3` command-line client to start an image build process and produce a ready to boot image that is customized and extended based on a specific use case.
+This section provides an example on how users can leverage the `elemental3` command-line interface to start an image build process and produce a ready to boot image that is customized and extended based on a specific use case.
 
 ### Prerequisites
 


### PR DESCRIPTION
Since we are not interacting with a server, change "command-line client"
to "command-line interface" (CLI).

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
