### PR TITLE
Make target and os-image required for install

### DIFF
--- a/internal/cli/cmd/install.go
+++ b/internal/cli/cmd/install.go
@@ -61,6 +61,7 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Name:        "os-image",
 				Usage:       "URI to the image containing the operating system",
 				Destination: &InstallArgs.OperatingSystemImage,
+				Required:    true,
 			},
 			&cli.StringFlag{
 				Name:        "overlay",
@@ -72,6 +73,7 @@ func NewInstallCommand(appName string, action func(*cli.Context) error) *cli.Com
 				Aliases:     []string{"t"},
 				Usage:       "Target device for the installation process",
 				Destination: &InstallArgs.Target,
+				Required:    true,
 			},
 			&cli.BoolFlag{
 				Name:        "create-boot-entry",

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -244,9 +244,19 @@ func (p Partitions) GetSnapshottedVolumes() RWVolumes {
 
 type SanitizeDeployment func(*sys.System, *Deployment) error
 
+// checkDiskDevice ensures that the disk device is not empty
+func checkDiskDevice(_ *sys.System, d *Deployment) error {
+	for _, disk := range d.Disks {
+		if disk.Device == "" {
+			return fmt.Errorf("disk device cannot be empty")
+		}
+	}
+	return nil
+}
+
 var sanitizers = []SanitizeDeployment{
 	checkSystemPart, checkEFIPart, checkRecoveryPart,
-	checkAllAvailableSize, checkPartitionsFS, checkRWVolumes,
+	checkAllAvailableSize, checkPartitionsFS, checkRWVolumes, checkDiskDevice,
 }
 
 // GetSystemPartition gets the data of the system partition.

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -62,6 +62,13 @@ var _ = Describe("Deployment", Label("deployment"), func() {
 			cleanup()
 		})
 
+		It("fails if disk device is empty", func() {
+			d := deployment.DefaultDeployment()
+			d.Disks[0].Device = ""
+			err = d.Sanitize(s)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("disk device cannot be empty"))
+		})
 		It("creates a default deployment", func() {
 			d := deployment.DefaultDeployment()
 			d.Disks[0].Device = "/dev/device"
@@ -126,7 +133,7 @@ var _ = Describe("Deployment", Label("deployment"), func() {
 		It("feeds default values even if some where undefined", func() {
 			d := &deployment.Deployment{
 				Disks: []*deployment.Disk{
-					{Partitions: []*deployment.Partition{
+					{Device: "/dev/device", Partitions: []*deployment.Partition{
 						{Role: deployment.System, Size: 1024},
 						{Role: deployment.EFI, RWVolumes: []deployment.RWVolume{{Path: "/some/path"}}},
 						{Role: deployment.Data, Size: deployment.AllAvailableSize},
@@ -150,6 +157,8 @@ var _ = Describe("Deployment", Label("deployment"), func() {
 			Expect(len(rD.Disks)).To(Equal(1))
 			Expect(rD.Disks[0].Device).To(BeEmpty())
 			Expect(len(rD.Disks[0].Partitions)).To(Equal(2))
+			// Set a device for the sanitized deployment, as it's not persisted in the deployment file
+			rD.Disks[0].Device = "/dev/device"
 			Expect(rD.Sanitize(s)).To(Succeed())
 		})
 		It("unmarshals Disk.Device", func() {


### PR DESCRIPTION
This leads to a sensible error recovery rather than an install on an undefined/empty disk