### PR TITLE
Prune old boot artifacts

### DIFF
--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -28,6 +28,7 @@ import (
 type Bootloader interface {
 	Install(rootPath, snapshotID, kernelCmdline string, d *deployment.Deployment) error
 	InstallLive(rootPath, target, kernelCmdline string) error
+	Prune(rootPath string, keepSnapshotIDs []int, d *deployment.Deployment) error
 }
 
 const (
@@ -50,6 +51,11 @@ func (n *None) Install(_, _, _ string, _ *deployment.Deployment) error {
 
 func (n *None) InstallLive(_, _, _ string) error {
 	n.s.Logger().Info("Skipping bootloader installation")
+	return nil
+}
+
+func (n *None) Prune(_ string, _ []int, _ *deployment.Deployment) error {
+	n.s.Logger().Info("Skipping bootloader pruning")
 	return nil
 }
 

--- a/pkg/transaction/mock/snapper.go
+++ b/pkg/transaction/mock/snapper.go
@@ -24,14 +24,15 @@ import (
 )
 
 type Transactioner struct {
-	InitErr        error
-	StartErr       error
-	CommitErr      error
-	RollbackErr    error
-	Trans          *transaction.Transaction
-	UpgradeHelper  UpgradeHelper
-	SrcDigest      string
-	rollbackCalled bool
+	InitErr           error
+	StartErr          error
+	CommitErr         error
+	RollbackErr       error
+	Trans             *transaction.Transaction
+	UpgradeHelper     UpgradeHelper
+	SrcDigest         string
+	rollbackCalled    bool
+	activeSnapshotIDs []int
 }
 
 type UpgradeHelper struct {
@@ -88,4 +89,8 @@ func (t *Transactioner) Rollback(_ *transaction.Transaction, _ error) error {
 
 func (t Transactioner) RollbackCalled() bool {
 	return t.rollbackCalled
+}
+
+func (t Transactioner) GetActiveSnapshotIDs() ([]int, error) {
+	return t.activeSnapshotIDs, nil
 }

--- a/pkg/transaction/overwrite.go
+++ b/pkg/transaction/overwrite.go
@@ -127,6 +127,10 @@ func (n Overwrite) Rollback(*Transaction, error) error {
 	return fmt.Errorf("cannot rollback transactions using 'overwrite' snapshotter")
 }
 
+func (n Overwrite) GetActiveSnapshotIDs() ([]int, error) {
+	return []int{0}, nil
+}
+
 func (n Overwrite) SyncImageContent(imgSrc *deployment.ImageSource, trans *Transaction, opts ...unpack.Opt) (err error) {
 	if trans.status != started {
 		return fmt.Errorf("given transaction '%d' is not started", trans.ID)

--- a/pkg/transaction/snapper.go
+++ b/pkg/transaction/snapper.go
@@ -238,6 +238,21 @@ func (sn *snapperT) probe(d deployment.Deployment) (err error) {
 	return nil
 }
 
+func (sn snapperT) GetActiveSnapshotIDs() ([]int, error) {
+	snaps, err := sn.snap.ListSnapshots(sn.rootDir, "root")
+	if err != nil {
+		return nil, fmt.Errorf("listing snapshots: %w", err)
+	}
+
+	snapIDs := make([]int, len(snaps))
+
+	for i := range snaps {
+		snapIDs[i] = snaps[i].Number
+	}
+
+	return snapIDs, nil
+}
+
 // mountPartition mounts the given partition to the given mount point. In addition it also
 // sets the umount cleanup task.
 func (sn snapperT) mountPartition(part *deployment.Partition, mountPoint string) error {

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -67,6 +67,8 @@ type Interface interface {
 	Start() (*Transaction, error)
 	Commit(*Transaction) error
 	Rollback(*Transaction, error) error
+
+	GetActiveSnapshotIDs() ([]int, error)
 }
 
 type UpgradeHelper interface {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -198,7 +198,12 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 		return fmt.Errorf("committing transaction: %w", err)
 	}
 
-	return nil
+	snapshots, err := u.t.GetActiveSnapshotIDs()
+	if err != nil {
+		return fmt.Errorf("get active snapshots: %w", err)
+	}
+
+	return u.b.Prune(trans.Path, snapshots, d)
 }
 
 func (u Upgrader) configHook(config string, root string) error {


### PR DESCRIPTION
On upgrade we copy kernel/initrd to the ESP and then we generate
boot-entries files under $ESP/loader/entries/<snapshot>.

In this commit we introduce the Prune method for the bootloader
interface which will clean up old boot artifacts under the ESP.

The Pruning process first removes the boot-entries for old snapshots and
then tries to delete old kernel directories.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
