### PR TITLE
Move ro=vfs option to default deployment settings

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -400,6 +400,7 @@ func DefaultDeployment() *Deployment {
 					MountPoint: SystemMnt,
 					FileSystem: Btrfs,
 					Size:       AllAvailableSize,
+					MountOpts:  []string{"ro=vfs"},
 					RWVolumes: []RWVolume{
 						{Path: "/var", NoCopyOnWrite: true, MountOpts: []string{"x-initrd.mount"}},
 						{Path: "/root", MountOpts: []string{"x-initrd.mount"}},

--- a/pkg/transaction/snapper_upgrade_helper.go
+++ b/pkg/transaction/snapper_upgrade_helper.go
@@ -406,7 +406,6 @@ func (sc snapperContext) createFstab(trans *Transaction) error {
 
 			opts := part.MountOpts
 			if part.Role == deployment.System {
-				opts = append([]string{"ro=vfs"}, opts...)
 				line.FsckOrder = 1
 			} else {
 				line.FsckOrder = 2


### PR DESCRIPTION
This commit moves the ro=vfs option to the default deployment settings instead of hardcoding it at
/etc/fstab creation. This way it is still configurable and being added by default, plus keeps all layout
configurations in a single place.