### PR TITLE
Correcting the conditional in the k8s-resource-installer systemd unit

### DIFF
--- a/internal/build/templates/k8s-resource-installer.service.tpl
+++ b/internal/build/templates/k8s-resource-installer.service.tpl
@@ -1,16 +1,13 @@
 [Unit]
 Description=Kubernetes Resources Installer
-Requires=rke2-server.service
 After=rke2-server.service
-ConditionPathExists=/var/lib/rancher/rke2/bin/kubectl
-ConditionPathExists=/etc/rancher/rke2/rke2.yaml
 
 [Service]
 Type=oneshot
 TimeoutSec=900
 Restart=on-failure
 RestartSec=60
-ExecStartPre=/bin/sh -c 'until [ "\$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done'
+ExecStartPre=/bin/sh -c 'until [ "$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done'
 ExecStart=/bin/bash "{{ .ManifestDeployScript }}" 
 ExecStartPost=/bin/sh -c "systemctl disable k8s-resource-installer.service"
 ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-resource-installer.service"


### PR DESCRIPTION
It seems as though when the k8s-resource-installer systemd unit is written, perhaps now via Ignition(?), it doesn't need the escape as we originally had in Edge Image Builder (https://github.com/suse-edge/edge-image-builder/blob/main/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl#L81). I removed this and it now starts to work as expected as shown below:

```
# systemctl status k8s-resource-installer
* k8s-resource-installer.service - Kubernetes Resources Installer
     Loaded: loaded (/etc/systemd/system/k8s-resource-installer.service; enabled; preset: enabled)
     Active: activating (start) since Wed 2025-10-15 13:39:08 UTC; 10min ago
        Job: 937
 Invocation: f913d6fa24ba4f7c93a969a07604792d
    Process: 2413 ExecStartPre=/bin/sh -c until [ "$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done (code=exited, status=0/SUCCESS)
   Main PID: 2415 (bash)
      Tasks: 10
        CPU: 3.194s
     CGroup: /system.slice/k8s-resource-installer.service
             |- 2415 /bin/bash /var/lib/elemental/kubernetes/k8s_res_deploy.sh
             `-12586 /var/lib/rancher/rke2/bin/kubectl wait --for=condition=complete --timeout=900s job/helm-install-rancher -n kube-system

Oct 15 13:41:17 localhost.localdomain bash[9170]: job.batch/helm-install-metallb condition met
Oct 15 13:41:17 localhost.localdomain bash[2415]: helmchart.helm.cattle.io/cert-manager created
Oct 15 13:41:17 localhost.localdomain bash[2415]: Waiting for cert-manager HelmChart to be available..
```

Fixes: #198