### PR TITLE
Fix for using blkid with udev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,7 @@ RUN ARCH=$(uname -m); \
 COPY --from=builder /work/build/elemental3ctl /usr/bin/elemental3ctl
 COPY --from=builder /work/build/elemental3 /usr/bin/elemental3
 
+# Fix for blkid only using udev on opensuse
+RUN echo "EVALUATE=scan" >> /etc/blkid.conf
+
 ENTRYPOINT ["/usr/bin/elemental3ctl"]

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ build-disk: $(BUILD_DIR) elemental-image
 		--volume $(DOCKER_SOCK):$(DOCKER_SOCK) \
 		--volume $(BUILD_DIR):/build \
 		--volume /dev:/dev \
-		--volume /run/udev:/run/udev:ro \
 		--privileged \
 		$(ELEMENTAL_IMAGE_REPO):$(VERSION) \
 		--debug install --os-image $(OS_REPO):$(OS_VERSION) --target $${TARGET} --cmdline "console=ttyS0,115200" --config /build/config.sh


### PR DESCRIPTION
Running blkid inside a container without udev requires a configuration
change in /etc/blkid.conf.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
