### PR TITLE
Adding kubernetes configuration to build

### DIFF
--- a/examples/elemental/build/kubernetes/config/agent.yaml
+++ b/examples/elemental/build/kubernetes/config/agent.yaml
@@ -1,0 +1,2 @@
+token: totally-not-generated-one
+debug: true

--- a/examples/elemental/build/kubernetes/config/server.yaml
+++ b/examples/elemental/build/kubernetes/config/server.yaml
@@ -1,0 +1,2 @@
+token: totally-not-generated-one
+selinux: true

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containerd/containerd/v2 v2.1.4
 	github.com/coreos/butane v0.25.1
+	github.com/coreos/ignition/v2 v2.23.0
 	github.com/distribution/reference v0.6.0
 	github.com/google/go-containerregistry v0.20.6
+	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/onsi/ginkgo/v2 v2.27.1
 	github.com/onsi/gomega v1.38.2
@@ -37,7 +39,6 @@ require (
 	github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
-	github.com/coreos/ignition/v2 v2.23.0 // indirect
 	github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -70,14 +70,14 @@ func (b *Builder) Run(ctx context.Context, d *image.Definition, buildDir image.B
 		}
 	}
 
-	k8sScript, err := b.configureKubernetes(ctx, d, m, buildDir)
+	k8sScript, k8sConfScript, err := b.configureKubernetes(ctx, d, m, buildDir)
 	if err != nil {
 		logger.Error("Configuring Kubernetes failed")
 		return err
 	}
 
-	if k8sScript != "" || len(d.ButaneConfig) > 0 {
-		if err = b.configureIgnition(d, buildDir, k8sScript); err != nil {
+	if k8sScript != "" || len(d.ButaneConfig) > 0 || k8sConfScript != "" {
+		if err = b.configureIgnition(d, buildDir, k8sScript, k8sConfScript); err != nil {
 			logger.Error("Configuring Ignition failed")
 			return err
 		}

--- a/internal/build/ignition.go
+++ b/internal/build/ignition.go
@@ -22,14 +22,21 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/coreos/butane/base/v0_6"
+	"github.com/coreos/ignition/v2/config/util"
+	"go.yaml.in/yaml/v3"
+
 	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/internal/template"
+	"github.com/suse/elemental/v3/pkg/sys"
 )
 
 const (
 	ensureSysextUnitName = "ensure-sysext.service"
 	k8sResourcesUnitName = "k8s-resource-installer.service"
+	k8sConfigUnitName    = "k8s-config-installer.service"
 )
 
 //go:embed templates/ensure-sysext.service
@@ -38,10 +45,13 @@ var ensureSysextUnit string
 //go:embed templates/k8s-resource-installer.service.tpl
 var k8sResourceUnitTpl string
 
+//go:embed templates/k8s-config-installer.service.tpl
+var k8sConfigUnitTpl string
+
 // configureIngition writes the ignition configuration file based on the provided butane configuration
 // and the given kubernetes configuration
-func (b *Builder) configureIgnition(def *image.Definition, buildDir image.BuildDir, k8sScript string) error {
-	if len(def.ButaneConfig) == 0 && k8sScript == "" {
+func (b *Builder) configureIgnition(def *image.Definition, buildDir image.BuildDir, k8sScript, k8sConfScript string) error {
+	if len(def.ButaneConfig) == 0 && k8sScript == "" && k8sConfScript == "" {
 		b.System.Logger().Info("No ignition configuration required")
 		return nil
 	}
@@ -77,6 +87,13 @@ func (b *Builder) configureIgnition(def *image.Definition, buildDir image.BuildD
 		config.AddSystemdUnit(k8sResourcesUnitName, k8sResourcesUnit, true)
 	}
 
+	if k8sConfScript != "" {
+		err := appendRke2Configuration(b.System, &config, &def.Kubernetes, k8sConfScript)
+		if err != nil {
+			return fmt.Errorf("failed appending rke2 configuration: %w", err)
+		}
+	}
+
 	ignitionFile := filepath.Join(buildDir.FirstbootConfigDir(), image.IgnitionFilePath())
 	return butane.WriteIgnitionFile(b.System, config, ignitionFile)
 }
@@ -94,5 +111,66 @@ func generateK8sResourcesUnit(deployScript string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parsing config script template: %w", err)
 	}
+	return data, nil
+}
+
+func generateK8sConfigUnit(deployScript string) (string, error) {
+	values := struct {
+		ConfigDeployScript string
+	}{
+		ConfigDeployScript: deployScript,
+	}
+
+	data, err := template.Parse(k8sConfigUnitName, k8sConfigUnitTpl, &values)
+	if err != nil {
+		return "", fmt.Errorf("parsing config script template: %w", err)
+	}
+	return data, nil
+}
+
+func appendRke2Configuration(s *sys.System, config *butane.Config, k *kubernetes.Kubernetes, configScript string) error {
+	c, err := kubernetes.NewCluster(s, k)
+	if err != nil {
+		return fmt.Errorf("failed parsing cluster: %w", err)
+	}
+
+	k8sConfigUnit, err := generateK8sConfigUnit(configScript)
+	if err != nil {
+		return fmt.Errorf("failed generating k8s config unit: %w", err)
+	}
+
+	config.AddSystemdUnit(k8sConfigUnitName, k8sConfigUnit, true)
+
+	k8sPath := filepath.Join("/", image.KubernetesPath())
+
+	serverBytes, err := marshalConfig(c.ServerConfig)
+	if err != nil {
+		return fmt.Errorf("failed marshaling server config: %w", err)
+	}
+
+	config.Storage.Files = append(config.Storage.Files, v0_6.File{
+		Path:     filepath.Join(k8sPath, "server.yaml"),
+		Contents: v0_6.Resource{Inline: util.StrToPtr(string(serverBytes))},
+	})
+
+	agentBytes, err := marshalConfig(c.AgentConfig)
+	if err != nil {
+		return fmt.Errorf("failed marshaling agent config: %w", err)
+	}
+
+	config.Storage.Files = append(config.Storage.Files, v0_6.File{
+		Path:     filepath.Join(k8sPath, "agent.yaml"),
+		Contents: v0_6.Resource{Inline: util.StrToPtr(string(agentBytes))},
+	})
+
+	return nil
+}
+
+func marshalConfig(config map[string]any) ([]byte, error) {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("serializing kubernetes config: %w", err)
+	}
+
 	return data, nil
 }

--- a/internal/build/templates/k8s-config-installer.service.tpl
+++ b/internal/build/templates/k8s-config-installer.service.tpl
@@ -1,0 +1,18 @@
+[Unit]
+Description=Kubernetes Config Installer
+ConditionPathExists=!/etc/rancher/rke2/config.yaml
+Requires=network-online.target
+Before=rke2-server.service
+Before=rke2-agent.service
+
+[Service]
+Type=oneshot
+TimeoutSec=900
+Restart=on-failure
+RestartSec=60
+ExecStart=/bin/bash "{{ .ConfigDeployScript }}"
+ExecStartPost=/bin/sh -c "systemctl disable k8s-config-installer.service"
+ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-config-installer.service"
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/build/templates/k8s_conf_deploy.sh.tpl
+++ b/internal/build/templates/k8s_conf_deploy.sh.tpl
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -uo pipefail
+
+declare -A hosts
+
+{{- range .Nodes }}
+hosts[{{ .Hostname }}]={{ .Type }}
+{{- end }}
+
+HOSTNAME=$(cat /etc/hostname)
+if [ ! "$HOSTNAME" ]; then
+    HOSTNAME=$(cat /proc/sys/kernel/hostname)
+fi
+
+NODETYPE="${hosts[$HOSTNAME]:-server}"
+
+CONFIGFILE="{{ .KubernetesDir }}/$NODETYPE.yaml"
+mkdir -p /etc/rancher/rke2
+echo "Copying rke2 config file ${CONFIGFILE}"
+cp $CONFIGFILE /etc/rancher/rke2/config.yaml
+
+{{- if and .APIVIP4 .APIHost }}
+echo "{{ .APIVIP4 }} {{ .APIHost }}" >> /etc/hosts
+{{- end }}
+
+{{- if and .APIVIP6 .APIHost }}
+echo "{{ .APIVIP6 }} {{ .APIHost }}" >> /etc/hosts
+{{- end }}
+

--- a/internal/image/config.go
+++ b/internal/image/config.go
@@ -21,8 +21,9 @@ import (
 	"bytes"
 	"path/filepath"
 
-	"github.com/suse/elemental/v3/pkg/deployment"
 	"go.yaml.in/yaml/v3"
+
+	"github.com/suse/elemental/v3/pkg/deployment"
 )
 
 type ConfigDir string
@@ -45,6 +46,10 @@ func (dir ConfigDir) ButaneFilepath() string {
 
 func (dir ConfigDir) kubernetesDir() string {
 	return filepath.Join(string(dir), "kubernetes")
+}
+
+func (dir ConfigDir) KubernetesConfigDir() string {
+	return filepath.Join(dir.kubernetesDir(), "config")
 }
 
 func (dir ConfigDir) KubernetesManifestsDir() string {

--- a/internal/image/kubernetes/cluster.go
+++ b/internal/image/kubernetes/cluster.go
@@ -1,0 +1,281 @@
+/*
+Copyright © 2025 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/netip"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+const (
+	tokenKey   = "token"
+	cniKey     = "cni"
+	serverKey  = "server"
+	tlsSANKey  = "tls-san"
+	selinuxKey = "selinux"
+)
+
+type Cluster struct {
+	// ServerConfig contains the server configurations for a single node cluster
+	// or the additional server nodes in a multi node cluster.
+	ServerConfig map[string]any
+	// AgentConfig contains the agent configurations in multi node clusters.
+	AgentConfig map[string]any
+}
+
+func NewCluster(s *sys.System, kube *Kubernetes) (*Cluster, error) {
+	serverConfig, err := ParseKubernetesConfig(s, kube.Config.ServerFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("parsing server config: %w", err)
+	}
+
+	if len(kube.Nodes) < 2 {
+		setSingleNodeConfigDefaults(s.Logger(), kube, serverConfig)
+		return &Cluster{ServerConfig: serverConfig}, nil
+	}
+
+	var ip4 netip.Addr
+	if kube.Network.APIVIP4 != "" {
+		ip4, err = netip.ParseAddr(kube.Network.APIVIP4)
+		if err != nil {
+			return nil, fmt.Errorf("parsing kubernetes ipv4 address: %w", err)
+		}
+	}
+
+	var ip6 netip.Addr
+	if kube.Network.APIVIP6 != "" {
+		ip6, err = netip.ParseAddr(kube.Network.APIVIP6)
+		if err != nil {
+			return nil, fmt.Errorf("parsing kubernetes ipv6 address: %w", err)
+		}
+	}
+
+	prioritizeIPv6 := IsIPv6Priority(serverConfig)
+	err = setMultiNodeConfigDefaults(s.Logger(), kube, serverConfig, ip4, ip6, prioritizeIPv6)
+	if err != nil {
+		return nil, fmt.Errorf("failed setting multi-node configuration: %w", err)
+	}
+
+	agentConfig, err := ParseKubernetesConfig(s, kube.Config.AgentFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("parsing agent config: %w", err)
+	}
+
+	// Ensure the agent uses the same cluster configuration values as the server
+	agentConfig[tokenKey] = serverConfig[tokenKey]
+	agentConfig[serverKey] = serverConfig[serverKey]
+	agentConfig[selinuxKey] = serverConfig[selinuxKey]
+	agentConfig[cniKey] = serverConfig[cniKey]
+
+	return &Cluster{
+		ServerConfig: serverConfig,
+		AgentConfig:  agentConfig,
+	}, nil
+}
+
+func ParseKubernetesConfig(s *sys.System, configFile string) (map[string]any, error) {
+	config := map[string]any{}
+
+	if exists, _ := vfs.Exists(s.FS(), configFile); !exists {
+		s.Logger().Warn("Kubernetes config file '%s' does not exist", configFile)
+		return config, nil
+	}
+
+	b, err := s.FS().ReadFile(configFile)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("reading kubernetes config file '%s': %w", configFile, err)
+		}
+
+		s.Logger().Warn("Kubernetes config file '%s' was not provided", configFile)
+
+		// Use an empty config which will be automatically populated later
+		return config, nil
+	}
+
+	if err = yaml.Unmarshal(b, &config); err != nil {
+		return nil, fmt.Errorf("parsing kubernetes config file '%s': %w", configFile, err)
+	}
+
+	s.Logger().Info("Kubernetes config file '%s' read", configFile)
+
+	return config, nil
+}
+
+func setSingleNodeConfigDefaults(logger log.Logger, kube *Kubernetes, config map[string]any) {
+	if kube.Network.APIVIP4 != "" {
+		appendClusterTLSSAN(logger, config, kube.Network.APIVIP4)
+	}
+
+	if kube.Network.APIVIP6 != "" {
+		appendClusterTLSSAN(logger, config, kube.Network.APIVIP6)
+	}
+
+	if kube.Network.APIHost != "" {
+		appendClusterTLSSAN(logger, config, kube.Network.APIHost)
+	}
+	delete(config, serverKey)
+}
+
+func setMultiNodeConfigDefaults(logger log.Logger, kube *Kubernetes, config map[string]any, ip4 netip.Addr, ip6 netip.Addr, prioritizeIPv6 bool) error {
+	const rke2ServerPort = 9345
+
+	servers := FilterServers(kube.Nodes)
+	if len(servers) > 1 {
+		err := setClusterAPIAddress(config, ip4, ip6, rke2ServerPort, prioritizeIPv6)
+		if err != nil {
+			return err
+		}
+	}
+
+	setClusterToken(logger, config)
+	if kube.Network.APIVIP4 != "" {
+		appendClusterTLSSAN(logger, config, kube.Network.APIVIP4)
+	}
+
+	if kube.Network.APIVIP6 != "" {
+		appendClusterTLSSAN(logger, config, kube.Network.APIVIP6)
+	}
+
+	setSELinux(config)
+	if kube.Network.APIHost != "" {
+		appendClusterTLSSAN(logger, config, kube.Network.APIHost)
+	}
+
+	return nil
+}
+
+func setClusterToken(logger log.Logger, config map[string]any) {
+	if _, ok := config[tokenKey].(string); ok {
+		return
+	}
+
+	token := uuid.NewString()
+
+	logger.Info("Generated cluster token: %s", token)
+	config[tokenKey] = token
+}
+
+func setClusterAPIAddress(config map[string]any, ip4 netip.Addr, ip6 netip.Addr, port uint16, prioritizeIPv6 bool) error {
+	if !ip4.IsValid() && !ip6.IsValid() {
+		return fmt.Errorf("attempted to set an invalid cluster API address")
+	}
+
+	if ip6.IsValid() && (prioritizeIPv6 || !ip4.IsValid()) {
+		config[serverKey] = fmt.Sprintf("https://%s", netip.AddrPortFrom(ip6, port).String())
+		return nil
+	}
+
+	config[serverKey] = fmt.Sprintf("https://%s", netip.AddrPortFrom(ip4, port).String())
+
+	return nil
+}
+
+func setSELinux(config map[string]any) {
+	if _, ok := config[selinuxKey].(bool); ok {
+		return
+	}
+
+	config[selinuxKey] = false
+}
+
+func appendClusterTLSSAN(logger log.Logger, config map[string]any, address string) {
+	if address == "" {
+		logger.Warn("Attempted to append TLS SAN with an empty address")
+		return
+	}
+
+	tlsSAN, ok := config[tlsSANKey]
+	if !ok {
+		config[tlsSANKey] = []string{address}
+		return
+	}
+
+	switch v := tlsSAN.(type) {
+	case string:
+		var tlsSANs []string
+		for san := range strings.SplitSeq(v, ",") {
+			tlsSANs = append(tlsSANs, strings.TrimSpace(san))
+		}
+		tlsSANs = append(tlsSANs, address)
+		config[tlsSANKey] = tlsSANs
+	case []string:
+		v = append(v, address)
+		config[tlsSANKey] = v
+	case []any:
+		v = append(v, address)
+		config[tlsSANKey] = v
+	default:
+		logger.Warn("Ignoring invalid 'tls-san' value: %v", v)
+		config[tlsSANKey] = []string{address}
+	}
+}
+
+func ServersCount(nodes Nodes) int {
+	var servers int
+
+	for _, node := range nodes {
+		if node.Type == NodeTypeServer {
+			servers++
+		}
+	}
+
+	return servers
+}
+
+func FilterServers(nodes Nodes) Nodes {
+	return FilterNodeType(nodes, NodeTypeServer)
+}
+
+func FilterNodeType(nodes Nodes, nodeType string) Nodes {
+	ret := Nodes{}
+
+	for _, node := range nodes {
+		if node.Type == nodeType {
+			ret = append(ret, node)
+		}
+	}
+
+	return ret
+}
+
+func IsIPv6Priority(serverConfig map[string]any) bool {
+	if clusterCIDR, ok := serverConfig["cluster-cidr"].(string); ok {
+		cidrs := strings.Split(clusterCIDR, ",")
+		if len(cidrs) > 0 {
+			return strings.Contains(cidrs[0], "::")
+		}
+	}
+
+	return false
+}
+
+func IsNodeIPSet(serverConfig map[string]any) bool {
+	_, ok := serverConfig["node-ip"].(string)
+	return ok
+}

--- a/internal/image/kubernetes/cluster_test.go
+++ b/internal/image/kubernetes/cluster_test.go
@@ -1,0 +1,250 @@
+package kubernetes
+
+import (
+	"net/netip"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+func TestClusterSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster test suite")
+}
+
+const (
+	exampleServerYaml = `
+token: token123
+selinux: true
+cni: calico
+disable:
+  - rke2-coredns
+tls-san:
+  - 10.10.10.1
+  - cluster1.suse.com
+`
+	exampleAgentYaml = `
+token: token123
+selinux: true
+debug: true
+server: cluster1.suse.com
+cni: canal
+`
+)
+
+var _ = Describe("Cluster", func() {
+	var (
+		s       *sys.System
+		fs      vfs.FS
+		cleanup func()
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		fs, cleanup, err = sysmock.TestFS(map[string]any{
+			"/etc/kubernetes/single-node/server.yaml": exampleServerYaml,
+			"/etc/kubernetes/multi-node/server.yaml":  exampleServerYaml,
+			"/etc/kubernetes/multi-node/agent.yaml":   exampleAgentYaml,
+			"/etc/kubernetes/empty/server.yaml":       "",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		s, err = sys.NewSystem(
+			sys.WithLogger(log.New(log.WithDiscardAll())),
+			sys.WithFS(fs),
+		)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("Sets default values for missing config values", func() {
+		kubernetes := &Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.122.50",
+			},
+		}
+
+		cluster, err := NewCluster(s, kubernetes)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.ServerConfig).ToNot(BeEmpty())
+		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"192.168.122.50", "api.suse.com"}))
+		Expect(cluster.ServerConfig["cni"]).To(BeNil())
+		Expect(cluster.ServerConfig["token"]).To(BeNil())
+		Expect(cluster.ServerConfig["server"]).To(BeNil())
+		Expect(cluster.ServerConfig["selinux"]).To(BeNil())
+		Expect(cluster.ServerConfig["disable"]).To(BeNil())
+		Expect(cluster.AgentConfig).To(BeEmpty())
+	})
+	It("Loads values from single-node server config", func() {
+		kubernetes := &Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.122.50",
+				APIVIP6: "fd12:3456:789a::21",
+			},
+			Config: Config{
+				ServerFilePath: "/etc/kubernetes/single-node/server.yaml",
+				AgentFilePath:  "",
+			},
+		}
+
+		cluster, err := NewCluster(s, kubernetes)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.ServerConfig).ToNot(BeEmpty())
+		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))
+		Expect(cluster.ServerConfig["token"]).To(Equal("token123"))
+		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
+		Expect(cluster.ServerConfig["selinux"]).To(BeTrue())
+		Expect(cluster.ServerConfig["server"]).To(BeNil())
+
+		Expect(cluster.AgentConfig).To(BeNil())
+	})
+	It("Loads values from multi-node config", func() {
+		kubernetes := &Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.122.50",
+				APIVIP6: "fd12:3456:789a::21",
+			},
+			Nodes: Nodes{
+				{
+					Hostname: "host1.suse.com",
+					Type:     NodeTypeServer,
+				},
+				{
+					Hostname: "host2.suse.com",
+					Type:     NodeTypeAgent,
+				},
+			},
+			Config: Config{
+				ServerFilePath: "/etc/kubernetes/multi-node/server.yaml",
+				AgentFilePath:  "/etc/kubernetes/multi-node/agent.yaml",
+			},
+		}
+
+		cluster, err := NewCluster(s, kubernetes)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.ServerConfig).ToNot(BeEmpty())
+		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))
+		Expect(cluster.ServerConfig["token"]).To(Equal("token123"))
+		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
+		Expect(cluster.ServerConfig["selinux"]).To(BeTrue())
+		Expect(cluster.ServerConfig["server"]).To(Equal("https://192.168.122.50:9345"))
+
+		Expect(cluster.AgentConfig).ToNot(BeEmpty())
+		// server settings override the agent.yaml
+		Expect(cluster.AgentConfig["cni"]).To(Equal("calico"))
+		Expect(cluster.AgentConfig["token"]).To(Equal("token123"))
+		Expect(cluster.AgentConfig["server"]).To(Equal("https://192.168.122.50:9345"))
+		Expect(cluster.AgentConfig["selinux"]).To(BeTrue())
+		Expect(cluster.AgentConfig["debug"]).To(BeTrue())
+	})
+})
+
+var _ = Describe("Cluster Helpers", func() {
+	It("sets cluster API address", func() {
+		config := map[string]any{}
+
+		ip4, err := netip.ParseAddr("192.168.122.50")
+		Expect(err).ToNot(HaveOccurred())
+
+		ip6, err := netip.ParseAddr("fd12:3456:789a::21")
+		Expect(err).ToNot(HaveOccurred())
+
+		var emptyIP netip.Addr
+
+		setClusterAPIAddress(config, ip4, emptyIP, 9345, false)
+		Expect(config["server"]).To(Equal("https://192.168.122.50:9345"))
+
+		setClusterAPIAddress(config, ip4, ip6, 9345, false)
+		Expect(config["server"]).To(Equal("https://192.168.122.50:9345"))
+
+		setClusterAPIAddress(config, ip4, ip6, 9345, true)
+		Expect(config["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+
+		setClusterAPIAddress(config, emptyIP, ip6, 9345, true)
+		Expect(config["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+
+		setClusterAPIAddress(config, ip4, ip6, 9345, true)
+		Expect(config["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+	})
+
+	It("appends cluster tls-san", func() {
+		tests := []struct {
+			name           string
+			config         map[string]any
+			apiHost        string
+			expectedTLSSAN any
+		}{
+			{
+				name:           "Empty TLS SAN",
+				config:         map[string]any{},
+				apiHost:        "",
+				expectedTLSSAN: nil,
+			},
+			{
+				name:           "Missing TLS SAN",
+				config:         map[string]any{},
+				apiHost:        "api.cluster01.hosted.on.edge.suse.com",
+				expectedTLSSAN: []string{"api.cluster01.hosted.on.edge.suse.com"},
+			},
+			{
+				name: "Invalid TLS SAN",
+				config: map[string]any{
+					"tls-san": 5,
+				},
+				apiHost:        "api.cluster01.hosted.on.edge.suse.com",
+				expectedTLSSAN: []string{"api.cluster01.hosted.on.edge.suse.com"},
+			},
+			{
+				name: "Existing TLS SAN string",
+				config: map[string]any{
+					"tls-san": "api.edge1.com, api.edge2.com",
+				},
+				apiHost:        "api.cluster01.hosted.on.edge.suse.com",
+				expectedTLSSAN: []string{"api.edge1.com", "api.edge2.com", "api.cluster01.hosted.on.edge.suse.com"},
+			},
+			{
+				name: "Existing TLS SAN string list",
+				config: map[string]any{
+					"tls-san": []string{"api.edge1.com", "api.edge2.com"},
+				},
+				apiHost:        "api.cluster01.hosted.on.edge.suse.com",
+				expectedTLSSAN: []string{"api.edge1.com", "api.edge2.com", "api.cluster01.hosted.on.edge.suse.com"},
+			},
+			{
+				name: "Existing TLS SAN list",
+				config: map[string]any{
+					"tls-san": []any{"api.edge1.com", "api.edge2.com"},
+				},
+				apiHost:        "api.cluster01.hosted.on.edge.suse.com",
+				expectedTLSSAN: []any{"api.edge1.com", "api.edge2.com", "api.cluster01.hosted.on.edge.suse.com"},
+			},
+		}
+
+		logger := log.New(log.WithDiscardAll())
+
+		for _, test := range tests {
+			appendClusterTLSSAN(logger, test.config, test.apiHost)
+			if test.expectedTLSSAN != nil {
+				Expect(test.config["tls-san"]).To(Equal(test.expectedTLSSAN))
+			} else {
+				Expect(test.config["tls-san"]).To(BeNil())
+			}
+		}
+	})
+})

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -21,6 +21,11 @@ import (
 	"github.com/suse/elemental/v3/pkg/helm"
 )
 
+const (
+	NodeTypeServer = "server"
+	NodeTypeAgent  = "agent"
+)
+
 type Kubernetes struct {
 	// RemoteManifests - manifest URLs specified under config/kubernetes.yaml
 	RemoteManifests []string `yaml:"manifests,omitempty"`
@@ -28,6 +33,16 @@ type Kubernetes struct {
 	Helm *Helm `yaml:"helm,omitempty"`
 	// LocalManifests - local manifest files specified under config/kubernetes/manifests
 	LocalManifests []string
+	Nodes          Nodes   `yaml:"nodes,omitempty"`
+	Network        Network `yaml:"network,omitempty"`
+	Config         Config  `yaml:"-"`
+}
+
+type Config struct {
+	// AgentFilePath path to agent.yaml rke2 configuration file
+	AgentFilePath string
+	// ServerFilePath path to server.yaml rke2 configuration file
+	ServerFilePath string
 }
 
 type Helm struct {
@@ -80,4 +95,17 @@ func (c *HelmChart) ToCRD(values []byte, repository string) *helm.CRD {
 type HelmRepository struct {
 	Name string `yaml:"name"`
 	URL  string `yaml:"url"`
+}
+
+type Node struct {
+	Hostname string `yaml:"hostname"`
+	Type     string `yaml:"type"`
+}
+
+type Nodes []Node
+
+type Network struct {
+	APIHost string `yaml:"apiHost"`
+	APIVIP4 string `yaml:"apiVIP"`
+	APIVIP6 string `yaml:"apiVIP6"`
 }


### PR DESCRIPTION
In this commit we try to parse the agent/server.yaml config files in
kubernetes/config/ configuration directory. These files are then
enriched with more info and installed into /var/lib/elemental/kubernetes
directory.

A new unit k8s-config-installer.service is added using ignition that
will try to install the correct config file to
/etc/rancher/rke2/config.yaml based on the node type specified in
kubernetes.yaml.

To get this working we add two new keys in kubernetes.yaml: 'nodes' and
'network', as seen in this example:

```yaml
manifests:
  - https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml
nodes:
- hostname: node1.suse.com
  type: server
- hostname: node2.suse.com
  type: agent
network:
    apiVIP: 10.0.2.15
    apiHost: 10.0.2.15.sslip.io
```