### PR TITLE
Add debug log when extensions are not enabled/found

### DIFF
--- a/internal/build/systemd_sysext_test.go
+++ b/internal/build/systemd_sysext_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/release"
+	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
 	"github.com/suse/elemental/v3/pkg/manifest/api/core"
 	"github.com/suse/elemental/v3/pkg/manifest/api/product"
@@ -30,6 +31,8 @@ import (
 )
 
 var _ = Describe("Systemd extensions", func() {
+	logger := log.New(log.WithDiscardAll())
+
 	It("Detects remote sources", func() {
 		Expect(isRemoteURL("http://example.com/extension.raw")).To(BeTrue(), "http")
 		Expect(isRemoteURL("https://example.com/extension.raw")).To(BeTrue(), "https")
@@ -71,7 +74,7 @@ var _ = Describe("Systemd extensions", func() {
 				},
 			}
 
-			extensions, err := enabledExtensions(rm, def)
+			extensions, err := enabledExtensions(rm, def, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(MatchRegexp("filtering enabled helm charts: adding helm chart 'longhorn': " +
 				"adding dependent helm chart 'longhorn-crd': helm chart does not exist")))
@@ -156,7 +159,7 @@ var _ = Describe("Systemd extensions", func() {
 				},
 			}
 
-			extensions, err := enabledExtensions(rm, def)
+			extensions, err := enabledExtensions(rm, def, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(extensions).To(HaveLen(4))
 


### PR DESCRIPTION
I ran into an issue during my test: I set `- extension: rke` instead of `rke2` but the build was OK and no error/warning showed, even in debug mode. So I search for quite some times why RKE2 was not in the OS image...

I think that it could be useful to add more information at least in debug mode (I perfectly agree to keep the default as-is).

I added 2 cases:
- When the extension exists in the release manifest but it is not enabled (like `rke2` for example).
- When an extension is mentioned but is not found, nothing is done like what we have now but adding a not in debug to know that the extension is not found.

Example of extension not found:
```
DEBU[0000] Extension 'longhorn' not found               
DEBU[0000] Extension 'foo' not found                    
DEBU[0000] Extension 'bar' not found                    
INFO[0000] Pulling extension elemental3ctl from https://download.suse.de/ibs/Devel:/UnifiedCore:/Releases:/0.6/sysexts/elemental3ctl_3.1_x86-64.raw... 
INFO[0001] Pulling extension rke2 from https://download.suse.de/ibs/Devel:/UnifiedCore:/Releases:/0.6/sysexts/rke2-1.33_6.1_x86-64.raw... 
INFO[0004] Creating RAW disk image
```

Example of extension not enabled:
```
DEBU[0000] Extension 'rke2' not enabled
DEBU[0000] Extension 'foo' not found                    
DEBU[0000] Extension 'bar' not found                    
INFO[0000] Pulling extension elemental3ctl from https://download.suse.de/ibs/Devel:/UnifiedCore:/Releases:/0.6/sysexts/elemental3ctl_3.1_x86-64.raw... 
INFO[0004] Creating RAW disk image
```