### PR TITLE
Fix warning in Butane/Ignition conversion

### DIFF
--- a/docs/configuration-directory.md
+++ b/docs/configuration-directory.md
@@ -71,8 +71,8 @@ During the build this will be translated into an [Ignition](https://coreos.githu
 The example below shows how it can be used to setup users:
 
 ```yaml
-version: 1.1.0
-variant: flatcar
+version: 1.6.0
+variant: fcos
 passwd:
   users:
   - name: root

--- a/examples/elemental/build/butane.yaml
+++ b/examples/elemental/build/butane.yaml
@@ -1,5 +1,5 @@
-version: 1.1.0
-variant: flatcar
+version: 1.6.0
+variant: fcos
 passwd:
   users:
   - name: root

--- a/internal/build/ignition_test.go
+++ b/internal/build/ignition_test.go
@@ -153,8 +153,8 @@ passwd:
 		var butane map[string]any
 
 		butaneConfigString := `
-version: 1.1.0
-variant: flatcar
+version: 1.6.0
+variant: fcos
 passwd:
   usrs:
   - name: pipo

--- a/internal/butane/config_test.go
+++ b/internal/butane/config_test.go
@@ -67,23 +67,23 @@ var _ = Describe("Ignition configuration", func() {
 		var conf butane.Config
 		var jsonMap map[string]any
 
-		conf.Variant = "flatcar"
-		conf.Version = "1.1.0"
+		conf.Variant = "fcos"
+		conf.Version = "1.6.0"
 		conf.Passwd.Users = []v0_6.PasswdUser{{
 			Name:              "pipo",
 			SSHAuthorizedKeys: []v0_6.SSHAuthorizedKey{"longkey"},
 		}}
 
 		conf.AddSystemdUnit("test.service", "[Unit]\nDescription=Test unit\n[Install]\nWantedBy=test.target", true)
-		conf.MergeInlineIgnition("{\"ignition\": {\"version\": \"3.4.0\"}}")
+		conf.MergeInlineIgnition("{\"ignition\": {\"version\": \"3.5.0\"}}")
 
 		Expect(butane.WriteIgnitionFile(system, conf, "/ignition.ign")).To(Succeed())
 		ignBytes, err := system.FS().ReadFile("/ignition.ign")
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(json.Unmarshal(ignBytes, &jsonMap)).To(Succeed())
-		// Converted to ignition 3.4.0 as expected by flatcar 1.1.0 variant
-		Expect(jsonMap["ignition"].(map[string]any)["version"]).To(Equal("3.4.0"))
+		// Converted to ignition 3.5.0 as expected by fcos 1.6.0 variant
+		Expect(jsonMap["ignition"].(map[string]any)["version"]).To(Equal("3.5.0"))
 
 		// Defined user is added
 		user := jsonMap["passwd"].(map[string]any)["users"].([]any)[0].(map[string]any)


### PR DESCRIPTION
The conversion from Butane to Ignition sent a warning because the version is changed from `3.4.0` to `3.5.0`. According to the Butane [unit test](https://github.com/SUSE/elemental/blob/513341d2d6111dc9e4cc87042be6519c1e119851/internal/butane/config_test.go#L85) it seems that version `3.4.0` should be used for `flatcar`.

```
INFO[0000] Translating butane configuration to Ignition syntax 
DEBU[0000] Butane configuration translated:
--- Generated Ignition Config ---
{
  "ignition": {
    "version": "3.4.0"
  },
  "passwd": {
    "users": [
      {
        "name": "root",
        "passwordHash": "$6$dkiCjuXvS8brdFUA$w1b4wSV.0wQ7BmZ7l/Be6fhqlk8CMEE8NQkhtaXIPjMTFw90JNYfI1lBhSoUILhmqupcmOp681FHIdvIZdbc90"
      }
    ]
  }
} 
WARN[0000] translating Butane to Ignition reported non fatal entries: warning at $.ignition.config.merge.0.version, line 6 col 15: skipping validation for the merge/replace ignition config due to an unkown version 
DEBU[0000] Butane configuration translated:
--- Generated Ignition Config ---
{
  "ignition": {
    "config": {
      "merge": [
        {
          "compression": "gzip",
          "source": "data:;base64,H4sIAAAAAAAC/0SPwW+CMBjF7/wVXxqOhkFmEL0NI7HLdDPMxbnsALauFUqxBXpY+N+XdiZ+ly/v915e8n49AMR/Gt5x2aAFWA2ABqr0P0CPwTQIkQcwTmy2LbQ25J7sNVUaLeDLSbhhZzWFoLZBSdmhyZ27CqnIutDM+n7sk4ovL/1hyJNSkWz/5JuonJr8IwjNbpaK46x+SGl8Zte6Spab1SrZ7irWFQf8dtm8Z2YePm8/zziqU5bLPX5h4tq3J/HaxkmUrTEZ8JGUp7mbYW90/9uO8sa/AAAA///7SD2LAwEAAA=="
        }
      ]
    },
    "version": "3.5.0"
  }
}
```

Feel free to comment, maybe there another issue to fix this warning. Or we can keep it if it does not break anything. Despite the warning I had no issue, but I think it's better to keep the number of warning as low as possible.