### PR TITLE
Let scripts/run_vm.sh use raw disks

### DIFF
--- a/scripts/run_vm.sh
+++ b/scripts/run_vm.sh
@@ -59,6 +59,9 @@ function start {
 
   # Generate the VM disk
   case "${base_disk}" in
+    *.raw)
+      qemu-img convert -O qcow2 "${base_disk}" "${ELMNTL_TESTDISK}" > /dev/null
+      ;;
     *.qcow2)
       qemu-img create -f qcow2 -b "${base_disk}" -F qcow2 "${ELMNTL_TESTDISK}" > /dev/null
       ;;


### PR DESCRIPTION
If scripts/run_vm.sh is invoked with a raw disk it will convert it to a
qcow2 format and use it in the tests.

This let's us invoke scripts/run_vm.sh with an image built using the
'elemental3 build' command directly

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
