### PR TITLE
Support excludes in unpack

### DIFF
--- a/pkg/unpack/oci.go
+++ b/pkg/unpack/oci.go
@@ -116,7 +116,7 @@ func (o OCI) SynchedUnpack(ctx context.Context, destination string, excludes []s
 	return digest, nil
 }
 
-func (o OCI) Unpack(ctx context.Context, destination string) (string, error) {
+func (o OCI) Unpack(ctx context.Context, destination string, excludes ...string) (string, error) {
 	platform, err := containerregistry.ParsePlatform(o.platformRef)
 	if err != nil {
 		return "", err
@@ -155,7 +155,8 @@ func (o OCI) Unpack(ctx context.Context, destination string) (string, error) {
 		return "", err
 	}
 
-	_, err = archive.Apply(ctx, destination, reader)
+	filter := excludesFilter(destination, excludes...)
+	_, err = archive.Apply(ctx, destination, reader, archive.WithFilter(filter))
 	return digest.String(), err
 }
 

--- a/pkg/unpack/oci_test.go
+++ b/pkg/unpack/oci_test.go
@@ -82,10 +82,14 @@ var _ = Describe("OCIUnpacker", Label("oci", "rootlesskit"), func() {
 
 		unpacker := unpack.NewOCIUnpacker(s, alpineImageRef, unpack.WithPlatformRefOCI("linux/amd64"), unpack.WithLocalOCI(true))
 		Expect(vfs.MkdirAll(tfs, "/target/root", vfs.DirPerm)).To(Succeed())
-		digest, err := unpacker.Unpack(context.Background(), "/target/root")
+
+		// Unpack excluding /usr/sbin
+		digest, err := unpacker.Unpack(context.Background(), "/target/root", "/usr/sbin")
 		Expect(err).NotTo(HaveOccurred())
 		exists, _ := vfs.Exists(tfs, "/target/root/etc/os-release")
 		Expect(exists).To(BeTrue())
+		exists, _ = vfs.Exists(tfs, "/target/root/usr/sbin")
+		Expect(exists).To(BeFalse())
 		data, err := tfs.ReadFile("/target/root/etc/os-release")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(data)).To(ContainSubstring("VERSION_ID=3.21.3"))

--- a/pkg/unpack/raw.go
+++ b/pkg/unpack/raw.go
@@ -48,7 +48,7 @@ func NewRawUnpacker(s *sys.System, path string, opts ...RawOpt) *Raw {
 	return r
 }
 
-func (r Raw) Unpack(ctx context.Context, destination string) (digest string, err error) {
+func (r Raw) Unpack(ctx context.Context, destination string, excludes ...string) (digest string, err error) {
 	var umount umountFunc
 	var mountpoint string
 
@@ -64,7 +64,7 @@ func (r Raw) Unpack(ctx context.Context, destination string) (digest string, err
 	}()
 
 	unpackD := NewDirectoryUnpacker(r.s, mountpoint, WithRsyncFlagsDir(r.rsyncFlags...))
-	return unpackD.Unpack(ctx, destination)
+	return unpackD.Unpack(ctx, destination, excludes...)
 }
 
 func (r Raw) SynchedUnpack(ctx context.Context, destination string, excludes []string, deleteExcludes []string) (digest string, err error) {

--- a/pkg/unpack/tar_test.go
+++ b/pkg/unpack/tar_test.go
@@ -82,6 +82,19 @@ var _ = Describe("TarUnpacker", Label("tar"), func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("unpacks data excluding given paths", func() {
+		_, err := unpacker.Unpack(context.Background(), "/root", "var", "etc/os")
+		Expect(err).NotTo(HaveOccurred())
+
+		ok, _ := vfs.Exists(tfs, "/root/var")
+		Expect(ok).To(BeFalse())
+
+		// exclude 'etc/os' does not exlude os-release file
+		// exludes require a full directory or file path to be effective
+		ok, _ = vfs.Exists(tfs, "/root/etc/os-release")
+		Expect(ok).To(BeTrue())
+	})
+
 	It("mirrors data deleting pre-existing content", func() {
 		data, err := tfs.ReadFile("/root/etc/os-release")
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/unpack/unpacker.go
+++ b/pkg/unpack/unpacker.go
@@ -26,8 +26,9 @@ import (
 )
 
 type Interface interface {
-	// Unpack extracts the contents to the provided destination
-	Unpack(ctx context.Context, destination string) (string, error)
+	// Unpack extracts the contents to the provided destination. It allows to exclude
+	// certain given paths. All exclude paths are assumed to be tied to source root
+	Unpack(ctx context.Context, destination string, excludes ...string) (string, error)
 
 	// SynchedUnpack extracts the contents to the provided destination ensuring origin and
 	// destination are perfectly synched, that is any preexisting content in destination which


### PR DESCRIPTION
This commit adds support to exclude unpacking certain paths in oci, raw, dir and tar sources. The given exclude paths are always referring to source root.