### PR TITLE
Replace qemu-img with truncate in build

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -222,7 +222,7 @@ func createDisk(runner sys.Runner, img image.Image, diskSize imginstall.DiskSize
 		return fmt.Errorf("invalid disk size definition '%s'", diskSize)
 	}
 
-	_, err := runner.Run("qemu-img", "create", "-f", "raw", img.OutputImageName, string(diskSize))
+	_, err := runner.Run("truncate", "-s", string(diskSize), img.OutputImageName)
 	return err
 }
 


### PR DESCRIPTION
This removes a dependency on the qemu-img package during building. Truncate is installed from coreutils and available on most systems.

Noticed this dependency in #214 