### PR TITLE
Use lsblk to list partitions for Pruning

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -344,6 +344,19 @@ func (d Deployment) GetEfiPartition() *Partition {
 	return nil
 }
 
+// GetSystemDisk gets the disk data including the system partition.
+// returns nil if not found
+func (d Deployment) GetEfiDisk() *Disk {
+	for _, disk := range d.Disks {
+		for _, part := range disk.Partitions {
+			if part.Role == EFI {
+				return disk
+			}
+		}
+	}
+	return nil
+}
+
 // BaseKernelCmdline returns the base kernel command line for the current deployment
 func (d Deployment) BaseKernelCmdline() string {
 	return fmt.Sprintf("root=LABEL=%s", d.GetSystemLabel())


### PR DESCRIPTION
The previous attempt used the /dev/disk/by-label to mount the ESP, which
fails if there is another partition labeled the same as the ESP on the
host.

This commit uses the lsblk output to get the correct partition based on
the installed disk.

Fixes: #224 
Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
