### PR TITLE
Include bootloader Prune as a commit callback

### DIFF
--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -28,7 +28,7 @@ import (
 type Bootloader interface {
 	Install(rootPath, snapshotID, kernelCmdline string, d *deployment.Deployment) error
 	InstallLive(rootPath, target, kernelCmdline string) error
-	Prune(rootPath string, keepSnapshotIDs []int, d *deployment.Deployment) error
+	Prune(rootPath, espDir string, keepSnapshotIDs []int) error
 }
 
 const (
@@ -54,7 +54,7 @@ func (n *None) InstallLive(_, _, _ string) error {
 	return nil
 }
 
-func (n *None) Prune(_ string, _ []int, _ *deployment.Deployment) error {
+func (n *None) Prune(_, _ string, _ []int) error {
 	n.s.Logger().Info("Skipping bootloader pruning")
 	return nil
 }

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -26,8 +26,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/suse/elemental/v3/pkg/block"
-	"github.com/suse/elemental/v3/pkg/block/mock"
 	"github.com/suse/elemental/v3/pkg/bootloader"
 	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/log"
@@ -109,24 +107,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 			},
 		}
 
-		blk := mock.NewBlockDevice([]*block.Partition{
-			{
-				Name:       "/dev/loop0p1",
-				Label:      deployment.EfiLabel,
-				UUID:       "1234-ABCD",
-				FileSystem: deployment.VFat.String(),
-				Disk:       "/dev/loop0",
-			},
-			{
-				Name:       "/dev/loop0p2",
-				Label:      deployment.SystemLabel,
-				UUID:       "2345-ABCD",
-				FileSystem: deployment.Ext4.String(),
-				Disk:       "/dev/loop0",
-			},
-		}...)
-
-		grub = bootloader.NewGrub(s, bootloader.WithDevice(blk))
+		grub = bootloader.NewGrub(s)
 
 		// Setup GRUB and EFI dirs
 		Expect(vfs.MkdirAll(tfs, "/target/dir/usr/share/efi/x86_64", vfs.DirPerm)).To(Succeed())
@@ -282,7 +263,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(string(entries)).To(Equal("entries=active 2 1"))
 
 		// Prune snapshot 1 (keep 2)
-		err = grub.Prune("/target/dir", []int{2}, d)
+		err = grub.Prune("/target/dir", "/target/dir/boot/", []int{2})
 		Expect(err).ToNot(HaveOccurred())
 
 		entries, err = tfs.ReadFile("/target/dir/boot/grubenv")

--- a/pkg/transaction/mock/snapper.go
+++ b/pkg/transaction/mock/snapper.go
@@ -78,7 +78,7 @@ func (t Transactioner) Start() (*transaction.Transaction, error) {
 	return t.Trans, t.StartErr
 }
 
-func (t Transactioner) Commit(_ *transaction.Transaction) error {
+func (t Transactioner) Commit(_ *transaction.Transaction, _ func() error) error {
 	return t.CommitErr
 }
 

--- a/pkg/transaction/overwrite.go
+++ b/pkg/transaction/overwrite.go
@@ -47,8 +47,11 @@ func NewOverwrite(ctx context.Context, s *sys.System, d *deployment.Deployment, 
 var _ Interface = (*Overwrite)(nil)
 var _ UpgradeHelper = (*Overwrite)(nil)
 
-func (n Overwrite) Commit(trans *Transaction) (err error) {
+func (n Overwrite) Commit(trans *Transaction, cleanup func() error) (err error) {
 	trans.status = committed
+	if cleanup != nil {
+		n.cleanStack.Push(cleanup)
+	}
 	return n.cleanStack.Cleanup(err)
 }
 

--- a/pkg/transaction/overwrite_test.go
+++ b/pkg/transaction/overwrite_test.go
@@ -84,7 +84,7 @@ var _ = Describe("OverwriteTransaction", Label("transaction", "overwrite"), func
 		Expect(err).To(Succeed())
 		tran, err := overwrite.Start()
 		Expect(err).To(Succeed())
-		err = overwrite.Commit(tran)
+		err = overwrite.Commit(tran, nil)
 		Expect(err).To(Succeed())
 	})
 

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -65,7 +65,7 @@ type Transaction struct {
 type Interface interface {
 	Init(deployment.Deployment) (UpgradeHelper, error)
 	Start() (*Transaction, error)
-	Commit(*Transaction) error
+	Commit(trans *Transaction, cleanup func() error) error
 	Rollback(*Transaction, error) error
 
 	GetActiveSnapshotIDs() ([]int, error)


### PR DESCRIPTION
This PR moves the bootloader prune logic as a callback of the transaction.Commit method. This allows us not having to find and discover the EFI partition as part of the bootloader tasks as all partitions are mounted and in predictable paths during the transaction.

This also fixes #224 by providing a different approach that does not relay on having do find and discover partitions.