### PR TITLE
Install RKE2 SELinux module on firstboot

### DIFF
--- a/internal/build/templates/k8s-config-installer.service.tpl
+++ b/internal/build/templates/k8s-config-installer.service.tpl
@@ -8,6 +8,8 @@ Type=oneshot
 TimeoutSec=900
 Restart=on-failure
 RestartSec=60
+# TODO (atanasdinov): Figure out a declarative, non-hardcoded approach for installing selinux modules
+ExecStartPre=/bin/sh -c "semodule -i /usr/share/selinux/packages/rke2.pp"
 ExecStart=/bin/bash "{{ .ConfigDeployScript }}"
 ExecStartPost=/bin/sh -c "systemctl disable k8s-config-installer.service"
 ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-config-installer.service"


### PR DESCRIPTION
RKE2 is unable to start properly if it is enabled with the `selinux: true` configuration option. This is due to the systemd extension, containing both RKE2 itself and rke2-selinux policy, coming with properly relabeled files, resulting in improper context for the containerd and containerd-shim processes. By manually injecting the selinux policy this is now fixed.
