### PR TITLE
Adding optional recovery partition management

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -136,9 +136,11 @@ func (b *Builder) Run(ctx context.Context, d *image.Definition, buildDir image.B
 	manager := firmware.NewEfiBootManager(b.System)
 	upgrader := upgrade.New(
 		ctx, b.System, upgrade.WithBootManager(manager), upgrade.WithBootloader(boot),
-		upgrade.WithUnpackOpts(unpack.WithLocal(b.Local)),
 	)
-	installer := install.New(ctx, b.System, install.WithUpgrader(upgrader))
+	installer := install.New(
+		ctx, b.System, install.WithUpgrader(upgrader),
+		install.WithUnpackOpts(unpack.WithLocal(b.Local)),
+	)
 
 	logger.Info("Installing OS")
 	if err = installer.Install(dep); err != nil {

--- a/internal/cli/action/build_iso.go
+++ b/internal/cli/action/build_iso.go
@@ -73,7 +73,8 @@ func BuildInstaller(ctx *cli.Context) error { //nolint:dupl
 }
 
 func digestInstallerDeploymentSetup(s *sys.System, flags *cmd.InstallerFlags) (*deployment.Deployment, error) {
-	d := deployment.DefaultDeployment()
+	// Recovery partition size will be determined during the build
+	d := deployment.New(deployment.WithRecoveryPartition(0))
 	if flags.Overlay != "" {
 		src, err := deployment.NewSrcFromURI(flags.Overlay)
 		if err != nil {

--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -21,14 +21,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/sys"
 )
 
 type Bootloader interface {
-	Install(rootPath, snapshotID, kernelCmdline string, d *deployment.Deployment) error
-	InstallLive(rootPath, target, kernelCmdline string) error
-	Prune(rootPath, espDir string, keepSnapshotIDs []int) error
+	Install(rootPath, espDir, espLabel, entryID, kernelCmdline, recKernelCmdline string) error
+	InstallLive(rootPath, espDir, kernelCmdline string) error
+	Prune(rootPath, espDir string, keepEntryIDs []int) error
 }
 
 const (
@@ -44,7 +43,7 @@ func NewNone(s *sys.System) *None {
 	return &None{s}
 }
 
-func (n *None) Install(_, _, _ string, _ *deployment.Deployment) error {
+func (n *None) Install(_, _, _, _, _, _ string) error {
 	n.s.Logger().Info("Skipping bootloader installation")
 	return nil
 }


### PR DESCRIPTION
This commit introduces the notion of a recovery partition. It essentially sets an ISO installer to include an additional partition after the ESP partition to include the same contents the ISO filesystem has. This partition is bootable as a live system and it sets the base to eventually be used in a potential reset process to restore the system as it was installed back in a day.

As part of the changes it includes a bootloader interface refactor to drop its deployment package dependency. This to make it easier to reuse it in different contexts, such as installer builds, upgrades and clean installations.