### PR TITLE
Fix interactive editing in grub menu

### DIFF
--- a/pkg/bootloader/grubtemplates/grub.cfg
+++ b/pkg/bootloader/grubtemplates/grub.cfg
@@ -119,11 +119,11 @@ fi
 for entry in ${entries}; do
   load_env --file (${root})/loader/entries/${entry}
 
-  menuentry "${display_name}" --id "${entry}" {
-    if test -f "(${root})/loader/entries/${chosen}"; then
-      load_env --file (${root})/loader/entries/${chosen}
-    fi
-
+  menuentry "${display_name}" --id "${entry}" "${linux}" "${initrd}" "${cmdline}" {
+    set linux="${2}"
+    set initrd="${3}"
+    set cmdline="${4}"
+    
     echo 'Loading Linux...'
     linux "${linux}" ${cmdline}
     echo 'Loading initial ramdisk ...'


### PR DESCRIPTION
This commit avoids the use of the variable $chosen inside a menuentry. The reason for that is because the $chosen variable is not set if we are editing a boot entry by pressing ESC at run time.

In former logic this issue was causing a misbehavior, the last entry variables ($linux, $cmdline and $initrd) were used regardless of the chosen entry to edit. The reason for that is because the entry details were never reloaded, hence they were set to the last entry in the loop.