### PR TITLE
Minor updates to docs and examples

### DIFF
--- a/docs/image-build-and-customization.md
+++ b/docs/image-build-and-customization.md
@@ -166,7 +166,7 @@ virt-install --name uc-demo \
              --osinfo detect=on,name=sle-unknown \
              --graphics none \
              --console pty,target_type=serial \
-             --network default,model=virtio,mac=FE:C4:05:42:8B:AB \
+             --network network=default,model=virtio,mac=FE:C4:05:42:8B:AB \
              --virt-type kvm \
              --import \
              --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin

--- a/examples/elemental/build/suse-product-manifest.yaml
+++ b/examples/elemental/build/suse-product-manifest.yaml
@@ -25,7 +25,7 @@ components:
           crds:
             enabled: true
       - chart: "rancher"
-        version: "2.11.1"
+        version: "2.12.2"
         namespace: "cattle-system"
         repository: "rancher"
         values:

--- a/examples/elemental/install/config.sh
+++ b/examples/elemental/install/config.sh
@@ -7,7 +7,7 @@ grub2-editenv /boot/grubenv set timeout=5
 grub2-editenv /boot/grubenv set console=ttyS0,115200
 
 # Setting root passwd
-echo "uc0@linux" | passwd root --stdin
+echo "linux" | passwd root --stdin
 
 # Allow root ssh access (for testing purposes only!)
 echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/root_access.conf

--- a/tests/vm/sut.go
+++ b/tests/vm/sut.go
@@ -81,7 +81,7 @@ func NewSUT() *SUT {
 	sshKey, _ = os.ReadFile(sshKeyFile)
 
 	if pass = os.Getenv("SSH_PASS"); pass == "" {
-		pass = "uc0@linux"
+		pass = "linux"
 	}
 
 	if host = os.Getenv("SSH_HOST"); host == "" {


### PR DESCRIPTION
A few minor updates are made to the docs and examples

* network parameter in example virt-install command fixed
* rancher version in suse-product-manifest.yaml is bumped to 2.12.2 as 2.11 is not compatible with rke2 1.33
* the password in config.sh is updated to match to other examples