### PR TITLE
Minor updates to building linux image document

### DIFF
--- a/docs/building-linux-image.md
+++ b/docs/building-linux-image.md
@@ -433,7 +433,7 @@ sudo elemental3ctl --debug build-iso \
     --install-target /dev/sda \
     --install-overlay tar://overlays.tar.gz \
     --install-config config.sh \
-    --install-cmdline "root=LABEL=SYSTEM console=ttyS0 enforcing=0"
+    --install-cmdline "console=ttyS0 enforcing=0"
 ```
 
 Note that:


### PR DESCRIPTION
This commit

* updates `config-live.sh` script creation example to separate making the script executable as it can be easily missed by the people following the doc
* updates `elemental3ctl build-iso `command example to include `enforcing=0` in `--cmdline` and `--install-cmdline` to avoid hitting the issue preventing autologin or login with username and password