### PR TITLE
Remove build-dir after build

### DIFF
--- a/internal/cli/action/build.go
+++ b/internal/cli/action/build.go
@@ -76,6 +76,14 @@ func Build(ctx *cli.Context) error {
 		return err
 	}
 
+	defer func() {
+		logger.Debug("Cleaning up build-dir %s", buildDir)
+		err = system.FS().RemoveAll(string(buildDir))
+		if err != nil {
+			logger.Error("Cleaning up build-dir %s", buildDir)
+		}
+	}()
+
 	configDir := image.ConfigDir(args.ConfigDir)
 
 	valuesResolver := &helm.ValuesResolver{


### PR DESCRIPTION
The `build` command leaves artifacts in the build-dir that the find
command later complains about when running `make`:

```
find: ‘./build/build-2025-11-18T12-35-00’: Permission denied
find: ‘./build/build-2025-11-18T12-35-00’: Permission denied
```

This commit adds a defer method in the build action that removes the
build-dir after the build is done.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
