### PR TITLE
Install HA metallb setup for kubernetes-svc

### DIFF
--- a/internal/build/templates/k8s-vip.yaml.tpl
+++ b/internal/build/templates/k8s-vip.yaml.tpl
@@ -1,0 +1,60 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: api-ip
+  namespace: metallb-system
+spec:
+  addresses:
+  {{- if .APIAddress4 }}
+    - {{ .APIAddress4 }}/32
+  {{- end }}
+  {{- if .APIAddress6 }}
+    - {{ .APIAddress6 }}/128
+  {{- end }}
+  avoidBuggyIPs: true
+  serviceAllocation:
+    namespaces:
+      - default
+    serviceSelectors:
+      - matchExpressions:
+        - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: api-ip-l2-adv
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - api-ip
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-vip
+  namespace: default
+  labels:
+    serviceType: kubernetes-vip
+spec:
+  {{- if and .APIAddress4 .APIAddress6 }}
+  ipFamilyPolicy: RequireDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  {{- else if .APIAddress6 }}
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv6
+  {{- end }}
+  ports:
+  - name: rke2-api
+    port: 9345
+    protocol: TCP
+    targetPort: 9345
+  - name: k8s-api
+    port: 6443
+    protocol: TCP
+    targetPort: 6443
+  type: LoadBalancer
+


### PR DESCRIPTION
In order to achieve high-availability for the rke2 server nodes we deploy metallb and expose a LoadBalancer for the kubernetes-service.

This enables us to deploy multiple control-plane servers and load-balance the kubernetes API using metallb l2 mode [1]

A view of the deployed resource:

```
$ kubectl get svc --all-namespaces
NAMESPACE        NAME                                      TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                         AGE
default          kubernetes                                ClusterIP      10.43.0.1       <none>          443/TCP                         5m5s
default          kubernetes-vip                            LoadBalancer   10.43.119.206   10.0.2.15       9345:32173/TCP,6443:30453/TCP   2m28s
```

In order to sync the kubernetes service in case a node goes down we also deploy the endpoint-copier which will copy endpoints from the kubernetes service to kubernetes-vip. This works around an issue with using metallb for load-balancing the kubernetes API [2].

[1] https://metallb.universe.tf/concepts/layer2/