### PR TITLE
Include SUSE Linux grub theme to ISOs

### DIFF
--- a/pkg/bootloader/grubtemplates/grub_live.cfg
+++ b/pkg/bootloader/grubtemplates/grub_live.cfg
@@ -1,12 +1,82 @@
 set default=0
 set timeout=5
-set timeout_style=menu
 
 load_env --file (${root})/boot/grubenv
 
-menuentry "{{.DisplayName}}" --class os --unrestricted {
+set menuentry_id_option=""
+if test "${feature_menuentry_id}" == "y"; then
+  menuentry_id_option="--id"
+fi
+export menuentry_id_option
+
+function load_video {
+  if test "${feature_all_video_module}" == "y"; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+set font="${prefix}/unicode.pf2"
+if test "${feature_default_font_path}" == "y"; then
+  font="unicode"
+fi
+
+if loadfont $font ; then
+  if test "${grub_platform}" == "efi"; then
+    clear
+    echo "Please press 't' to show the boot menu on this console"
+  fi
+  set gfxmode="auto"
+  load_video
+  insmod gfxterm
+fi
+terminal_input console
+
+for i in gfxterm; do
+  if test "${use_append}" == "true"; then
+     terminal_output --append $i
+  elif terminal_output $i; then
+     use_append=true;
+  fi
+done
+
+insmod part_gpt
+insmod gfxmenu
+insmod png
+
+set theme_path="${prefix}/themes/SLE"
+if test -d "${theme_path}"; then
+  loadfont ${theme_path}/DejaVuSans-Bold14.pf2
+  loadfont ${theme_path}/DejaVuSans10.pf2
+  loadfont ${theme_path}/DejaVuSans12.pf2
+  loadfont ${theme_path}/ascii.pf2
+  set theme="${theme_path}/theme.txt"
+  export theme
+fi
+
+if test "${feature_timeout_style}" == "y"; then
+  set timeout_style=menu
+fi
+
+menuentry "{{.DisplayName}} (Installer)" --id "installer" {
 	echo 'Loading Linux...'
 	linux ($root){{.Linux}} ${cmdline}
 	echo 'Loading initial ramdisk...'
 	initrd ($root){{.Initrd}}
 }
+
+if test "${grub_platform}" == "efi"; then
+  # On EFI systems we can only have graphics *or* serial, so allow the user
+  # to switch between the two
+  hiddenentry 'Text mode' --hotkey 't' {
+    set textmode=true
+    terminal_output console
+  }
+fi

--- a/pkg/bootloader/grubtemplates/grub_live_efi.cfg
+++ b/pkg/bootloader/grubtemplates/grub_live_efi.cfg
@@ -1,3 +1,3 @@
 search --file --set=root {{.IDFile}}
-set prefix=($root)/boot/grub2
+set prefix="($root)/boot/grub2"
 configfile ($root)/boot/grub2/grub.cfg


### PR DESCRIPTION
This makes grub setup for Live booting and standard boots almost equivalent. In fact, I am convinced we could further improve the bootloader setup to completely align the two use cases and simplify the bootloader interface. But I think better keep this for a follow up PR as this is not related to any missing functionality.