### PR TITLE
Fix deployment merge logic

### DIFF
--- a/pkg/deployment/merge.go
+++ b/pkg/deployment/merge.go
@@ -102,6 +102,16 @@ func mergePtrSlice[T ~[]*E, E any](t *transformer) func(dest, src reflect.Value)
 				finalSlice = append(finalSlice, item)
 			}
 		}
+
+		// keep unmerged already existing items
+		if len(srcSlice) < len(destSlice) {
+			for _, item := range destSlice[loop:] {
+				if item == nil {
+					continue
+				}
+				finalSlice = append(finalSlice, item)
+			}
+		}
 		dest.Set(reflect.ValueOf(slices.Clip(finalSlice)))
 		return nil
 	}


### PR DESCRIPTION
This commit considers the case where the destination slice is longer than the source slice. Former logic omitted this particular case, which resulted in truncating the destination slice to the length of source slice.