### PR TITLE
Add --log-file global CLI flag

### DIFF
--- a/cmd/elemental/main.go
+++ b/cmd/elemental/main.go
@@ -32,6 +32,7 @@ func main() {
 		cmd.Usage,
 		cmd.GlobalFlags(),
 		cmd.Setup,
+		cmd.Teardown,
 		cmd.NewBuildCommand(appName, action.Build),
 		cmd.NewCustomizeCommand(appName, action.Customize),
 		cmd.NewVersionCommand(appName))

--- a/cmd/elemental3ctl/main.go
+++ b/cmd/elemental3ctl/main.go
@@ -32,6 +32,7 @@ func main() {
 		cmd.Usage,
 		cmd.GlobalFlags(),
 		cmd.Setup,
+		cmd.Teardown,
 		cmd.NewInstallCommand(appName, action.Install),
 		cmd.NewUpgradeCommand(appName, action.Upgrade),
 		cmd.NewUnpackImageCommand(appName, action.Unpack),

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -28,7 +28,7 @@ func Name() string {
 	return filepath.Base(os.Args[0])
 }
 
-func New(usage string, globalFlags []cli.Flag, setupFunc cli.BeforeFunc, commands ...*cli.Command) *cli.App {
+func New(usage string, globalFlags []cli.Flag, setupFunc cli.BeforeFunc, teardownFunc cli.AfterFunc, commands ...*cli.Command) *cli.App {
 	app := cli.NewApp()
 
 	app.Flags = globalFlags
@@ -37,6 +37,7 @@ func New(usage string, globalFlags []cli.Flag, setupFunc cli.BeforeFunc, command
 	app.Usage = usage
 	app.Suggest = true
 	app.Before = setupFunc
+	app.After = teardownFunc
 
 	return app
 }

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -18,19 +18,31 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
 const Usage = "Install and upgrade immutable operating systems"
+
+var (
+	logFile *os.File
+)
 
 func GlobalFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "debug",
 			Usage: "Set logging at debug level",
+		},
+		&cli.StringFlag{
+			Name:  "log-file",
+			Usage: "Save logs to file, accepts path to file or stdout/stderr",
 		},
 	}
 }
@@ -44,9 +56,44 @@ func Setup(ctx *cli.Context) error {
 	if ctx.Bool("debug") {
 		s.Logger().SetLevel(log.DebugLevel())
 	}
+
+	if err = SetLoggerTarget(s, ctx); err != nil {
+		return err
+	}
+
 	if ctx.App.Metadata == nil {
 		ctx.App.Metadata = map[string]any{}
 	}
 	ctx.App.Metadata["system"] = s
+	return nil
+}
+
+func Teardown(_ *cli.Context) error {
+	if logFile != nil {
+		return logFile.Close()
+	}
+
+	return nil
+}
+
+func SetLoggerTarget(s *sys.System, ctx *cli.Context) error {
+	logPath := ctx.String("log-file")
+	switch logPath {
+	case "":
+		break
+	case "-":
+	case "stdout":
+		s.Logger().SetOutput(os.Stdout)
+	case "stderr":
+		s.Logger().SetOutput(os.Stderr)
+	default:
+		var err error
+		logFile, err = s.FS().OpenFile(logPath, os.O_WRONLY|os.O_CREATE, vfs.FilePerm)
+		if err != nil {
+			return fmt.Errorf("opening log file '%s': %w", logPath, err)
+		}
+		s.Logger().SetOutput(logFile)
+	}
+
 	return nil
 }


### PR DESCRIPTION
The --log-file flag takes a string that can be a path to a file or
-/stdout/stderr and sets the log target.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
