### PR TITLE
Fix unpack-image command

### DIFF
--- a/pkg/unpack/oci.go
+++ b/pkg/unpack/oci.go
@@ -74,10 +74,17 @@ func WithRsyncFlagsOCI(flags ...string) OCIOpt {
 }
 
 func NewOCIUnpacker(s *sys.System, imageRef string, opts ...OCIOpt) *OCI {
-	unpacker := &OCI{s: s, imageRef: imageRef, platformRef: s.Platform().String()}
+	unpacker := &OCI{
+		s:           s,
+		verify:      true,
+		platformRef: s.Platform().String(),
+		imageRef:    imageRef,
+	}
+
 	for _, o := range opts {
 		o(unpacker)
 	}
+
 	return unpacker
 }
 


### PR DESCRIPTION
The `unpack-image` command fails like this:
```
$ elemental3ctl --debug unpack-image --image registry.suse.de/devel/unifiedcore/main/totest/containers/suse/uc/longhorn:3.9-1.2 --target tmp/
INFO[0000] Starting unpack action with args: &{Image:registry.suse.de/devel/unifiedcore/main/totest/containers/suse/uc/longhorn:3.9-1.2 TargetDir:tmp/ Platform: Local:false Verify:true} 
ERRO[0009] Failed to unpack image registry.suse.de/devel/unifiedcore/main/totest/containers/suse/uc/longhorn:3.9-1.2
```

It works if I set `--platform linux/amd64` but I think that this should be set to the host architecture by default (it still can be forced to something else with `--platform`).