### PR TITLE
Adds ExitError's Stderr to debug output

### DIFF
--- a/pkg/repart/disk_repart.go
+++ b/pkg/repart/disk_repart.go
@@ -217,7 +217,6 @@ func runSystemdRepart(s *sys.System, target string, parts []Partition, flags ...
 	args = append(args, target)
 
 	out, err := s.Runner().RunEnv("systemd-repart", []string{"PATH=/sbin:/usr/sbin:/usr/bin:/bin"}, args...)
-	s.Logger().Debug("systemd-repart output:\n%s", string(out))
 	if err != nil {
 		return fmt.Errorf("failed partitioning disk '%s' with systemd-repart: %w", target, err)
 	}

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -64,8 +64,12 @@ func (r run) RunEnv(command string, env []string, args ...string) ([]byte, error
 	cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
-		r.debug("'%s' command reported an error: %s", command, err.Error())
-		r.debug("'%s' command output: %s", command, out)
+		r.debug("%q command reported an error: %s", command, err.Error())
+		r.debug("%q command output: %s", command, out)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			r.debug("%q stderr: %s", command, string(exitErr.Stderr))
+		}
 	}
 	return out, err
 }


### PR DESCRIPTION
From the output of `elemental3ctl install` with `--debug` enabled, it now becomes clearer to point/figure out what caused the underlying shell command to fail.

Two additional lines get added in the debug output:
```
DEBU[0000] systemd-repart failed with exit code: 1
DEBU[0000] systemd-repart stderr: Failed to open file or determine backing device of /dev/nbd0: Permission denied
```

<details>

<summary> Before: </summary>

```sh
$ elemental3ctl --debug install \
--overlay tar://overlays.tar.gz \
--config config.sh \
--os-image registry.opensuse.org/devel/unifiedcore/tumbleweed/containers/uc-base-os-kernel-default:latest \
--target /dev/nbd0 \
--cmdline "root=LABEL=SYSTEM console=ttyS0"
INFO[0000] Starting install action with args: &{OperatingSystemImage:registry.opensuse.org/devel/unifiedcore/tumbleweed/containers/uc-base-os-kernel-default:latest Target:/dev/nbd0 Description: ConfigScript:config.sh Overlay:tar://overlays.tar.gz CreateBootEntry:false Bootloader:grub KernelCmdline:root=LABEL=SYSTEM console=ttyS0 Verify:true Local:false EnableFips:false Snapshotter:snapper}
INFO[0000] Checked configuration, running installation process
INFO[0000] Creating systemd-repart configuration at /tmp/elemental-repart.d544956679
DEBU[0000] Running cmd: 'lsblk -J -d -o NAME,PHY-SEC /dev/nbd0'
INFO[0000] Partitioning device '/dev/nbd0'
DEBU[0000] Running cmd: 'PATH=/sbin:/usr/sbin:/usr/bin:/bin systemd-repart --empty=force --json=pretty --definitions=/tmp/elemental-repart.d544956679 --dry-run=no --sector-size=512 /dev/nbd0'
DEBU[0000] 'systemd-repart' command reported an error: exit status 1
DEBU[0000] 'systemd-repart' command output:
DEBU[0000] systemd-repart output:
ERRO[0000] Installation failed
2025/11/20 11:35:09 partitioning disk '/dev/nbd0': failed partitioning disk '/dev/nbd0' with systemd-repart: exit status 1
```

</details>

<details>

<summary> After: </summary>

```
$ elemental3ctl --debug install \
--overlay tar://overlays.tar.gz \
--config config.sh \
--os-image registry.opensuse.org/devel/unifiedcore/tumbleweed/containers/uc-base-os-kernel-default:latest \
--target /dev/nbd0 \
--cmdline "root=LABEL=SYSTEM console=ttyS0"
INFO[0000] Starting install action with args: &{OperatingSystemImage:registry.opensuse.org/devel/unifiedcore/tumbleweed/containers/uc-base-os-kernel-default:latest Target:/dev/nbd0 Description: ConfigScript:config.sh Overlay:tar://overlays.tar.gz CreateBootEntry:false Bootloader:grub KernelCmdline:root=LABEL=SYSTEM console=ttyS0 Verify:true Local:false EnableFips:false Snapshotter:snapper}
INFO[0000] Checked configuration, running installation process
INFO[0000] Creating systemd-repart configuration at /tmp/elemental-repart.d209670132
DEBU[0000] Running cmd: 'lsblk -J -d -o NAME,PHY-SEC /dev/nbd0'
INFO[0000] Partitioning device '/dev/nbd0'
DEBU[0000] Running cmd: 'PATH=/sbin:/usr/sbin:/usr/bin:/bin systemd-repart --empty=force --json=pretty --definitions=/tmp/elemental-repart.d209670132 --dry-run=no --sector-size=512 /dev/nbd0'
DEBU[0000] 'systemd-repart' command reported an error: exit status 1
DEBU[0000] 'systemd-repart' command output:
DEBU[0000] systemd-repart output:
DEBU[0000] systemd-repart failed with exit code: 1
DEBU[0000] systemd-repart stderr: Failed to open file or determine backing device of /dev/nbd0: Permission denied
ERRO[0000] Installation failed
2025/11/20 11:35:18 partitioning disk '/dev/nbd0': failed partitioning disk '/dev/nbd0' with systemd-repart: exit status 1
```

</details>