### PR TITLE
Use elemental3 build for build-disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ RUN ARCH=$(uname -m); \
 COPY --from=builder /work/build/elemental3ctl /usr/bin/elemental3ctl
 COPY --from=builder /work/build/elemental3 /usr/bin/elemental3
 
-ENTRYPOINT ["/usr/bin/elemental3ctl"]
+ENTRYPOINT ["/usr/bin/elemental3"]


### PR DESCRIPTION
The build-disk target used the old method of manually setting up a
loopdevice and running 'elemental3ctl install' on the resulting device.

The 'elemental3 build' command does essentially the same thing. This
allows us to drop alot of the setup code in the Makefile as well as
changing the entrypoint of the Dockerfile to elemental3.

There are some changes to network and mounting of
/var/lib/ca-certificates to be able to download the systemd extensions
specified in the default release-manifest.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
