### PR TITLE
Use correct core release manifest in build examples

### DIFF
--- a/examples/elemental/build/suse-product-manifest.yaml
+++ b/examples/elemental/build/suse-product-manifest.yaml
@@ -7,7 +7,7 @@ metadata:
   creationDate: "2025-07-10"
 corePlatform:
   # Registry path to the release manifest OCI image of the Core Platform that this SUSE Product extends
-  image: "registry.suse.de/devel/unifiedcore/releases/0.6/containers/release-manifest"
+  image: "registry.suse.de/devel/unifiedcore/releases/0.6/containers/suse/uc/release-manifest"
   # Release manifest version to use
   version: "0.0.1"
 components:


### PR DESCRIPTION
If you attempt to do an HA build using the current examples, you would get:

```
ERRO[0000] Build process failed
2025/11/24 08:05:06 configuring helm charts: retrieving helm charts: filtering enabled helm charts: adding helm chart 'endpoint-copier-operator': helm chart does not exist
```

This is happening due to the `suse-product-manifest.yaml` not referring to a wrong core platform release manifest that is missing ECO. This PR points the `suse-product-manifest.yaml` to the correct core platform release manifest.