### PR TITLE
Make the EFI boot entry under ELEMENTAL the default one

### DIFF
--- a/pkg/firmware/efi_manager.go
+++ b/pkg/firmware/efi_manager.go
@@ -80,7 +80,7 @@ func DefaultBootEntry(p *platform.Platform, disk string) *EfiBootEntry {
 
 	return &EfiBootEntry{
 		Label:  EfiBootEntryName,
-		Loader: filepath.Join(EfiFallbackPath, efiImgName),
+		Loader: filepath.Join(EfiEntryPath, efiImgName),
 		Disk:   disk,
 	}
 }


### PR DESCRIPTION
This PR makes the default EFI boot entry to be placed under `EFI/ELEMENTAL`. IMHO it does not really make much sense adding an entry for the actual EFI fallback, which is anyway reachable and not Elemental specific.