### PR TITLE
Set kubernetes config file paths

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,13 +26,14 @@ import (
 	"slices"
 	"strings"
 
+	"go.yaml.in/yaml/v3"
+
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/internal/image/release"
 	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/manifest/source"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
-	"go.yaml.in/yaml/v3"
 )
 
 type Dir string
@@ -199,10 +200,7 @@ func parseKubernetes(f vfs.FS, configDir Dir, k *kubernetes.Kubernetes, r *relea
 
 func parseKubernetesDir(f vfs.FS, configDir Dir, k *kubernetes.Kubernetes) error {
 	entries, err := f.ReadDir(configDir.KubernetesManifestsDir())
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("reading %s: %w", configDir.KubernetesManifestsDir(), err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -240,6 +240,16 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("parsing custom directory: directory \"/tmp/config-dir/custom/files\" is empty"))
 	})
+
+	It("Parses {server,agent}.yaml without manifests subdir", func() {
+		Expect(fs.RemoveAll(configDir.KubernetesManifestsDir())).To(Succeed())
+
+		cfg, err := Parse(fs, configDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cfg.Kubernetes.Config.ServerFilePath).To(Equal("/tmp/config-dir/kubernetes/config/server.yaml"))
+		Expect(cfg.Kubernetes.Config.AgentFilePath).To(Equal("/tmp/config-dir/kubernetes/config/agent.yaml"))
+	})
 })
 
 func containsChart(name string, charts []release.HelmChart) bool {


### PR DESCRIPTION
When the manifests dir does not exist we still want to check if
{server,agent}.yaml kubernetes config files exist and set accordingly.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
