### PR TITLE
Fix lint issues

### DIFF
--- a/pkg/crypto/policy.go
+++ b/pkg/crypto/policy.go
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//revive:disable:var-naming
 package crypto
 
 const (

--- a/pkg/http/download.go
+++ b/pkg/http/download.go
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//revive:disable:var-naming
 package http
 
 import (

--- a/pkg/manifest/api/shared.go
+++ b/pkg/manifest/api/shared.go
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//revive:disable:var-naming
 package api
 
 import (


### PR DESCRIPTION
Skip var-naming revive rule for packages crypto, http and api to avoid
the following errors:

```
Error: pkg/crypto/policy.go:18:9: var-naming: avoid package names that conflict with Go standard library package names (revive)
Error: pkg/http/download.go:18:9: var-naming: avoid package names that conflict with Go standard library package names (revive)
Error: pkg/manifest/api/shared.go:18:9: var-naming: avoid meaningless package names (revive)
```

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
