### PR TITLE
Setup manifests for HA

### DIFF
--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -43,7 +43,7 @@ var k8sResDeployScriptTpl string
 var k8sConfDeployScriptTpl string
 
 func needsManifestsSetup(conf *image.Configuration) bool {
-	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0
+	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsHA()
 }
 
 func needsHelmChartsSetup(conf *image.Configuration) bool {

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -132,3 +132,7 @@ type Network struct {
 	APIVIP4 string `yaml:"apiVIP"`
 	APIVIP6 string `yaml:"apiVIP6"`
 }
+
+func (n Network) IsHA() bool {
+	return n.APIVIP4 != "" || n.APIVIP6 != ""
+}


### PR DESCRIPTION
When enabling HA and not having any manifests we still want to deploy
the k8s-vip.yaml manifest, this commit changes needsManifestSetup to
also account for the kubernetes network config.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
