### PR TITLE
Only run k8s-resource-installer on init-node

### DIFF
--- a/internal/config/templates/k8s-resource-installer.service.tpl
+++ b/internal/config/templates/k8s-resource-installer.service.tpl
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kubernetes Resources Installer
 After=rke2-server.service
+ConditionHost={{ .InitHostname }}
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This commit only runs the k8s-resource-installer service on the
configured init-node by setting ConditionHost= on the systemd unit.

If no nodes are specified (single-node deploy), the service will run for
any hostname.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
