### PR TITLE
Always include --output file into --customize-output value

### DIFF
--- a/internal/cli/action/customize.go
+++ b/internal/cli/action/customize.go
@@ -134,8 +134,8 @@ func setupFileExtractor(ctx context.Context, s *sys.System, outDir config.Output
 }
 
 func digestCustomizeDefinition(f vfs.FS, args *cmd.CustomizeFlags) (def *image.Definition, err error) {
-	outputPath := args.OutputPath
-	if outputPath == "" {
+	outputPath := filepath.Join(args.CustomizeOutput, args.OutputPath)
+	if args.OutputPath == "" {
 		imageName := fmt.Sprintf("image-%s.%s", time.Now().UTC().Format("2006-01-02T15-04-05"), args.MediaType)
 		outputPath = filepath.Join(args.CustomizeOutput, imageName)
 	}


### PR DESCRIPTION
Always include the resulting image file(s) inside the defined directory as in `--customize-output`.

Before this PR a customize call with the following parameters results into `customize.raw` being written in the current directory and leaving an empty `targetdir` directory behind.

```
elemental3 customize --type raw --config-dir configdir --customize-output targetdir --output customized.raw
```