### PR TITLE
Fit within 16GB disks

### DIFF
--- a/examples/elemental/customize/linux-only/install.yaml
+++ b/examples/elemental/customize/linux-only/install.yaml
@@ -1,7 +1,7 @@
 bootloader: grub
 kernelCmdLine: "console=ttyS0 loglevel=3"
 raw:
-  diskSize: 8G
+  diskSize: 12G
 # Alternatively if type of media specified is ISO
 # iso:
 #   device: "/dev/sda"

--- a/examples/elemental/customize/multi-node/install.yaml
+++ b/examples/elemental/customize/multi-node/install.yaml
@@ -1,7 +1,7 @@
 bootloader: grub
 kernelCmdLine: "console=ttyS0 quiet loglevel=3"
 raw:
-  diskSize: 35G
+  diskSize: 12G
 # Alternatively if type of media specified is ISO
 # iso:
 #   device: "/dev/sda"

--- a/examples/elemental/customize/single-node/install.yaml
+++ b/examples/elemental/customize/single-node/install.yaml
@@ -1,7 +1,7 @@
 bootloader: grub
 kernelCmdLine: "console=ttyS0 loglevel=3"
 raw:
-  diskSize: 35G
+  diskSize: 12G
 # Alternatively if type of media specified is ISO
 # iso:
 #   device: "/dev/sda"


### PR DESCRIPTION
Creating 35GB raw disks means that we're writing 30GB of zeros on disk, which doesn't do anything other than wearing out SSDs.