### PR TITLE
replace "we" by "you"

### DIFF
--- a/docs/building-linux-image.md
+++ b/docs/building-linux-image.md
@@ -323,7 +323,7 @@ You should see the bootloader prompting you to start `openSUSE Tumbleweed`.
 
 Elemental supports creating installation media in the form of live ISOs or RAW disk images. Content-wise they both are almost the same. The difference is that ISO installs to a target disk device and the RAW disk resets to factory from a recovery partition.
 
-The ISO image includes EFI binaries and bootloader setup, the OS image (as a squashfs image) and the installation assets (configuration script and drop-in files overlayed over the OS). 
+The ISO image includes EFI binaries and bootloader setup, the OS image (as a squashfs image) and the installation assets (configuration script and drop-in files overlayed over the OS).
 
 The RAW image includes the ESP partition with the EFI binaries, the bootloader setup and a recovery partition including the OS image (again as an squashfs image) together with the installation assets.
 
@@ -349,7 +349,7 @@ These kernel parameters can be easily used to handle automated actions at boot l
 
 #### Example live configuration script
 
-In this example, we are going to prepare a configuration script that will set four aspects:
+In this example, you prepare a configuration script that sets four aspects:
 
 * Autologin so the live ISO does not require a root password
 * An elemental-autoinstaller service to run the installation at boot
@@ -522,7 +522,7 @@ Note that:
 > **NOTE:** Make sure you have `qemu` installed on your system. If not, you can install it using `zypper -n install qemu-x86`.
 > If you are using a different architecture, ensure the package name and respective command below are adjusted accordingly.
 
-In order to test the RAW installer image with QEMU we need to dump the image to a bigger image or either expand the
+To test the RAW installer image with QEMU, you need to either dump the image to a bigger image or expand the
 generated image.
 
 ```shell
@@ -531,7 +531,7 @@ qemu-img resize build/installer.raw 16G
 ```
 
 Launch a virtual machine to boot the installer RAW and verify, at boot, it self expands the partition table
-to fullfil the disk geometry and creates additional partitions.
+to fulfill the disk geometry and creates additional partitions.
 
 ```shell
 qemu-system-x86_64 -m 8G \

--- a/docs/image-customization.md
+++ b/docs/image-customization.md
@@ -17,7 +17,7 @@ As part of the command, users are expected to provide:
 1. **Specifications for the image** - these are defined as options to the command itself. Available specification options can be viewed by calling the command's help message: `elemental3 customize -h`.
 2. **Information about the desired state of the image** - this is done through the definition of a configuration directory that the user creates beforehand. For more information on the directory itself, refer to the [Configuration Directory Guide](configuration-directory.md).
 
-We recommend you familiarize yourself with both points before attempting to customize your first image. 
+Please familiarize yourself with both points before attempting to customize your first image.
 
 For further understanding of the customization process, you can also refer to the following sections:
 
@@ -78,7 +78,7 @@ Unless configured otherwise, after execution, the process will create a director
 
 > **IMPORTANT:** Access to SUSE's internal VPN is required. As of this moment, our component images are not publicly available. This will change in the future.
 
-> **NOTE:** This section assumes you have pulled the `elemental3` container image and referenced it in the `ELEMENTAL_IMAGE` variable. 
+> **NOTE:** This section assumes you have pulled the `elemental3` container image and referenced it in the `ELEMENTAL_IMAGE` variable.
 
 Run the customization process:
 
@@ -131,20 +131,20 @@ The customized image can be booted as any other regular image. Below you can fin
 * ISO media:
 
    * Create an empty `disk.img` disk image that will be used as a storage device:
-     
+
      ```shell
      truncate -s 20G disk.img
      ```
 
    * Create a local copy of the EFI variable store:
-     
+
      > **NOTE:** This is needed in order to persist any new EFI entries included during the ISO installer boot.
      ```shell
      cp /usr/share/qemu/ovmf-x86_64-vars.bin .
      ```
 
    * Boot a VM using the previously created resources, namely the `customized.iso`, `disk.img` and local EFI store:
-   
+
       ```shell
       virt-install --name customized-iso \
                   --ram 16000 \
@@ -188,7 +188,7 @@ Additionally, the user wants to configure the image’s network and extend the e
 
 #### Configuration directory setup
 
-The user creates a [configuration directory](../examples/elemental/customize/linux-only/) that describes the desired configurations that needs to be applied over the desired `Core Platform` release.
+The user creates a [configuration directory](../examples/elemental/customize/linux-only/) that describes the desired configurations that need to be applied over the desired `Core Platform` release.
 
 The contents of this directory include:
 
@@ -200,7 +200,7 @@ The contents of this directory include:
 #### Producing the customized image
 
 1. Navigate to your configuration directory:
-   
+
    ```shell
    cd examples/elemental/customize/linux-only/
    ```
@@ -211,7 +211,7 @@ The contents of this directory include:
    ```shell
    podman run -it -v .:/config-dir -v /run/podman/podman.sock:/var/run/docker.sock $ELEMENTAL_IMAGE customize --type raw --config-dir /config-dir --output /config-dir/customized.raw --local
    ```
-   
+
 After execution, for a RAW disk type, your `examples/elemental/customize/linux-only` directory should look similar to:
 
 ```text
@@ -226,7 +226,7 @@ After execution, for a RAW disk type, your `examples/elemental/customize/linux-o
 
 #### Booting the image
 
-Following what is described in the "[Booting a customized image](#booting-a-customized-image)" section, we boot a virtual machine using Libvirt: 
+Following what is described in the "[Booting a customized image](#booting-a-customized-image)" section, you boot a virtual machine using Libvirt:
 
 ```shell
 virt-install --name linux-only-example \
@@ -246,7 +246,7 @@ virt-install --name linux-only-example \
 
 #### Environment overview
 
-Once the machine has successfully been booted with the customized image, you can verify the environment going through the following set of steps:
+Once the machine has successfully been booted with the customized image, you can verify the environment by going through the following set of steps:
 
 1. Verify that the expected operating system is running:
 
@@ -292,7 +292,7 @@ Furthermore, using this image, the user wants to setup a single-node Kubernetes 
 
 #### Configuration directory setup
 
-The user creates a [configuration directory](../examples/elemental/customize/single-node/) that describes the desired configurations that needs to be applied over the desired `Product` release.
+The user creates a [configuration directory](../examples/elemental/customize/single-node/) that describes the desired configurations that need to be applied over the desired `Product` release.
 
 The contents of this directory include:
 
@@ -310,7 +310,7 @@ The contents of this directory include:
 #### Producing the customized image
 
 1. Navigate to your configuration directory:
-   
+
    ```shell
    cd examples/elemental/customize/single-node/
    ```
@@ -321,7 +321,7 @@ The contents of this directory include:
    ```shell
    podman run -it -v .:/config-dir -v /run/podman/podman.sock:/var/run/docker.sock $ELEMENTAL_IMAGE customize --type raw --config-dir /config-dir --output /config-dir/customized.raw --local
    ```
-   
+
 After execution, for a RAW disk type, your `examples/elemental/customize/single-node/` directory should look similar to:
 
 ```text
@@ -339,7 +339,7 @@ After execution, for a RAW disk type, your `examples/elemental/customize/single-
 
 #### Booting the image
 
-Following what is described in the [Booting a customized image](#booting-a-customized-image) section, we boot a virtual machine using Libvirt: 
+Following what is described in the [Booting a customized image](#booting-a-customized-image) section, you boot a virtual machine using Libvirt:
 
 ```shell
 virt-install --name single-node-example \
@@ -359,7 +359,7 @@ virt-install --name single-node-example \
 
 #### Environment overview
 
-Once the machine has successfully been booted with the customized image, you can verify the environment going through the following set of steps:
+Once the machine has successfully been booted with the customized image, you can verify the environment by going through the following set of steps:
 
 1. Verify that the expected operating system is running:
 
@@ -492,7 +492,7 @@ Furthermore, using this image, the user wants to setup a multi-node Kubernetes c
 
 #### Configuration directory setup
 
-The user creates a [configuration directory](../examples/elemental/customize/multi-node/) that describes the desired configurations that needs to be applied over the desired `Product` release.
+The user creates a [configuration directory](../examples/elemental/customize/multi-node/) that describes the desired configurations that need to be applied over the desired `Product` release.
 
 The contents of the directory are the same as the contents for a [single-node Kubernetes setup](#configuration-directory-setup-1), with the following additions:
 
@@ -503,7 +503,7 @@ The contents of the directory are the same as the contents for a [single-node Ku
 #### Producing the customized image
 
 1. Navigate to your configuration directory:
-   
+
    ```shell
    cd examples/elemental/customize/multi-node/
    ```
@@ -514,8 +514,8 @@ The contents of the directory are the same as the contents for a [single-node Ku
    ```shell
    podman run -it -v .:/config-dir -v /run/podman/podman.sock:/var/run/docker.sock $ELEMENTAL_IMAGE customize --type raw --config-dir /config-dir --output /config-dir/customized.raw --local
    ```
-   
-After execution, for a RAW disk type, your `examples/elemental/customize/single-node/` directory should look similar to:
+
+After execution, for a RAW disk type, your `examples/elemental/customize/multi-node/` directory should look similar to:
 
 ```text
 .
@@ -534,7 +534,7 @@ After execution, for a RAW disk type, your `examples/elemental/customize/single-
 
 > **NOTE:** This section assumes that each node will be booted using a copy of the produced `customized.raw` image as disk.
 
-Following what is described in the "[Booting a customized image](#booting-a-customized-image)" section, for each desired node, we boot a virtual machine using the following template: 
+Following what is described in the "[Booting a customized image](#booting-a-customized-image)" section, for each desired node, you boot a virtual machine using the following template:
 
 ```shell
 virt-install --name <machine-name> \
@@ -561,10 +561,10 @@ Where:
 Much of the environment validation is the same as for the [single-node Kubernetes cluster](#environment-overview-1) environment with following validation additions:
 
 1. Validate [endpoint-copier-operator](https://github.com/suse-edge/endpoint-copier-operator) is deployed:
-   
+
    ```shell
    kubectl get pods -n endpoint-copier-operator
-   
+
    # Example output
    NAME                                        READY   STATUS    RESTARTS      AGE
    endpoint-copier-operator-695f9b84f6-lcvmw   1/1     Running   1 (17m ago)   19m
@@ -572,7 +572,7 @@ Much of the environment validation is the same as for the [single-node Kubernete
    ```
 
 1. Validate `kubernetes-vip` service is created and running the IP specified in the [kubernetes.yaml](../examples/elemental/customize/multi-node/kubernetes.yaml) file:
-   
+
    ```shell
    kubectl get svc kubernetes-vip
 


### PR DESCRIPTION
In technical documentation, there is no we. It is either the writer or the reader. The reader should be referred to as you.

also a few typos I found while reading.