### PR TITLE
customize: do not replace extension in --output flag

### DIFF
--- a/internal/cli/action/customize.go
+++ b/internal/cli/action/customize.go
@@ -57,7 +57,7 @@ func Customize(ctx *cli.Context) error {
 	}
 
 	defer func() {
-		logger.Debug("Cleaning up temporary working directory", tmpDir)
+		logger.Debug("Cleaning up temporary working directory %s", tmpDir)
 		rmErr := fs.RemoveAll(tmpDir)
 		if rmErr != nil {
 			logger.Error("Cleaning up temporary working directory '%s' failed: %v", tmpDir, rmErr)

--- a/internal/customize/customize.go
+++ b/internal/customize/customize.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	_ "embed"
 
@@ -134,8 +133,7 @@ func (r *Runner) Run(ctx context.Context, def *image.Definition, outputDir confi
 		media := installer.NewMedia(ctx, r.System, mediaType, mediaOpts...)
 		media.InputFile = iso
 		media.OutputDir = filepath.Dir(def.Image.OutputImageName)
-		imageName := filepath.Base(def.Image.OutputImageName)
-		media.Name = strings.TrimSuffix(imageName, filepath.Ext(imageName))
+		media.Name = filepath.Base(def.Image.OutputImageName)
 		r.Media = media
 	}
 


### PR DESCRIPTION
With #302, as a side effect, #300 got almost fixed, but not entirely. Essentially now running `customize` command with an output like `--output myappliance.img` will result on creating an image file named `myappliance.raw` (or  `.iso` for ISO types). This PR does not replace any eventual extension and it simply appends on it.

So with the current PR flag such as `--output myappliance.img` would produce `myappliance.img.raw` for RAW types or `myappliance.img.iso` for ISOs.

Fixes #300