### PR TITLE
Switch recovery and config partitions to ext4 FS

### DIFF
--- a/internal/customize/customize.go
+++ b/internal/customize/customize.go
@@ -187,7 +187,7 @@ func parseDeployment(
 			Label:      deployment.ConfigLabel,
 			MountPoint: deployment.ConfigMnt,
 			Role:       deployment.Data,
-			FileSystem: deployment.Btrfs,
+			FileSystem: deployment.Ext4,
 			Size:       deployment.MiB(configSize/128)*128 + 256,
 			Hidden:     true,
 		}

--- a/internal/customize/customize_test.go
+++ b/internal/customize/customize_test.go
@@ -203,7 +203,7 @@ disks:
 			Label:      deployment.ConfigLabel,
 			MountPoint: deployment.ConfigMnt,
 			Role:       deployment.Data,
-			FileSystem: deployment.Btrfs,
+			FileSystem: deployment.Ext4,
 			Size:       256,
 			Hidden:     true,
 		}))

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -592,7 +592,7 @@ func WithConfigPartition(size MiB) Opt {
 		Label:      ConfigLabel,
 		MountPoint: ConfigMnt,
 		Role:       Data,
-		FileSystem: Btrfs,
+		FileSystem: Ext4,
 		Size:       size,
 		Hidden:     true,
 	}
@@ -608,7 +608,7 @@ func WithRecoveryPartition(size MiB) Opt {
 	part := &Partition{
 		Label:      RecoveryLabel,
 		Role:       Recovery,
-		FileSystem: Btrfs,
+		FileSystem: Ext4,
 		Size:       size,
 		Hidden:     true,
 	}
@@ -698,7 +698,7 @@ func checkRecoveryPart(s *sys.System, d *Deployment) error {
 					part.RWVolumes = []RWVolume{}
 				}
 				if part.FileSystem.String() == Unknown {
-					part.FileSystem = Ext2
+					part.FileSystem = Ext4
 				}
 				if part.Label == "" {
 					part.Label = RecoveryLabel


### PR DESCRIPTION
Increase the extra space added for recovery partition and use ext4 FS for config and recovery partitions by default.

Fixes #287