### PR TITLE
Allow users to provide credentials for Helm Charts

### DIFF
--- a/docs/configuration-directory.md
+++ b/docs/configuration-directory.md
@@ -31,6 +31,10 @@ components:
   helm:
     - chart: foo
       valuesFile: foo.yaml
+    - chart: bar
+      credentials:
+        username: user
+        password: pass
   systemd:
     - extension: bar
 ```
@@ -42,6 +46,9 @@ components:
   * `helm` - Optional; List of Helm chart components that need to be enabled from the Core Platform base.
     * `chart` - Required; The actual chart that needs to be enabled, as seen in the Core Platform release manifest.
     * `valuesFile` - Optional; The name of the [Helm values file](https://helm.sh/docs/chart_template_guide/values_files/) (not including the path) that will be applied to this chart. The values file must be placed under `kubernetes/helm/values` for the specified chart.
+    * `credentials` - Required for authenticated repositories/registries.
+      * `username` - Required; Defines the username for accessing the specified repository/registry.
+      * `password` - Required; Defines the password for accessing the specified repository/registry.
   * `systemd` - Optional; List of System extensions that need to be enabled from the product base.
     * `extension` - Required; The actual extension that needs to be enabled, as seen in the product release manifest.
 
@@ -115,9 +122,18 @@ helm:
       targetNamespace: "cattle-system"
       repositoryName: "rancher"
       valuesFile: rancher.yaml
+    - name: "cert-manager-fips"
+      version: "1.19.3"
+      targetNamespace: "cmf-system"
+      repositoryName: "application-collection"
   repositories:
     - name: "rancher"
       url: "https://releases.rancher.com/server-charts/stable"
+    - name: "application-collection"
+      url: "oci://dp.apps.rancher.io/charts"
+      credentials:
+        username: user
+        password: pass
 nodes:
 - hostname: node1.example
   type: server
@@ -146,6 +162,9 @@ network:
     * `name` - Required; Defines the name for this repository. This name doesn't have to match the name of the actual
     repository, but must correspond with the `repositoryName` of one or more charts.
     * `url` - Required; Defines the URL where this chart repository can be reached.
+    * `credentials` - Required for authenticated repositories/registries.
+      * `username` - Required; Defines the username for accessing the specified repository/registry.
+      * `password` - Required; Defines the password for accessing the specified repository/registry.
 * `nodes` - Required for multi-node clusters; Defines a list of all nodes that form the cluster.
   * `hostname` -  Required; Indicates the fully qualified domain name (FQDN) to identify the particular node on which the remainder of these attributes will be applied.
   * `type` - Required; Selects the Kubernetes node type, either server (for control plane nodes) or agent (for worker nodes).

--- a/internal/cli/action/init.go
+++ b/internal/cli/action/init.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/urfave/cli/v3"
 
 	cmdpkg "github.com/suse/elemental/v3/internal/cli/cmd"
@@ -77,8 +78,52 @@ func defaultConfiguration() *image.Configuration {
 		Release: release.Release{
 			Name:        "my-product",
 			ManifestURI: "oci://registry.example.com/my-product/release-manifest:latest",
+			Components: release.Components{
+				HelmCharts: []release.HelmChart{
+					{
+						Name: "metallb",
+					},
+					{
+						Name: "endpoint-copier-operator",
+						Credentials: &auth.Credentials{
+							Username: "release-user",
+							Password: "release-pass",
+						},
+					},
+				},
+			},
 		},
 		Kubernetes: kubernetes.Kubernetes{
+			Helm: &kubernetes.Helm{
+				Charts: []*kubernetes.HelmChart{
+					{
+						Name:            "example-chart",
+						RepositoryName:  "example-chart-collection",
+						Version:         "1.0",
+						TargetNamespace: "exampleNamespace",
+					},
+					{
+						Name:            "example-auth-chart",
+						RepositoryName:  "example-auth-chart-collection",
+						Version:         "2.0",
+						TargetNamespace: "exampleNamespace",
+					},
+				},
+				Repositories: []*kubernetes.HelmRepository{
+					{
+						Name: "example-chart-collection",
+						URL:  "https://example-charts.io",
+					},
+					{
+						Name: "example-auth-chart-collection",
+						URL:  "https://example-auth-charts.io",
+						Credentials: &auth.Credentials{
+							Username: "example-user",
+							Password: "example-pass",
+						},
+					},
+				},
+			},
 			Nodes: kubernetes.Nodes{
 				{
 					Hostname: "node1.example",

--- a/internal/cli/action/init_test.go
+++ b/internal/cli/action/init_test.go
@@ -35,6 +35,34 @@ import (
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
+var expectedReleaseSubstring = `components:
+  helm:
+    - chart: metallb
+    - chart: endpoint-copier-operator
+      credentials:
+        username: release-user
+        password: release-pass`
+var expectedClusterSubstring = `helm:
+  charts:
+    - name: example-chart
+      repositoryName: example-chart-collection
+      version: "1.0"
+      targetNamespace: exampleNamespace
+      valuesFile: ""
+    - name: example-auth-chart
+      repositoryName: example-auth-chart-collection
+      version: "2.0"
+      targetNamespace: exampleNamespace
+      valuesFile: ""
+  repositories:
+    - name: example-chart-collection
+      url: https://example-charts.io
+    - name: example-auth-chart-collection
+      url: https://example-auth-charts.io
+      credentials:
+        username: example-user
+        password: example-pass`
+
 var _ = Describe("Init action", Label("init"), func() {
 	var s *sys.System
 	var tfs vfs.FS
@@ -95,12 +123,21 @@ var _ = Describe("Init action", Label("init"), func() {
 		Expect(string(data)).To(ContainSubstring("bootloader: grub"))
 	})
 
+	It("writes valid cluster.yaml with auth and non-auth helm repositories", func() {
+		Expect(action.Init(context.Background(), cliCmd)).To(Succeed())
+
+		data, err := tfs.ReadFile(filepath.Join(targetDir, "kubernetes", "cluster.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring(expectedClusterSubstring))
+	})
+
 	It("writes valid release.yaml with manifest URI", func() {
 		Expect(action.Init(context.Background(), cliCmd)).To(Succeed())
 
 		data, err := tfs.ReadFile(filepath.Join(targetDir, "release.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(data)).To(ContainSubstring("manifestURI:"))
+		Expect(string(data)).To(ContainSubstring(expectedReleaseSubstring))
 	})
 
 	It("writes butane.yaml with root user", func() {

--- a/internal/config/helm.go
+++ b/internal/config/helm.go
@@ -18,11 +18,15 @@ limitations under the License.
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/suse/elemental/v3/internal/image/auth"
+	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/suse/elemental/v3/internal/image"
@@ -42,7 +46,7 @@ type helmChart interface {
 	GetName() string
 	GetInlineValues() map[string]any
 	GetRepositoryName() string
-	ToCRD(values []byte, repository string) *helm.CRD
+	ToCRD(values []byte, repository string, hasAuth bool) *helm.CRD
 }
 
 type Helm struct {
@@ -63,7 +67,7 @@ func NewHelm(fs vfs.FS, valuesResolver helmValuesResolver, logger log.Logger, de
 	}
 }
 
-func (h *Helm) Configure(conf *image.Configuration, rm *resolver.ResolvedManifest) ([]string, error) {
+func (h *Helm) Configure(conf *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
 	if len(conf.Release.Components.HelmCharts) > 0 {
 		var charts []string
 		for _, c := range conf.Release.Components.HelmCharts {
@@ -73,17 +77,22 @@ func (h *Helm) Configure(conf *image.Configuration, rm *resolver.ResolvedManifes
 		h.Logger.Info("Enabling the following Helm components: %s", strings.Join(charts, ", "))
 	}
 
-	charts, err := h.retrieveHelmCharts(rm, conf)
+	charts, secrets, err := h.retrieveHelmCharts(rm, conf)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving helm charts: %w", err)
+		return nil, nil, fmt.Errorf("retrieving helm charts: %w", err)
 	}
 
 	chartFiles, err := h.writeHelmCharts(charts)
 	if err != nil {
-		return nil, fmt.Errorf("writing helm chart resources: %w", err)
+		return nil, nil, fmt.Errorf("writing helm chart resources: %w", err)
 	}
 
-	return chartFiles, nil
+	helmSecrets, err := h.createHelmSecretFileMap(secrets)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating helm secrets: %w", err)
+	}
+
+	return chartFiles, helmSecrets, nil
 }
 
 func (h *Helm) writeHelmCharts(crds []*helm.CRD) ([]string, error) {
@@ -112,19 +121,40 @@ func (h *Helm) writeHelmCharts(crds []*helm.CRD) ([]string, error) {
 	return charts, nil
 }
 
-func (h *Helm) retrieveHelmCharts(rm *resolver.ResolvedManifest, conf *image.Configuration) ([]*helm.CRD, error) {
+func (h *Helm) createHelmSecretFileMap(secrets []*helm.Secret) (map[string][]byte, error) {
+	helmSecrets := make(map[string][]byte)
+	for _, secret := range secrets {
+		data, err := yaml.Marshal(secret)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling secret %s: %w", secret.Metadata.Name, err)
+		}
+
+		secretName := fmt.Sprintf("%s-priority.yaml", secret.Metadata.Name)
+		helmSecrets[secretName] = data
+	}
+
+	return helmSecrets, nil
+}
+
+func (h *Helm) retrieveHelmCharts(rm *resolver.ResolvedManifest, conf *image.Configuration) ([]*helm.CRD, []*helm.Secret, error) {
 	var crds []*helm.CRD
 
 	charts, repositories, err := enabledHelmCharts(rm, conf.Release.Components.HelmCharts, h.Logger)
 	if err != nil {
-		return nil, fmt.Errorf("filtering enabled helm charts: %w", err)
+		return nil, nil, fmt.Errorf("filtering enabled helm charts: %w", err)
 	}
 
 	valueFiles := conf.Release.Components.HelmValueFiles()
 
+	authMap, err := createAuthMap(charts, repositories, conf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating helm chart auth map: %w", err)
+	}
+
 	for _, chart := range charts {
-		if err = h.appendHelmChart(chart, repositories, valueFiles, &crds); err != nil {
-			return nil, fmt.Errorf("collecting helm charts: %w", err)
+		needsAuth := authMap[chart.Chart] != nil
+		if err = h.appendHelmChart(chart, repositories, valueFiles, &crds, needsAuth); err != nil {
+			return nil, nil, fmt.Errorf("collecting helm charts: %w", err)
 		}
 	}
 
@@ -133,16 +163,81 @@ func (h *Helm) retrieveHelmCharts(rm *resolver.ResolvedManifest, conf *image.Con
 		valueFiles = conf.Kubernetes.Helm.ValueFiles()
 
 		for _, chart := range conf.Kubernetes.Helm.Charts {
-			if err = h.appendHelmChart(chart, repositories, valueFiles, &crds); err != nil {
-				return nil, fmt.Errorf("collecting user helm charts: %w", err)
+			needsAuth := authMap[chart.Name] != nil
+			if err = h.appendHelmChart(chart, repositories, valueFiles, &crds, needsAuth); err != nil {
+				return nil, nil, fmt.Errorf("collecting user helm charts: %w", err)
 			}
 		}
 	}
 
-	return crds, nil
+	return crds, generateHelmSecrets(authMap), nil
 }
 
-func (h *Helm) appendHelmChart(chart helmChart, repositories, valueFiles map[string]string, crds *[]*helm.CRD) error {
+func createAuthMap(charts []*api.HelmChart, repositories map[string]string, conf *image.Configuration) (map[string]*auth.HelmAuth, error) {
+	authMap := make(map[string]*auth.HelmAuth)
+	if conf.Release.Components.HelmCharts != nil {
+		releaseChartsMap := make(map[string]*api.HelmChart, len(charts))
+		for _, c := range charts {
+			releaseChartsMap[c.Chart] = c
+		}
+
+		for _, rc := range conf.Release.Components.HelmCharts {
+			c, ok := releaseChartsMap[rc.Name]
+			if !ok || rc.Credentials == nil {
+				continue
+			}
+			extractedHost, err := extractHost(repositories[c.Repository])
+			if err != nil {
+				return nil, fmt.Errorf("extracting host: %w", err)
+			}
+			authMap[c.Chart] = &auth.HelmAuth{
+				URL: extractedHost,
+				Credentials: auth.Credentials{
+					Username: rc.Credentials.Username,
+					Password: rc.Credentials.Password,
+				},
+			}
+		}
+	}
+
+	if conf.Kubernetes.Helm != nil {
+		reposByName := make(map[string]*kubernetes.HelmRepository, len(conf.Kubernetes.Helm.Repositories))
+		for _, r := range conf.Kubernetes.Helm.Repositories {
+			reposByName[r.Name] = r
+		}
+		for _, c := range conf.Kubernetes.Helm.Charts {
+			r, ok := reposByName[c.RepositoryName]
+			if !ok || r.Credentials == nil {
+				continue
+			}
+			extractedHost, err := extractHost(r.URL)
+			if err != nil {
+				return nil, fmt.Errorf("extracting host: %w", err)
+			}
+			authMap[c.Name] = &auth.HelmAuth{
+				URL: extractedHost,
+				Credentials: auth.Credentials{
+					Username: r.Credentials.Username,
+					Password: r.Credentials.Password,
+				},
+			}
+		}
+	}
+
+	return authMap, nil
+}
+
+func generateHelmSecrets(authMap map[string]*auth.HelmAuth) []*helm.Secret {
+	var secrets []*helm.Secret
+
+	for chart, creds := range authMap {
+		secrets = append(secrets, NewSecret(chart, creds))
+	}
+
+	return secrets
+}
+
+func (h *Helm) appendHelmChart(chart helmChart, repositories, valueFiles map[string]string, crds *[]*helm.CRD, needsAuth bool) error {
 	name := chart.GetName()
 	repository, ok := repositories[chart.GetRepositoryName()]
 	if !ok {
@@ -155,7 +250,7 @@ func (h *Helm) appendHelmChart(chart helmChart, repositories, valueFiles map[str
 		return fmt.Errorf("resolving values for chart %s: %w", name, err)
 	}
 
-	crd := chart.ToCRD(values, repository)
+	crd := chart.ToCRD(values, repository, needsAuth)
 	*crds = append(*crds, crd)
 
 	return nil
@@ -234,4 +329,36 @@ func enabledHelmCharts(rm *resolver.ResolvedManifest, enabled []release.HelmChar
 	}
 
 	return charts, repositories, nil
+}
+
+func NewSecret(name string, creds *auth.HelmAuth) *helm.Secret {
+	a := base64.StdEncoding.EncodeToString([]byte(creds.Credentials.Username + ":" + creds.Credentials.Password))
+	dockerConfig := fmt.Sprintf(`{"auths":{"%s":{"username":"%s","password":"%s","auth":"%s"}}}`, creds.URL, creds.Credentials.Username, creds.Credentials.Password, a)
+	encoded := base64.StdEncoding.EncodeToString([]byte(dockerConfig))
+
+	return &helm.Secret{
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Metadata: helm.SecretMetadata{
+			Name:      fmt.Sprintf("%s-auth", name),
+			Namespace: "kube-system",
+		},
+		Type: "kubernetes.io/dockerconfigjson",
+		Data: helm.SecretData{
+			DockerConfigJSON: encoded,
+		},
+	}
+}
+
+func extractHost(rawURL string) (string, error) {
+	r := rawURL
+	if !strings.Contains(r, "://") {
+		r = "https://" + r
+	}
+	u, err := url.Parse(r)
+	if err != nil {
+		return "", fmt.Errorf("parsing url %q: %w", r, err)
+	}
+
+	return u.Host, nil
 }

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -23,8 +23,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/internal/image/release"
 	"github.com/suse/elemental/v3/pkg/helm"
@@ -154,10 +154,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver, Logger: logger}
 
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting helm charts: resolving values for chart metallb: resolving failed"))
 			Expect(charts).To(BeNil())
+			Expect(secrets).To(BeNil())
 		})
 
 		It("Fails resolving values of product Helm chart", func() {
@@ -176,10 +177,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver, Logger: logger}
 
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting helm charts: resolving values for chart neuvector-crd: resolving failed"))
 			Expect(charts).To(BeNil())
+			Expect(secrets).To(BeNil())
 		})
 
 		It("Fails resolving values of user Helm chart", func() {
@@ -208,10 +210,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver}
 
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting user helm charts: resolving values for chart apache: resolving failed"))
 			Expect(charts).To(BeNil())
+			Expect(secrets).To(BeNil())
 		})
 
 		It("Fails to collect chart with a missing repository", func() {
@@ -233,10 +236,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 			}
 
 			h := &Helm{ValuesResolver: resolver}
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting user helm charts: repository not found for chart: apache"))
 			Expect(charts).To(BeNil())
+			Expect(secrets).To(BeNil())
 		})
 
 		It("Fails enabling a missing release chart", func() {
@@ -255,10 +259,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver, Logger: logger}
 
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: filtering enabled helm charts: adding helm chart 'rancher': helm chart does not exist"))
 			Expect(charts).To(BeNil())
+			Expect(secrets).To(BeNil())
 		})
 
 		It("Fails writing Helm charts to the FS", func() {
@@ -278,10 +283,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 				RelativePath:   helmPath,
 			}
 
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("writing helm chart resources: creating directory: Mkdir /etc/overlays/helm: operation not permitted"))
 			Expect(charts).To(BeNil())
+			Expect(secrets).To(BeNil())
 		})
 
 		It("Collects and writes core, product and user Helm charts to the FS", func() {
@@ -347,8 +353,9 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 				Logger:         logger,
 			}
 
-			charts, err := h.Configure(conf, rm)
+			charts, secrets, err := h.Configure(conf, rm)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(secrets).To(BeEmpty())
 			Expect(charts).To(ConsistOf(
 				"/helm/metallb.yaml",
 				"/helm/endpoint-copier-operator.yaml",
@@ -483,6 +490,181 @@ spec:
 			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "nginx.yaml"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(b)).To(Equal(contents))
+		})
+
+		It("Collects and writes core, product and user Helm charts with auth to the FS", func() {
+			fs, cleanup, err := sysmock.TestFS(map[string]string{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(cleanup)
+
+			resolver := &helm.ValuesResolver{
+				ValuesDir: filepath.Join(overlaysPath, helmPath),
+				FS:        fs,
+			}
+
+			conf := &image.Configuration{
+				Release: release.Release{
+					Components: release.Components{
+						HelmCharts: []release.HelmChart{
+							{Name: "metallb"},
+							{
+								Name: "endpoint-copier-operator",
+								Credentials: &auth.Credentials{
+									Username: "eco-user",
+									Password: "eco-pass",
+								},
+							},
+						},
+					},
+				},
+				Kubernetes: kubernetes.Kubernetes{
+					Helm: &kubernetes.Helm{
+						Charts: []*kubernetes.HelmChart{
+							{
+								Name:            "apache",
+								RepositoryName:  "apache",
+								TargetNamespace: "web",
+								Version:         "10.7.0",
+							},
+							{
+								Name:            "nginx",
+								RepositoryName:  "nginx",
+								TargetNamespace: "web",
+								Version:         "1.29.3",
+							},
+							{
+								Name:            "suse-storage",
+								RepositoryName:  "storage",
+								TargetNamespace: "suse-storage",
+								Version:         "1.11.0",
+							},
+						},
+						Repositories: []*kubernetes.HelmRepository{
+							{
+								Name: "apache",
+								URL:  "https://example.com/apache",
+								Credentials: &auth.Credentials{
+									Username: "apache-user",
+									Password: "apache-pass",
+								},
+							},
+							{
+								Name: "nginx",
+								URL:  "oci://example.com/web",
+							},
+							{
+								Name: "storage",
+								URL:  "oci://example-1.com/charts",
+								Credentials: &auth.Credentials{
+									Username: "storage-user",
+									Password: "storage-pass",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			h := &Helm{
+				FS:             fs,
+				ValuesResolver: resolver,
+				DestinationDir: overlaysPath,
+				RelativePath:   helmPath,
+				Logger:         logger,
+			}
+
+			charts, secrets, err := h.Configure(conf, rm)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(charts).To(ConsistOf(
+				"/helm/metallb.yaml",
+				"/helm/endpoint-copier-operator.yaml",
+				"/helm/apache.yaml",
+				"/helm/nginx.yaml",
+				"/helm/suse-storage.yaml"))
+
+			apacheAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: apache-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6ImFwYWNoZS11c2VyIiwicGFzc3dvcmQiOiJhcGFjaGUtcGFzcyIsImF1dGgiOiJZWEJoWTJobExYVnpaWEk2WVhCaFkyaGxMWEJoYzNNPSJ9fX0=\n"
+			storageAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: suse-storage-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoic3RvcmFnZS11c2VyIiwicGFzc3dvcmQiOiJzdG9yYWdlLXBhc3MiLCJhdXRoIjoiYzNSdmNtRm5aUzExYzJWeU9uTjBiM0poWjJVdGNHRnpjdz09In19fQ==\n"
+			ecoAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: endpoint-copier-operator-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoiZWNvLXVzZXIiLCJwYXNzd29yZCI6ImVjby1wYXNzIiwiYXV0aCI6IlpXTnZMWFZ6WlhJNlpXTnZMWEJoYzNNPSJ9fX0=\n"
+
+			Expect(string(secrets["apache-auth-priority.yaml"])).To(Equal(apacheAuthSecret))
+			Expect(string(secrets["endpoint-copier-operator-auth-priority.yaml"])).To(Equal(ecoAuthSecret))
+			Expect(string(secrets["suse-storage-auth-priority.yaml"])).To(Equal(storageAuthSecret))
+
+			// Verify the contents of the various written Helm resources
+			contents := `apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+    name: metallb
+    namespace: kube-system
+spec:
+    chart: metallb
+    version: 302.0.0+up0.14.9
+    repo: https://example.com/suse-core
+    valuesContent: |
+        frrk8s:
+            enabled: true
+    targetNamespace: metallb-system
+    createNamespace: true
+    backOffLimit: 20
+`
+			b, err := fs.ReadFile(filepath.Join(overlaysPath, helmPath, "metallb.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(Equal(contents))
+
+			contents = `apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+    name: endpoint-copier-operator
+    namespace: kube-system
+spec:
+    chart: oci://example-1.com/charts/endpoint-copier-operator
+    version: 0.3.0
+    targetNamespace: endpoint-copier-operator
+    createNamespace: true
+    backOffLimit: 20
+    dockerRegistrySecret:
+        name: endpoint-copier-operator-auth
+`
+			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "endpoint-copier-operator.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(Equal(contents), "full actual:\n%s", string(b))
+			Expect(string(b)).To(Equal(contents))
+
+			contents = `apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+    name: apache
+    namespace: kube-system
+spec:
+    chart: apache
+    version: 10.7.0
+    repo: https://example.com/apache
+    targetNamespace: web
+    createNamespace: true
+    backOffLimit: 20
+    dockerRegistrySecret:
+        name: apache-auth
+`
+			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "apache.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(Equal(contents))
+
+			contents = `apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+    name: nginx
+    namespace: kube-system
+spec:
+    chart: oci://example.com/web/nginx
+    version: 1.29.3
+    targetNamespace: web
+    createNamespace: true
+    backOffLimit: 20
+`
+			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "nginx.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(Equal(contents))
+
 		})
 	})
 

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -41,8 +41,8 @@ var k8sResDeployScriptTpl string
 //go:embed templates/k8s_conf_deploy.sh.tpl
 var k8sConfDeployScriptTpl string
 
-func needsManifestsSetup(conf *image.Configuration) bool {
-	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsHA()
+func needsManifestsSetup(conf *image.Configuration, additionalManifests map[string][]byte) bool {
+	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsHA() || additionalManifests != nil
 }
 
 func needsHelmChartsSetup(conf *image.Configuration) bool {
@@ -50,7 +50,7 @@ func needsHelmChartsSetup(conf *image.Configuration) bool {
 }
 
 func isKubernetesEnabled(conf *image.Configuration) bool {
-	return conf.Release.Components.Kubernetes != nil || needsHelmChartsSetup(conf) || needsManifestsSetup(conf)
+	return conf.Release.Components.Kubernetes != nil || needsHelmChartsSetup(conf) || needsManifestsSetup(conf, nil)
 }
 
 func (m *Manager) configureKubernetes(
@@ -68,20 +68,21 @@ func (m *Manager) configureKubernetes(
 	}
 
 	var runtimeHelmCharts []string
+	var additionalManifests map[string][]byte
 	if needsHelmChartsSetup(conf) {
 		m.system.Logger().Info("Configuring Helm charts")
 
-		runtimeHelmCharts, err = m.helm.Configure(conf, manifest)
+		runtimeHelmCharts, additionalManifests, err = m.helm.Configure(conf, manifest)
 		if err != nil {
 			return "", "", fmt.Errorf("configuring helm charts: %w", err)
 		}
 	}
 
 	var runtimeManifestsDir string
-	if needsManifestsSetup(conf) {
+	if needsManifestsSetup(conf, additionalManifests) {
 		m.system.Logger().Info("Configuring Kubernetes manifests")
 
-		runtimeManifestsDir, err = m.setupManifests(ctx, &conf.Kubernetes, output)
+		runtimeManifestsDir, err = m.setupManifests(ctx, &conf.Kubernetes, additionalManifests, output)
 		if err != nil {
 			return "", "", fmt.Errorf("configuring kubernetes manifests: %w", err)
 		}
@@ -107,7 +108,7 @@ func (m *Manager) configureKubernetes(
 	return k8sResourceScript, k8sConfScript, nil
 }
 
-func (m *Manager) setupManifests(ctx context.Context, k *kubernetes.Kubernetes, output Output) (string, error) {
+func (m *Manager) setupManifests(ctx context.Context, k *kubernetes.Kubernetes, additionalManifests map[string][]byte, output Output) (string, error) {
 	fs := m.system.FS()
 
 	relativeManifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
@@ -129,6 +130,13 @@ func (m *Manager) setupManifests(ctx context.Context, k *kubernetes.Kubernetes, 
 		overlayPath := filepath.Join(manifestsDir, filepath.Base(manifest))
 		if err := vfs.CopyFile(fs, manifest, overlayPath); err != nil {
 			return "", fmt.Errorf("copying local manifest '%s' to '%s': %w", manifest, overlayPath, err)
+		}
+	}
+
+	for name, manifest := range additionalManifests {
+		secretPath := filepath.Join(manifestsDir, filepath.Base(name))
+		if err := fs.WriteFile(secretPath, manifest, 0o644); err != nil {
+			return "", fmt.Errorf("writing secret %q: %w", secretPath, err)
 		}
 	}
 

--- a/internal/config/kubernetes_test.go
+++ b/internal/config/kubernetes_test.go
@@ -24,8 +24,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/internal/image/release"
 	"github.com/suse/elemental/v3/pkg/log"
@@ -40,7 +40,8 @@ var _ = Describe("Kubernetes", func() {
 	Describe("Resources trigger", func() {
 		It("Skips manifests setup if manifests are not provided", func() {
 			conf := &image.Configuration{}
-			Expect(needsManifestsSetup(conf)).To(BeFalse())
+			var additionalManifests map[string][]byte
+			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeFalse())
 		})
 
 		It("Requires manifests setup if local manifests are provided", func() {
@@ -49,7 +50,15 @@ var _ = Describe("Kubernetes", func() {
 					LocalManifests: []string{"/apache.yaml"},
 				},
 			}
-			Expect(needsManifestsSetup(conf)).To(BeTrue())
+			var additionalManifests map[string][]byte
+			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeTrue())
+		})
+
+		It("Requires manifests setup if there are runtime secrets", func() {
+			conf := &image.Configuration{}
+			additionalManifests := make(map[string][]byte)
+			additionalManifests["example"] = []byte("test")
+			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeTrue())
 		})
 
 		It("Requires manifests setup if remote manifests are provided", func() {
@@ -58,7 +67,8 @@ var _ = Describe("Kubernetes", func() {
 					RemoteManifests: []string{"https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml"},
 				},
 			}
-			Expect(needsManifestsSetup(conf)).To(BeTrue())
+			var additionalManifests map[string][]byte
+			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeTrue())
 		})
 
 		It("Skips Helm setup if charts are not provided", func() {
@@ -141,8 +151,8 @@ var _ = Describe("Kubernetes", func() {
 
 		It("Fails to configure Helm charts", func() {
 			helmMock := &helmConfiguratorMock{
-				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, error) {
-					return nil, fmt.Errorf("helm error")
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+					return nil, nil, fmt.Errorf("helm error")
 				},
 			}
 
@@ -229,8 +239,8 @@ var _ = Describe("Kubernetes", func() {
 
 		It("Succeeds to configure RKE2 with additional resources", func() {
 			helmMock := &helmConfiguratorMock{
-				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, error) {
-					return []string{"rancher.yaml"}, nil
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+					return []string{"rancher.yaml"}, nil, nil
 				},
 			}
 
@@ -288,6 +298,7 @@ var _ = Describe("Kubernetes", func() {
 			Expect(string(b)).To(ContainSubstring("deployHelmCharts"))
 			Expect(string(b)).To(ContainSubstring("rancher.yaml"))
 			Expect(string(b)).To(ContainSubstring("deployManifests"))
+			Expect(string(b)).To(ContainSubstring("deployPriorityManifests"))
 
 			_, err = fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
 			Expect(err).NotTo(HaveOccurred())
@@ -332,6 +343,131 @@ var _ = Describe("Kubernetes", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(script).To(BeEmpty())
 			Expect(confScript).ToNot(BeEmpty())
+		})
+
+		It("Succeeds to configure RKE2 with additional resources and auth", func() {
+			additionalManifests := make(map[string][]byte)
+			additionalManifests["example-auth-priority.yaml"] = []byte("apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: example-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLmlvIjp7InVzZXJuYW1lIjoiZXhhbXBsZS11c2VyIiwicGFzc3dvcmQiOiJleGFtcGxlLXBhc3MiLCJhdXRoIjoiWlhoaGJYQnNaUzExYzJWeU9tVjRZVzF3YkdVdGNHRnpjdz09In19fQ==\n")
+			additionalManifests["endpoint-copier-operator-auth-priority.yaml"] = []byte("apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: endpoint-copier-operator-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoiZWNvLXVzZXIiLCJwYXNzd29yZCI6ImVjby1wYXNzIiwiYXV0aCI6IlpXTnZMWFZ6WlhJNlpXTnZMWEJoYzNNPSJ9fX0=\n")
+			helmMock := &helmConfiguratorMock{
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+					return []string{"rancher.yaml"}, additionalManifests, nil
+				},
+			}
+
+			dlFunc := func(ctx context.Context, fs vfs.FS, url, path string) error {
+				return nil
+			}
+
+			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
+				installSh := filepath.Join(destDir, "install.sh")
+				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+			}
+
+			m := NewManager(
+				system,
+				helmMock,
+				WithDownloadFunc(dlFunc),
+				WithUnpackFunc(unpackFunc),
+			)
+
+			manifest := &resolver.ResolvedManifest{
+				CorePlatform: &core.ReleaseManifest{
+					Components: core.Components{
+						Kubernetes: &core.Kubernetes{
+							Version: "v1.35.0+rke2r1",
+							Image:   "registry.example.com/rke2:1.35_1.0",
+						},
+					},
+				},
+			}
+			conf := &image.Configuration{
+				Kubernetes: kubernetes.Kubernetes{
+					RemoteManifests: []string{"some-url"},
+					Helm: &kubernetes.Helm{
+						Charts: []*kubernetes.HelmChart{
+							{
+								Name:            "example",
+								RepositoryName:  "example-repo",
+								Version:         "1.0",
+								TargetNamespace: "exampleNamespace",
+							},
+						},
+						Repositories: []*kubernetes.HelmRepository{
+							{
+								Name: "example-repo",
+								URL:  "https://example.io",
+								Credentials: &auth.Credentials{
+									Username: "example-user",
+									Password: "example-pass",
+								},
+							},
+						},
+					},
+					Nodes: kubernetes.Nodes{
+						{Hostname: "node1", Type: "server"},
+					},
+				},
+				Release: release.Release{
+					Components: release.Components{
+						HelmCharts: []release.HelmChart{
+							{
+								Name: "rancher",
+							},
+							{
+								Name: "endpoint-copier-operator",
+								Credentials: &auth.Credentials{
+									Username: "eco-user",
+									Password: "eco-pass",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			script, confScript, err := m.configureKubernetes(context.Background(), conf, manifest, output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(script).To(Equal("/var/lib/elemental/kubernetes/k8s_res_deploy.sh"))
+
+			// Verify deployment script contents
+			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), script))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring("deployHelmCharts"))
+			Expect(string(b)).To(ContainSubstring("rancher.yaml"))
+			Expect(string(b)).To(ContainSubstring("deployManifests"))
+			Expect(string(b)).To(ContainSubstring("deployPriorityManifests"))
+
+			_, err = fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedECOManifestContents := `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+    name: endpoint-copier-operator-auth
+type: kubernetes.io/dockerconfigjson
+data:
+    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoiZWNvLXVzZXIiLCJwYXNzd29yZCI6ImVjby1wYXNzIiwiYXV0aCI6IlpXTnZMWFZ6WlhJNlpXTnZMWEJoYzNNPSJ9fX0=`
+			ecoSecretManifests := "endpoint-copier-operator-auth-priority.yaml"
+			relativeManifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
+			manifestsDir := filepath.Join(output.OverlaysDir(), relativeManifestsPath)
+			b, err = fs.ReadFile(filepath.Join(manifestsDir, ecoSecretManifests))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring(expectedECOManifestContents))
+
+			expectedExampleManifestContents := `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+    name: example-auth
+type: kubernetes.io/dockerconfigjson
+data:
+    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLmlvIjp7InVzZXJuYW1lIjoiZXhhbXBsZS11c2VyIiwicGFzc3dvcmQiOiJleGFtcGxlLXBhc3MiLCJhdXRoIjoiWlhoaGJYQnNaUzExYzJWeU9tVjRZVzF3YkdVdGNHRnpjdz09In19fQ==`
+			exampleSecretManifests := "example-auth-priority.yaml"
+			b, err = fs.ReadFile(filepath.Join(manifestsDir, exampleSecretManifests))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring(expectedExampleManifestContents))
 		})
 	})
 })

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -36,7 +36,7 @@ type downloadFunc func(ctx context.Context, fs vfs.FS, url, path string) error
 type unpackFunc func(ctx context.Context, imageRef, destDir string) error
 
 type helmConfigurator interface {
-	Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, error)
+	Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error)
 }
 
 type releaseManifestResolver interface {

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -46,10 +46,10 @@ func TestConfigurationSuite(t *testing.T) {
 }
 
 type helmConfiguratorMock struct {
-	configureFunc func(*image.Configuration, *resolver.ResolvedManifest) ([]string, error)
+	configureFunc func(*image.Configuration, *resolver.ResolvedManifest) ([]string, map[string][]byte, error)
 }
 
-func (h *helmConfiguratorMock) Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, error) {
+func (h *helmConfiguratorMock) Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
 	if h.configureFunc != nil {
 		return h.configureFunc(conf, manifest)
 	}
@@ -78,7 +78,7 @@ var _ = Describe("Manager", func() {
 	var cleanup func()
 	var err error
 	var system *sys.System
-	var defaultHelmFunc func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, error)
+	var defaultHelmFunc func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error)
 	var defaultResolveFunc func(uri string) (*resolver.ResolvedManifest, error)
 	var butaneConfigString = `
 version: 1.6.0
@@ -156,8 +156,8 @@ passwd:
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		defaultHelmFunc = func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, error) {
-			return nil, nil
+		defaultHelmFunc = func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+			return nil, nil, nil
 		}
 
 		defaultResolveFunc = func(uri string) (*resolver.ResolvedManifest, error) {
@@ -184,10 +184,10 @@ passwd:
 
 		m := NewManager(
 			system,
-			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, error) {
+			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
 				helmPath := filepath.Join(output.OverlaysDir(), image.HelmPath())
 				if err := vfs.MkdirAll(fs, helmPath, vfs.DirPerm); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 
 				files := []string{}
@@ -195,10 +195,10 @@ passwd:
 					files = append(files, chart.Name)
 					_, err := fs.Create(filepath.Join(helmPath, chart.Name))
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 				}
-				return files, nil
+				return files, nil, nil
 			}},
 			WithManifestResolver(&resolverMock{resolveFunc: func(uri string) (*resolver.ResolvedManifest, error) {
 				if uri == activeConfig.Release.ManifestURI {
@@ -298,8 +298,8 @@ passwd:
 		By("Failing helm configuration")
 		m := NewManager(
 			system,
-			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, error) {
-				return nil, fmt.Errorf("unable to configure helm charts")
+			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+				return nil, nil, fmt.Errorf("unable to configure helm charts")
 			}},
 			WithManifestResolver(&resolverMock{resolveFunc: defaultResolveFunc}),
 		)

--- a/internal/config/templates/k8s_res_deploy.sh.tpl
+++ b/internal/config/templates/k8s_res_deploy.sh.tpl
@@ -95,6 +95,25 @@ deployManifests() {
   local failed=false
   echo "Deploying Kubernetes manifests.."
   for manifest in {{ .ManifestsDir }}/*.yaml; do
+    [[ "$manifest" == *-priority.yaml ]] && continue
+    retryKubectlCreate "$manifest" 6 10
+    if [[ $? -ne 0 ]]; then
+      failed=true
+    fi
+  done
+
+  if [ "$failed" = true ]; then
+    exit 1
+  fi
+}
+{{- end }}
+
+{{- if .ManifestsDir }}
+deployPriorityManifests() {
+  local failed=false
+  echo "Deploying Kubernetes priority manifests.."
+  for manifest in {{ .ManifestsDir }}/*-priority.yaml; do
+    [[ -e "$manifest" ]] || continue
     retryKubectlCreate "$manifest" 6 10
     if [[ $? -ne 0 ]]; then
       failed=true
@@ -136,6 +155,10 @@ waitForCoreRKE2Charts() {
 }
 
 waitForCoreRKE2Charts
+
+{{- if .ManifestsDir }}
+deployPriorityManifests
+{{- end }}
 
 {{- if .HelmCharts }}
 deployHelmCharts

--- a/internal/config/v0/config_test.go
+++ b/internal/config/v0/config_test.go
@@ -68,6 +68,9 @@ helm:
   repositories:
     - name: "foo-charts"
       url: "https://charts.foo.bar"
+      credentials:
+        username: cluster-user
+        password: cluster-pass
 nodes:
   - hostname: node1.foo.bar
     type: server
@@ -85,6 +88,9 @@ components:
   helm:
     - chart: foo
       valuesFile: foo.yaml
+      credentials:
+        username: release-user
+        password: release-pass
 `
 
 var _ = Describe("Configuration", Label("configuration"), func() {
@@ -135,6 +141,8 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 		Expect(conf.Kubernetes.Helm.Charts[0].Version).To(Equal("0.0.0"))
 		Expect(conf.Kubernetes.Helm.Repositories[0].Name).To(Equal("foo-charts"))
 		Expect(conf.Kubernetes.Helm.Repositories[0].URL).To(Equal("https://charts.foo.bar"))
+		Expect(conf.Kubernetes.Helm.Repositories[0].Credentials.Username).To(Equal("cluster-user"))
+		Expect(conf.Kubernetes.Helm.Repositories[0].Credentials.Password).To(Equal("cluster-pass"))
 		Expect(conf.Kubernetes.Nodes[0].Hostname).To(Equal("node1.foo.bar"))
 		Expect(conf.Kubernetes.Nodes[0].Type).To(Equal("server"))
 		Expect(conf.Kubernetes.Network.APIHost).To(Equal("192.168.120.100"))
@@ -152,6 +160,8 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 		Expect(len(conf.Release.Components.HelmCharts)).To(Equal(3))
 		Expect(conf.Release.Components.HelmCharts[0].Name).To(Equal("foo"))
 		Expect(conf.Release.Components.HelmCharts[0].ValuesFile).To(Equal("foo.yaml"))
+		Expect(conf.Release.Components.HelmCharts[0].Credentials.Username).To(Equal("release-user"))
+		Expect(conf.Release.Components.HelmCharts[0].Credentials.Password).To(Equal("release-pass"))
 		Expect(containsChart("metallb", conf.Release.Components.HelmCharts)).To(BeTrue())
 		Expect(containsChart("endpoint-copier-operator", conf.Release.Components.HelmCharts)).To(BeTrue())
 		Expect(conf.Release.ManifestURI).To(Equal("oci://registry.foo.bar/release-manifest:0.0.1"))

--- a/internal/image/auth/auth.go
+++ b/internal/image/auth/auth.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+type HelmAuth struct {
+	URL         string      `yaml:"url"`
+	Credentials Credentials `yaml:"credentials"`
+}
+
+type Credentials struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -20,6 +20,7 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/suse/elemental/v3/pkg/helm"
 )
 
@@ -90,13 +91,14 @@ func (c *HelmChart) GetRepositoryName() string {
 	return c.RepositoryName
 }
 
-func (c *HelmChart) ToCRD(values []byte, repository string) *helm.CRD {
-	return helm.NewCRD(c.TargetNamespace, c.Name, c.Version, string(values), repository)
+func (c *HelmChart) ToCRD(values []byte, repository string, hasAuth bool) *helm.CRD {
+	return helm.NewCRD(c.TargetNamespace, c.Name, c.Version, string(values), repository, hasAuth)
 }
 
 type HelmRepository struct {
-	Name string `yaml:"name" validate:"required"`
-	URL  string `yaml:"url" validate:"required,url"`
+	Name        string            `yaml:"name" validate:"required"`
+	URL         string            `yaml:"url" validate:"required,url"`
+	Credentials *auth.Credentials `yaml:"credentials,omitempty"`
 }
 
 type Node struct {

--- a/internal/image/release/release.go
+++ b/internal/image/release/release.go
@@ -17,6 +17,8 @@ limitations under the License.
 
 package release
 
+import "github.com/suse/elemental/v3/internal/image/auth"
+
 type Release struct {
 	Name        string     `yaml:"name,omitempty"`
 	ManifestURI string     `yaml:"manifestURI" validate:"required"`
@@ -42,6 +44,7 @@ type SystemdExtension struct {
 }
 
 type HelmChart struct {
-	Name       string `yaml:"chart" validate:"required"`
-	ValuesFile string `yaml:"valuesFile,omitempty"`
+	Name        string            `yaml:"chart" validate:"required"`
+	ValuesFile  string            `yaml:"valuesFile,omitempty"`
+	Credentials *auth.Credentials `yaml:"credentials,omitempty"`
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -42,16 +42,38 @@ type Metadata struct {
 }
 
 type Spec struct {
-	Chart           string `yaml:"chart"`
-	Version         string `yaml:"version"`
-	Repo            string `yaml:"repo,omitempty"`
-	ValuesContent   string `yaml:"valuesContent,omitempty"`
-	TargetNamespace string `yaml:"targetNamespace,omitempty"`
-	CreateNamespace bool   `yaml:"createNamespace,omitempty"`
-	BackOffLimit    int    `yaml:"backOffLimit"`
+	Chart           string     `yaml:"chart"`
+	Version         string     `yaml:"version"`
+	Repo            string     `yaml:"repo,omitempty"`
+	ValuesContent   string     `yaml:"valuesContent,omitempty"`
+	TargetNamespace string     `yaml:"targetNamespace,omitempty"`
+	CreateNamespace bool       `yaml:"createNamespace,omitempty"`
+	BackOffLimit    int        `yaml:"backOffLimit"`
+	AuthSecret      AuthSecret `yaml:"dockerRegistrySecret,omitempty"`
 }
 
-func NewCRD(namespace, chart, version, valuesContent, repository string) *CRD {
+type AuthSecret struct {
+	Name string `yaml:"name,omitempty"`
+}
+
+type Secret struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   SecretMetadata `yaml:"metadata"`
+	Type       string         `yaml:"type"`
+	Data       SecretData     `yaml:"data"`
+}
+
+type SecretMetadata struct {
+	Namespace string `yaml:"namespace"`
+	Name      string `yaml:"name"`
+}
+
+type SecretData struct {
+	DockerConfigJSON string `yaml:".dockerconfigjson"`
+}
+
+func NewCRD(namespace, chart, version, valuesContent string, repository string, auth bool) *CRD {
 	name := chart
 
 	if strings.HasPrefix(repository, "oci://") {
@@ -62,7 +84,7 @@ func NewCRD(namespace, chart, version, valuesContent, repository string) *CRD {
 		repository = ""
 	}
 
-	return &CRD{
+	crd := &CRD{
 		APIVersion: helmChartAPIVersion,
 		Kind:       helmChartKind,
 		Metadata: Metadata{
@@ -79,4 +101,12 @@ func NewCRD(namespace, chart, version, valuesContent, repository string) *CRD {
 			BackOffLimit:    helmBackoffLimit,
 		},
 	}
+
+	if auth {
+		crd.Spec.AuthSecret = AuthSecret{
+			Name: fmt.Sprintf("%s-auth", name),
+		}
+	}
+
+	return crd
 }

--- a/pkg/manifest/api/shared.go
+++ b/pkg/manifest/api/shared.go
@@ -63,8 +63,8 @@ func (c *HelmChart) GetRepositoryName() string {
 	return c.Repository
 }
 
-func (c *HelmChart) ToCRD(values []byte, repository string) *helm.CRD {
-	return helm.NewCRD(c.Namespace, c.Chart, c.Version, string(values), repository)
+func (c *HelmChart) ToCRD(values []byte, repository string, hasAuth bool) *helm.CRD {
+	return helm.NewCRD(c.Namespace, c.Chart, c.Version, string(values), repository, hasAuth)
 }
 
 func (c *HelmChart) ExtensionDependencies() []string {


### PR DESCRIPTION
Introduces the ability for users to provide credentials for Helm charts so they can be pulled at build time

Example usage can be seen here:
`release.yaml`
```
helm:
  - chart: endpoint-copier-operator
    credentials:
      username: USER
      password: PASS
```
`cluster.yaml`
```
helm:
  charts:
    - name: "suse-storage"
      version: "1.9.2"
      targetNamespace: "longhorn-system"
      repositoryName: "appco"
      valuesFile: "longhorn.yaml"
    - name: "second-chart"
      version: 1.0.0
      repositoryName: "appco"
  repositories:
    - name: "appco"
      url: "oci://dp.apps.rancher.io/charts"
      credentials:
        username: USER
        password: PASS
```