### PR TITLE
Adds `release-info` flag to `elemental3`

### DIFF
--- a/cmd/elemental/main.go
+++ b/cmd/elemental/main.go
@@ -37,7 +37,9 @@ func main() {
 		cmd.NewBuildCommand(appName, action.Build),
 		cmd.NewCustomizeCommand(appName, action.Customize),
 		cmd.NewInitCommand(appName, action.Init),
-		cmd.NewVersionCommand(appName))
+		cmd.NewVersionCommand(appName),
+		cmd.NewReleaseInfoCommand(appName, action.ReleaseInfo),
+	)
 
 	if err := application.Run(context.Background(), os.Args); err != nil {
 		log.Fatal(err)

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -28,6 +28,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/suse/elemental/v3/pkg/manifest/api"
+	"go.yaml.in/yaml/v3"
+
 	cmdpkg "github.com/suse/elemental/v3/internal/cli/cmd"
 	"github.com/suse/elemental/v3/internal/config"
 	"github.com/suse/elemental/v3/pkg/extractor"
@@ -40,21 +43,25 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// coreManifest struct here is only for the sake of `elemental3 release-info` command;
-// original struct is in pkg/manifest/api/core/manifest.go
-type coreManifest struct {
-	OperatingSystem   string   `yaml:"operatingSystem" json:"operatingSystem,omitempty"`
-	HelmCharts        []string `yaml:"helmCharts,omitempty" json:"helmCharts,omitempty"`
-	HelmRepos         []string `yaml:"helmRepos,omitempty" json:"helmRepos,omitempty"`
-	SystemdExtensions []string `yaml:"systemdExtensions,omitempty" json:"systemdExtensions,omitempty"`
+// ManifestInfo holds the structured information for display
+type ManifestInfo struct {
+	Core    *CoreInfo    `json:"core,omitempty" yaml:"core,omitempty"`
+	Product *ProductInfo `json:"product,omitempty" yaml:"product,omitempty"`
 }
 
-// productManifest struct here is only for the sake of `elemental3 release-info` command;
-// original struct is in pkg/manifest/api/product/manifest.go
-type productManifest struct {
-	SystemdExtensions []string `yaml:"systemdExtensions"`
-	HelmCharts        []string `yaml:"helmCharts"`
-	HelmRepos         []string `yaml:"helmRepos"`
+// CoreInfo represents core manifest details
+type CoreInfo struct {
+	OperatingSystem   string   `json:"operatingSystem" yaml:"operatingSystem"`
+	HelmCharts        []string `json:"helmCharts,omitempty" yaml:"helmCharts,omitempty"`
+	HelmRepos         []string `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
+	SystemdExtensions []string `json:"systemdExtensions,omitempty" yaml:"systemdExtensions,omitempty"`
+}
+
+// ProductInfo represents product manifest details
+type ProductInfo struct {
+	SystemdExtensions []string `json:"systemdExtensions,omitempty" yaml:"systemdExtensions,omitempty"`
+	HelmCharts        []string `json:"helmCharts,omitempty" yaml:"helmCharts,omitempty"`
+	HelmRepos         []string `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
 }
 
 func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
@@ -66,11 +73,21 @@ func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
 
 	system.Logger().Debug("release-info called with args: %+v", args)
 
-	// check if the provided arg is a local file or an OCI image
 	arg := cmd.Args().Get(0)
-	srcType, err := argSourceType(system, arg)
+	resolved, err := resolveManifest(ctx, system, arg, args.Local)
 	if err != nil {
 		return err
+	}
+
+	info := buildManifestInfo(resolved, args.Core, args.Product)
+
+	return printManifestInfo(info, args.Output)
+}
+
+func resolveManifest(ctx context.Context, system *sys.System, arg string, local bool) (*resolver.ResolvedManifest, error) {
+	srcType, err := argSourceType(system, arg)
+	if err != nil {
+		return nil, err
 	}
 	system.Logger().Debug("found source type: %s", srcType)
 
@@ -80,63 +97,141 @@ func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if srcType == source.OCI {
-		_, err = name.ParseReference(uri)
-		if err != nil {
-			return fmt.Errorf("invalid OCI image reference: %w", err)
+		if _, err := name.ParseReference(uri); err != nil {
+			return nil, fmt.Errorf("invalid OCI image reference: %w", err)
 		}
 	}
 
 	output, err := config.NewOutput(system.FS(), "", "")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer output.Cleanup(system.FS())
 
-	resolver, err := manifestResolver(system.FS(), output, args.Local)
+	res, err := manifestResolver(system.FS(), output, local)
 	if err != nil {
-		return err
-	}
-	resolvedManifest, err := resolver.Resolve(uri)
-	if err != nil {
-		return err
+		return nil, err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
+	return res.Resolve(uri)
+}
 
-	coreManifestOut := generateCoreManifest(resolvedManifest.CorePlatform)
-	//var pmOut *productManifest
-	//if resolvedManifest.ProductExtension != nil {
-	//	pmOut = printProductManifest(w, resolvedManifest.ProductExtension)
-	//
-	//	fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", len("Product Manifest")))
-	//	fmt.Fprintf(w, "Helm Charts\t %s\n", strings.Join(pmOut.HelmCharts, ", "))
-	//	fmt.Fprintf(w, "Helm Repositories\t %s \n", strings.Join(pmOut.HelmRepos, ", "))
-	//	fmt.Fprintln(w)
-	//}
-	//
-	//fmt.Fprintf(w, "Core Manifest\n%s\n", strings.Repeat("-", len("Core Manifest")))
-	//fmt.Fprintf(w, "Operating System\t %s\n", coreManifestOut.OperatingSystem)
-	//fmt.Fprintf(w, "Helm Charts\t %s\n", strings.Join(coreManifestOut.HelmCharts, ", "))
-	//fmt.Fprintf(w, "Helm Repositories\t %s \n", strings.Join(coreManifestOut.HelmRepos, ", "))
-	//
+func buildManifestInfo(resolved *resolver.ResolvedManifest, showCore, showProduct bool) *ManifestInfo {
+	info := &ManifestInfo{}
+
+	// If neither core nor product is specified, or both are specified, show both
+	defaultShow := (!showCore && !showProduct) || (showCore && showProduct)
+
+	if (showCore || defaultShow) && resolved.CorePlatform != nil {
+		info.Core = mapCoreInfo(resolved.CorePlatform)
+	}
+
+	if (showProduct || defaultShow) && resolved.ProductExtension != nil {
+		info.Product = mapProductInfo(resolved.ProductExtension)
+	}
+
+	return info
+}
+
+func printManifestInfo(info *ManifestInfo, format string) error {
+	switch strings.ToLower(format) {
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(info)
+	case "yaml":
+		encoder := yaml.NewEncoder(os.Stdout)
+		return encoder.Encode(info)
+	case "":
+		printTable(info)
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+func printTable(info *ManifestInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	if info.Product != nil {
+		fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", 16))
+		if len(info.Product.SystemdExtensions) > 0 {
+			fmt.Fprintf(w, "Systemd Extensions\t%s\n", strings.Join(info.Product.SystemdExtensions, ", "))
+		}
+		if len(info.Product.HelmCharts) > 0 {
+			fmt.Fprintf(w, "Helm Charts\t%s\n", strings.Join(info.Product.HelmCharts, ", "))
+		}
+		if len(info.Product.HelmRepos) > 0 {
+			fmt.Fprintf(w, "Helm Repositories\t%s\n", strings.Join(info.Product.HelmRepos, ", "))
+		}
+		fmt.Fprintln(w)
+	}
+
+	if info.Core != nil {
+		fmt.Fprintf(w, "Core Manifest\n%s\n", strings.Repeat("-", 13))
+		fmt.Fprintf(w, "Operating System\t%s\n", info.Core.OperatingSystem)
+		if len(info.Core.SystemdExtensions) > 0 {
+			fmt.Fprintf(w, "Systemd Extensions\t%s\n", strings.Join(info.Core.SystemdExtensions, ", "))
+		}
+		if len(info.Core.HelmCharts) > 0 {
+			fmt.Fprintf(w, "Helm Charts\t%s\n", strings.Join(info.Core.HelmCharts, ", "))
+		}
+		if len(info.Core.HelmRepos) > 0 {
+			fmt.Fprintf(w, "Helm Repositories\t%s\n", strings.Join(info.Core.HelmRepos, ", "))
+		}
+		fmt.Fprintln(w)
+	}
+
 	w.Flush()
-	//
-	//if pmOut != nil {
-	//	data, err := yaml.Marshal(&pmOut)
-	//	if err != nil {
-	//		return err
-	//	}
-	//	fmt.Println()
-	//	fmt.Println(string(data))
-	//}
-	data, err := json.Marshal(&coreManifestOut)
-	if err != nil {
-		return err
-	}
-	fmt.Println()
-	fmt.Println(string(data))
+}
 
-	return nil
+func mapCoreInfo(cm *core.ReleaseManifest) *CoreInfo {
+	osName := "Unknown"
+	if cm.Components.OperatingSystem.Image.Base != "" {
+		parts := strings.Split(cm.Components.OperatingSystem.Image.Base, ":")
+		if len(parts) > 1 {
+			osName = "SLES " + strings.Split(parts[1], "-")[0]
+		}
+	}
+
+	return &CoreInfo{
+		OperatingSystem:   osName,
+		HelmCharts:        mapHelmCharts(cm.Components.Helm.Charts),
+		HelmRepos:         mapHelmRepos(cm.Components.Helm.Repositories),
+		SystemdExtensions: mapSystemdExtensions(cm.Components.Systemd.Extensions),
+	}
+}
+
+func mapProductInfo(pm *product.ReleaseManifest) *ProductInfo {
+	return &ProductInfo{
+		SystemdExtensions: mapSystemdExtensions(pm.Components.Systemd.Extensions),
+		HelmCharts:        mapHelmCharts(pm.Components.Helm.Charts),
+		HelmRepos:         mapHelmRepos(pm.Components.Helm.Repositories),
+	}
+}
+
+func mapHelmCharts(charts []*api.HelmChart) []string {
+	var result []string
+	for _, h := range charts {
+		result = append(result, fmt.Sprintf("%s (%s)", h.GetName(), h.GetRepositoryName()))
+	}
+	return result
+}
+
+func mapHelmRepos(repos []*api.HelmRepository) []string {
+	var result []string
+	for _, r := range repos {
+		result = append(result, r.Name)
+	}
+	return result
+}
+
+func mapSystemdExtensions(exts []api.SystemdExtension) []string {
+	var result []string
+	for _, e := range exts {
+		result = append(result, e.Name)
+	}
+	return result
 }
 
 // argSourceType takes a string argument and returns if the release manifest source type is a file or an OCI image
@@ -159,51 +254,6 @@ func argSourceType(s *sys.System, arg string) (source.ReleaseManifestSourceType,
 		return source.File, nil
 	}
 	return source.OCI, nil
-}
-
-func generateCoreManifest(cm *core.ReleaseManifest) *coreManifest {
-	var os string
-	os = strings.Split(cm.Components.OperatingSystem.Image.Base, ":")[1]
-	os = "SLES " + strings.Split(os, "-")[0]
-
-	var helmCharts, helmRepos, systemdExtensions []string
-
-	for _, h := range cm.Components.Helm.Charts {
-		helmCharts = append(helmCharts, fmt.Sprintf("%s (%s)", h.GetName(), h.GetRepositoryName()))
-	}
-	for _, r := range cm.Components.Helm.Repositories {
-		helmRepos = append(helmRepos, r.Name)
-	}
-	for _, e := range cm.Components.Systemd.Extensions {
-		systemdExtensions = append(systemdExtensions, e.Name)
-	}
-
-	return &coreManifest{
-		OperatingSystem:   os,
-		HelmCharts:        helmCharts,
-		HelmRepos:         helmRepos,
-		SystemdExtensions: systemdExtensions,
-	}
-}
-
-func printProductManifest(w *tabwriter.Writer, pm *product.ReleaseManifest) *productManifest {
-	var systemdExtensions, helmCharts, helmRepos []string
-
-	for _, e := range pm.Components.Systemd.Extensions {
-		systemdExtensions = append(systemdExtensions, e.Name)
-	}
-	for _, h := range pm.Components.Helm.Charts {
-		helmCharts = append(helmCharts, fmt.Sprintf("%s (%s)", h.GetName(), h.GetRepositoryName()))
-	}
-	for _, r := range pm.Components.Helm.Repositories {
-		helmRepos = append(helmRepos, r.Name)
-	}
-
-	return &productManifest{
-		SystemdExtensions: systemdExtensions,
-		HelmCharts:        helmCharts,
-		HelmRepos:         helmRepos,
-	}
 }
 
 func manifestResolver(fs vfs.FS, out config.Output, local bool) (*resolver.Resolver, error) {

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -64,7 +64,7 @@ type ProductInfo struct {
 	HelmRepos         []string `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
 }
 
-func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
+func ReleaseInfo(_ context.Context, cmd *cli.Command) error {
 	if cmd.Root().Metadata == nil || cmd.Root().Metadata["system"] == nil {
 		return fmt.Errorf("error setting up initial configuration")
 	}
@@ -74,7 +74,7 @@ func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
 	system.Logger().Debug("release-info called with args: %+v", args)
 
 	arg := cmd.Args().Get(0)
-	resolved, err := resolveManifest(ctx, system, arg, args.Local)
+	resolved, err := resolveManifest(system, arg, args.Local)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
 	return printManifestInfo(info, args.Output, system.Logger().GetOutput())
 }
 
-func resolveManifest(ctx context.Context, system *sys.System, arg string, local bool) (*resolver.ResolvedManifest, error) {
+func resolveManifest(system *sys.System, arg string, local bool) (*resolver.ResolvedManifest, error) {
 	srcType, err := argSourceType(system, arg)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,12 @@ func resolveManifest(ctx context.Context, system *sys.System, arg string, local 
 	if err != nil {
 		return nil, err
 	}
-	defer output.Cleanup(system.FS())
+	defer func() {
+		system.Logger().Debug("Cleaning up working directory")
+		if rmErr := system.FS(); rmErr != nil {
+			system.Logger().Error("Cleaning up working directory failed: %v", rmErr)
+		}
+	}()
 
 	res, err := manifestResolver(system.FS(), output, local)
 	if err != nil {

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -73,6 +73,10 @@ func ReleaseInfo(_ context.Context, cmd *cli.Command) error {
 
 	system.Logger().Debug("release-info called with args: %+v", args)
 
+	if cmd.Args() == nil || cmd.Args().Len() == 0 {
+		system.Logger().Error("no file or OCI image provided")
+		return fmt.Errorf("refer usage: %s", cmd.UsageText)
+	}
 	arg := cmd.Args().Get(0)
 	resolved, err := resolveManifest(system, arg, args.Local)
 	if err != nil {
@@ -97,6 +101,7 @@ func resolveManifest(system *sys.System, arg string, local bool) (*resolver.Reso
 	}
 
 	if srcType == source.OCI {
+		// check if it's a valid OCI image before proceeding
 		if _, err := name.ParseReference(uri); err != nil {
 			return nil, fmt.Errorf("invalid OCI image reference: %w", err)
 		}
@@ -108,7 +113,7 @@ func resolveManifest(system *sys.System, arg string, local bool) (*resolver.Reso
 	}
 	defer func() {
 		system.Logger().Debug("Cleaning up working directory")
-		if rmErr := system.FS(); rmErr != nil {
+		if rmErr := output.Cleanup(system.FS()); rmErr != nil {
 			system.Logger().Error("Cleaning up working directory failed: %v", rmErr)
 		}
 	}()

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -1,0 +1,230 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	cmdpkg "github.com/suse/elemental/v3/internal/cli/cmd"
+	"github.com/suse/elemental/v3/internal/config"
+	"github.com/suse/elemental/v3/pkg/extractor"
+	"github.com/suse/elemental/v3/pkg/manifest/api/core"
+	"github.com/suse/elemental/v3/pkg/manifest/api/product"
+	"github.com/suse/elemental/v3/pkg/manifest/resolver"
+	"github.com/suse/elemental/v3/pkg/manifest/source"
+	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"github.com/urfave/cli/v3"
+)
+
+// coreManifest struct here is only for the sake of `elemental3 release-info` command;
+// original struct is in pkg/manifest/api/core/manifest.go
+type coreManifest struct {
+	OperatingSystem   string   `yaml:"operatingSystem" json:"operatingSystem,omitempty"`
+	HelmCharts        []string `yaml:"helmCharts,omitempty" json:"helmCharts,omitempty"`
+	HelmRepos         []string `yaml:"helmRepos,omitempty" json:"helmRepos,omitempty"`
+	SystemdExtensions []string `yaml:"systemdExtensions,omitempty" json:"systemdExtensions,omitempty"`
+}
+
+// productManifest struct here is only for the sake of `elemental3 release-info` command;
+// original struct is in pkg/manifest/api/product/manifest.go
+type productManifest struct {
+	SystemdExtensions []string `yaml:"systemdExtensions"`
+	HelmCharts        []string `yaml:"helmCharts"`
+	HelmRepos         []string `yaml:"helmRepos"`
+}
+
+func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
+	if cmd.Root().Metadata == nil || cmd.Root().Metadata["system"] == nil {
+		return fmt.Errorf("error setting up initial configuration")
+	}
+	system := cmd.Root().Metadata["system"].(*sys.System)
+	args := &cmdpkg.ReleaseInfoArgs
+
+	system.Logger().Debug("release-info called with args: %+v", args)
+
+	// check if the provided arg is a local file or an OCI image
+	arg := cmd.Args().Get(0)
+	srcType, err := argSourceType(system, arg)
+	if err != nil {
+		return err
+	}
+	system.Logger().Debug("found source type: %s", srcType)
+
+	uri := arg
+	if !strings.Contains(arg, "://") {
+		uri = fmt.Sprintf("%s://%s", srcType, arg)
+	}
+
+	if srcType == source.OCI {
+		_, err = name.ParseReference(uri)
+		if err != nil {
+			return fmt.Errorf("invalid OCI image reference: %w", err)
+		}
+	}
+
+	output, err := config.NewOutput(system.FS(), "", "")
+	if err != nil {
+		return err
+	}
+	defer output.Cleanup(system.FS())
+
+	resolver, err := manifestResolver(system.FS(), output, args.Local)
+	if err != nil {
+		return err
+	}
+	resolvedManifest, err := resolver.Resolve(uri)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
+
+	coreManifestOut := generateCoreManifest(resolvedManifest.CorePlatform)
+	//var pmOut *productManifest
+	//if resolvedManifest.ProductExtension != nil {
+	//	pmOut = printProductManifest(w, resolvedManifest.ProductExtension)
+	//
+	//	fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", len("Product Manifest")))
+	//	fmt.Fprintf(w, "Helm Charts\t %s\n", strings.Join(pmOut.HelmCharts, ", "))
+	//	fmt.Fprintf(w, "Helm Repositories\t %s \n", strings.Join(pmOut.HelmRepos, ", "))
+	//	fmt.Fprintln(w)
+	//}
+	//
+	//fmt.Fprintf(w, "Core Manifest\n%s\n", strings.Repeat("-", len("Core Manifest")))
+	//fmt.Fprintf(w, "Operating System\t %s\n", coreManifestOut.OperatingSystem)
+	//fmt.Fprintf(w, "Helm Charts\t %s\n", strings.Join(coreManifestOut.HelmCharts, ", "))
+	//fmt.Fprintf(w, "Helm Repositories\t %s \n", strings.Join(coreManifestOut.HelmRepos, ", "))
+	//
+	w.Flush()
+	//
+	//if pmOut != nil {
+	//	data, err := yaml.Marshal(&pmOut)
+	//	if err != nil {
+	//		return err
+	//	}
+	//	fmt.Println()
+	//	fmt.Println(string(data))
+	//}
+	data, err := json.Marshal(&coreManifestOut)
+	if err != nil {
+		return err
+	}
+	fmt.Println()
+	fmt.Println(string(data))
+
+	return nil
+}
+
+// argSourceType takes a string argument and returns if the release manifest source type is a file or an OCI image
+func argSourceType(s *sys.System, arg string) (source.ReleaseManifestSourceType, error) {
+	if arg == "" {
+		return 0, fmt.Errorf("no file or OCI image provided to release-info")
+	}
+	u, err := url.Parse(arg)
+	if err == nil && u.Scheme != "" {
+		switch u.Scheme {
+		case "file":
+			return source.File, nil
+		case "oci":
+			return source.OCI, nil
+		default:
+			return 0, fmt.Errorf("encountered invalid schema %q; supported schemas: %q, %q", u.Scheme, "file", "oci")
+		}
+	}
+	if ok, _ := vfs.Exists(s.FS(), arg); ok {
+		return source.File, nil
+	}
+	return source.OCI, nil
+}
+
+func generateCoreManifest(cm *core.ReleaseManifest) *coreManifest {
+	var os string
+	os = strings.Split(cm.Components.OperatingSystem.Image.Base, ":")[1]
+	os = "SLES " + strings.Split(os, "-")[0]
+
+	var helmCharts, helmRepos, systemdExtensions []string
+
+	for _, h := range cm.Components.Helm.Charts {
+		helmCharts = append(helmCharts, fmt.Sprintf("%s (%s)", h.GetName(), h.GetRepositoryName()))
+	}
+	for _, r := range cm.Components.Helm.Repositories {
+		helmRepos = append(helmRepos, r.Name)
+	}
+	for _, e := range cm.Components.Systemd.Extensions {
+		systemdExtensions = append(systemdExtensions, e.Name)
+	}
+
+	return &coreManifest{
+		OperatingSystem:   os,
+		HelmCharts:        helmCharts,
+		HelmRepos:         helmRepos,
+		SystemdExtensions: systemdExtensions,
+	}
+}
+
+func printProductManifest(w *tabwriter.Writer, pm *product.ReleaseManifest) *productManifest {
+	var systemdExtensions, helmCharts, helmRepos []string
+
+	for _, e := range pm.Components.Systemd.Extensions {
+		systemdExtensions = append(systemdExtensions, e.Name)
+	}
+	for _, h := range pm.Components.Helm.Charts {
+		helmCharts = append(helmCharts, fmt.Sprintf("%s (%s)", h.GetName(), h.GetRepositoryName()))
+	}
+	for _, r := range pm.Components.Helm.Repositories {
+		helmRepos = append(helmRepos, r.Name)
+	}
+
+	return &productManifest{
+		SystemdExtensions: systemdExtensions,
+		HelmCharts:        helmCharts,
+		HelmRepos:         helmRepos,
+	}
+}
+
+func manifestResolver(fs vfs.FS, out config.Output, local bool) (*resolver.Resolver, error) {
+	const (
+		globPattern = "release_manifest*.yaml"
+	)
+
+	searchPaths := []string{
+		globPattern,
+		filepath.Join("etc", "release-manifest", globPattern),
+	}
+
+	manifestsDir := out.ReleaseManifestsStoreDir()
+	if err := vfs.MkdirAll(fs, manifestsDir, 0700); err != nil {
+		return nil, fmt.Errorf("creating release manifest store '%s': %w", manifestsDir, err)
+	}
+
+	extr, err := extractor.New(searchPaths, extractor.WithStore(manifestsDir), extractor.WithLocal(local), extractor.WithFS(fs))
+	if err != nil {
+		return nil, fmt.Errorf("initializing OCI release manifest extractor: %w", err)
+	}
+
+	return resolver.New(source.NewReader(extr)), nil
+}

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
@@ -81,7 +81,7 @@ func ReleaseInfo(ctx context.Context, cmd *cli.Command) error {
 
 	info := buildManifestInfo(resolved, args.Core, args.Product)
 
-	return printManifestInfo(info, args.Output)
+	return printManifestInfo(info, args.Output, system.Logger().GetOutput())
 }
 
 func resolveManifest(ctx context.Context, system *sys.System, arg string, local bool) (*resolver.ResolvedManifest, error) {
@@ -133,25 +133,25 @@ func buildManifestInfo(resolved *resolver.ResolvedManifest, showCore, showProduc
 	return info
 }
 
-func printManifestInfo(info *ManifestInfo, format string) error {
+func printManifestInfo(info *ManifestInfo, format string, out io.Writer) error {
 	switch strings.ToLower(format) {
 	case "json":
-		encoder := json.NewEncoder(os.Stdout)
+		encoder := json.NewEncoder(out)
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(info)
 	case "yaml":
-		encoder := yaml.NewEncoder(os.Stdout)
+		encoder := yaml.NewEncoder(out)
 		return encoder.Encode(info)
 	case "":
-		printTable(info)
+		printTable(info, out)
 		return nil
 	default:
 		return fmt.Errorf("unsupported output format: %s", format)
 	}
 }
 
-func printTable(info *ManifestInfo) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func printTable(info *ManifestInfo, out io.Writer) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 
 	if info.Product != nil {
 		fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", 16))

--- a/internal/cli/action/release_info_test.go
+++ b/internal/cli/action/release_info_test.go
@@ -1,0 +1,137 @@
+package action_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/internal/cli/action"
+	"github.com/suse/elemental/v3/internal/cli/cmd"
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"github.com/urfave/cli/v3"
+)
+
+var _ = Describe("Release info tests", Label("release-info"), func() {
+	var s *sys.System
+	var tfs vfs.FS
+	var cleanup func()
+	var err error
+	var cliCmd *cli.Command
+	var buffer *bytes.Buffer
+	var ctx context.Context
+	var manifest = `metadata:
+  name: suse-core
+  version: 0.6-rc.20260317
+  creationDate: '2026-03-17'
+components:
+  operatingSystem:
+    image:
+      base: registry.suse.com/beta/uc/uc-base-os-kernel-default:16.0-55.79
+      iso: registry.suse.com/beta/uc/uc-base-kernel-default-iso:16.0-55.132
+  systemd:
+    extensions:
+    - name: elemental3ctl
+      image: registry.suse.com/beta/uc/elemental3ctl:0.6_19.2-3.151
+      required: true
+    - name: rke2
+      image: registry.suse.com/beta/uc/rke2:1.35_1.42-1.77
+  helm:
+    charts:
+    - name: MetalLB
+      chart: metallb
+      version: 0.15.2
+      namespace: metallb-system
+      repository: metallb
+    - name: Endpoint Copier Operator
+      chart: endpoint-copier-operator
+      version: 0.3.0
+      namespace: endpoint-copier-operator
+      repository: suse-edge
+    repositories:
+    - name: metallb
+      url: https://metallb.github.io/metallb
+    - name: suse-edge
+      url: https://suse-edge.github.io/charts`
+
+	BeforeEach(func() {
+		cmd.ReleaseInfoArgs = cmd.ReleaseInfoFlags{}
+		buffer = &bytes.Buffer{}
+		tfs, cleanup, err = sysmock.TestFS(map[string]string{
+			"/etc/elemental3/manifest.yaml": manifest,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs),
+			sys.WithLogger(log.New(log.WithBuffer(buffer))),
+		)
+		cliCmd = &cli.Command{
+			Metadata: map[string]any{
+				"system": s,
+			},
+		}
+		ctx = context.Background()
+		cmd.ReleaseInfoArgs.Local = true
+		cliCmd.Action = action.ReleaseInfo
+		cliCmd.Writer = buffer
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("fails if no sys.System instance is available", func() {
+		cliCmd.Metadata["system"] = nil
+		Expect(action.ReleaseInfo(ctx, cliCmd)).ToNot(Succeed())
+	})
+
+	It("fails if no argument is passed to it", func() {
+		Expect(action.ReleaseInfo(ctx, cliCmd)).ToNot(Succeed())
+	})
+
+	It("tests various options of release-info command", func() {
+		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		manifestPath = "file://" + manifestPath
+
+		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(ContainSubstring("Core Manifest"))
+		Expect(buffer).To(ContainSubstring("Helm Repositories"))
+		Expect(buffer).To(ContainSubstring("metallb"))
+		Expect(buffer).To(ContainSubstring("suse-edge"))
+		Expect(buffer).To(ContainSubstring("Helm Charts"))
+	})
+
+	It("tests for JSON output", func() {
+		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		manifestPath = "file://" + manifestPath
+
+		cmd.ReleaseInfoArgs.Output = "json"
+		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(json.Valid(buffer.Bytes())).To(BeTrue())
+		Expect(buffer).To(ContainSubstring("core"))
+		Expect(buffer).To(ContainSubstring("helmRepos"))
+		Expect(buffer).To(ContainSubstring("helmCharts"))
+		Expect(buffer).To(ContainSubstring("systemdExtensions"))
+	})
+
+	It("tests for YAML output", func() {
+		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		manifestPath = "file://" + manifestPath
+
+		cmd.ReleaseInfoArgs.Output = "yaml"
+		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buffer).To(ContainSubstring("core"))
+		Expect(buffer).To(ContainSubstring("helmRepos"))
+		Expect(buffer).To(ContainSubstring("helmCharts"))
+		Expect(buffer).To(ContainSubstring("systemdExtensions"))
+	})
+})

--- a/internal/cli/cmd/release_info.go
+++ b/internal/cli/cmd/release_info.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+type ReleaseInfoFlags struct {
+	Output  string
+	Core    bool
+	Product bool
+	Local   bool
+}
+
+var ReleaseInfoArgs ReleaseInfoFlags
+
+var description = `release-info takes as argument either an OCI image containing a release manifest file in it
+or a local release manifest file and prints detailed information about components that make up the Core and Product manifest.`
+
+func NewReleaseInfoCommand(appName string, releaseInfoAction func(context.Context, *cli.Command) error) *cli.Command {
+	localFlag := &cli.BoolFlag{
+		Name:        "local",
+		Usage:       "Load OCI images from the local container storage instead of a remote registry",
+		Destination: &ReleaseInfoArgs.Local,
+	}
+	return &cli.Command{
+		Name:        "release-info",
+		Usage:       "Prints details of components that make up a Core and Product release manifest file",
+		Description: fmt.Sprintf("%s %s", appName, description),
+		UsageText:   fmt.Sprintf("%s release-info [flags] <manifest-file>", appName),
+		Action:      releaseInfoAction,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "output",
+				Aliases:     []string{"o"},
+				Usage:       "Output format. One of: (json, yaml)",
+				Destination: &ReleaseInfoArgs.Output,
+			},
+			&cli.BoolFlag{
+				Name:        "core",
+				Usage:       "Print only the Core Release Manifest information; doesn't print details pertaining to Core Release Manifest",
+				Destination: &ReleaseInfoArgs.Core,
+			},
+			&cli.BoolFlag{
+				Name:        "product",
+				Usage:       "Print only the Product Release Manifest information; doesn't print details pertaining to Core Release Manifest",
+				Destination: &ReleaseInfoArgs.Product,
+			},
+			localFlag,
+		},
+	}
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -38,6 +38,7 @@ type Logger interface {
 	SetLevel(level uint32)
 	GetLevel() uint32
 	SetOutput(writer io.Writer)
+	GetOutput() io.Writer
 }
 
 var _ Logger = (*logrusWrapper)(nil)
@@ -117,4 +118,8 @@ func (w *logrusWrapper) Panic(msg string, args ...any) {
 
 func (w *logrusWrapper) Trace(msg string, args ...any) {
 	w.Tracef(msg, args...)
+}
+
+func (w *logrusWrapper) GetOutput() io.Writer {
+	return w.Out
 }


### PR DESCRIPTION
Example usage:

```sh
$ elemental3 release-info /path/to/manifest.yaml
$ elemental3 release-info /path/to/manifest.yaml --local
$ elemental3 release-info /path/to/manifest.yaml --core
$ elemental3 release-info /path/to/manifest.yaml --product
$ elemental3 release-info /path/to/manifest.yaml -o json
$ elemental3 release-info /path/to/manifest.yaml -o yaml

# All the flags as above, but with an OCI image
$ elemental3 release-info oci-image-containing-release-manifest
...
...
```

This PR doesn't implement the ability to do a diff between two manifests. It'll be added in a subsequent PR.