### PR TITLE
Adds `diff` subcommand to `elemental3 release-info`

### DIFF
--- a/cmd/elemental/main.go
+++ b/cmd/elemental/main.go
@@ -38,7 +38,7 @@ func main() {
 		cmd.NewCustomizeCommand(appName, action.Customize),
 		cmd.NewInitCommand(appName, action.Init),
 		cmd.NewVersionCommand(appName),
-		cmd.NewReleaseInfoCommand(appName, action.ReleaseInfo),
+		cmd.NewReleaseInfoCommand(appName, action.ReleaseInfo, action.Diff),
 	)
 
 	if err := application.Run(context.Background(), os.Args); err != nil {

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -51,6 +51,8 @@ type ManifestInfo struct {
 
 // CoreInfo represents core manifest details
 type CoreInfo struct {
+	Name              string   `json:"name" yaml:"name"`
+	Version           string   `json:"version" yaml:"version"`
 	OperatingSystem   string   `json:"operatingSystem" yaml:"operatingSystem"`
 	HelmCharts        []string `json:"helmCharts,omitempty" yaml:"helmCharts,omitempty"`
 	HelmRepos         []string `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
@@ -59,6 +61,8 @@ type CoreInfo struct {
 
 // ProductInfo represents product manifest details
 type ProductInfo struct {
+	Name              string   `json:"name" yaml:"name"`
+	Version           string   `json:"version" yaml:"version"`
 	SystemdExtensions []string `json:"systemdExtensions,omitempty" yaml:"systemdExtensions,omitempty"`
 	HelmCharts        []string `json:"helmCharts,omitempty" yaml:"helmCharts,omitempty"`
 	HelmRepos         []string `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
@@ -165,6 +169,8 @@ func printTable(info *ManifestInfo, out io.Writer) {
 
 	if info.Product != nil {
 		fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", 16))
+		fmt.Fprintf(w, "Name\t%s\n", info.Product.Name)
+		fmt.Fprintf(w, "Version\t%s\n", info.Product.Version)
 		if len(info.Product.SystemdExtensions) > 0 {
 			fmt.Fprintf(w, "Systemd Extensions\t%s\n", strings.Join(info.Product.SystemdExtensions, ", "))
 		}
@@ -179,6 +185,8 @@ func printTable(info *ManifestInfo, out io.Writer) {
 
 	if info.Core != nil {
 		fmt.Fprintf(w, "Core Manifest\n%s\n", strings.Repeat("-", 13))
+		fmt.Fprintf(w, "Name\t%s\n", info.Core.Name)
+		fmt.Fprintf(w, "Version\t%s\n", info.Core.Version)
 		fmt.Fprintf(w, "Operating System\t%s\n", info.Core.OperatingSystem)
 		if len(info.Core.SystemdExtensions) > 0 {
 			fmt.Fprintf(w, "Systemd Extensions\t%s\n", strings.Join(info.Core.SystemdExtensions, ", "))
@@ -205,6 +213,8 @@ func mapCoreInfo(cm *core.ReleaseManifest) *CoreInfo {
 	}
 
 	return &CoreInfo{
+		Name:              cm.Metadata.Name,
+		Version:           cm.Metadata.Version,
 		OperatingSystem:   osName,
 		HelmCharts:        mapHelmCharts(cm.Components.Helm.Charts),
 		HelmRepos:         mapHelmRepos(cm.Components.Helm.Repositories),
@@ -214,6 +224,8 @@ func mapCoreInfo(cm *core.ReleaseManifest) *CoreInfo {
 
 func mapProductInfo(pm *product.ReleaseManifest) *ProductInfo {
 	return &ProductInfo{
+		Name:              pm.Metadata.Name,
+		Version:           pm.Metadata.Version,
 		SystemdExtensions: mapSystemdExtensions(pm.Components.Systemd.Extensions),
 		HelmCharts:        mapHelmCharts(pm.Components.Helm.Charts),
 		HelmRepos:         mapHelmRepos(pm.Components.Helm.Repositories),
@@ -223,7 +235,7 @@ func mapProductInfo(pm *product.ReleaseManifest) *ProductInfo {
 func mapHelmCharts(charts []*api.HelmChart) []string {
 	var result []string
 	for _, h := range charts {
-		result = append(result, fmt.Sprintf("%s (%s)", h.GetName(), h.GetRepositoryName()))
+		result = append(result, fmt.Sprintf("%s-%s (%s)", h.GetName(), h.Version, h.GetRepositoryName()))
 	}
 	return result
 }
@@ -317,18 +329,22 @@ func Diff(_ context.Context, cmd *cli.Command) error {
 	manifestInfo1 := buildManifestInfo(r1, args.Core, args.Product)
 	manifestInfo2 := buildManifestInfo(r2, args.Core, args.Product)
 
-	printDiff(manifestInfo1, manifestInfo2, m1, m2, system.Logger().GetOutput())
+	printDiff(manifestInfo1, manifestInfo2, system.Logger().GetOutput())
 
 	return nil
 }
 
-func printDiff(info1, info2 *ManifestInfo, arg1, arg2 string, out io.Writer) {
+func printDiff(info1, info2 *ManifestInfo, out io.Writer) {
 	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 
 	if info1.Core != nil || info2.Core != nil {
+		title1 := getStringOrEmpty(info1.Core, func(p *CoreInfo) string { return p.Name }) + " " +
+			getStringOrEmpty(info1.Core, func(p *CoreInfo) string { return p.Version })
+		title2 := getStringOrEmpty(info2.Core, func(p *CoreInfo) string { return p.Name }) + " " +
+			getStringOrEmpty(info2.Core, func(p *CoreInfo) string { return p.Version })
 		fmt.Fprintf(w, "Core Manifest\n%s\n", strings.Repeat("-", 13))
-		fmt.Fprintf(w, "Field\t%s\t%s\n", arg1, arg2)
-		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.Repeat("-", 5), strings.Repeat("-", len(arg1)), strings.Repeat("-", len(arg2)))
+		fmt.Fprintf(w, "Field\t%s\t%s\n", title1, title2)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.Repeat("-", 5), strings.Repeat("-", len(title1)), strings.Repeat("-", len(title2)))
 
 		// Operating System
 		os1 := getStringOrEmpty(info1.Core, func(c *CoreInfo) string { return c.OperatingSystem })
@@ -355,9 +371,13 @@ func printDiff(info1, info2 *ManifestInfo, arg1, arg2 string, out io.Writer) {
 
 	// Show Product comparison if either manifest has Product info
 	if info1.Product != nil || info2.Product != nil {
+		title1 := getStringOrEmpty(info1.Product, func(p *ProductInfo) string { return p.Name }) + " " +
+			getStringOrEmpty(info1.Product, func(p *ProductInfo) string { return p.Version })
+		title2 := getStringOrEmpty(info2.Product, func(p *ProductInfo) string { return p.Name }) + " " +
+			getStringOrEmpty(info2.Product, func(p *ProductInfo) string { return p.Version })
 		fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", 16))
-		fmt.Fprintf(w, "Field\t%s\t%s\n", arg1, arg2)
-		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.Repeat("-", 5), strings.Repeat("-", len(arg1)), strings.Repeat("-", len(arg2)))
+		fmt.Fprintf(w, "Field\t%s\t%s\n", title1, title2)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.Repeat("-", 5), strings.Repeat("-", len(title1)), strings.Repeat("-", len(title2)))
 
 		// Systemd Extensions
 		printFieldComparison(w, "Systemd Extensions",

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -317,8 +317,116 @@ func Diff(_ context.Context, cmd *cli.Command) error {
 	manifestInfo1 := buildManifestInfo(r1, args.Core, args.Product)
 	manifestInfo2 := buildManifestInfo(r2, args.Core, args.Product)
 
-	printManifestInfo(manifestInfo1, "", system.Logger().GetOutput())
-	printManifestInfo(manifestInfo2, "", system.Logger().GetOutput())
+	printDiff(manifestInfo1, manifestInfo2, m1, m2, system.Logger().GetOutput())
 
 	return nil
+}
+
+func printDiff(info1, info2 *ManifestInfo, arg1, arg2 string, out io.Writer) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+
+	if info1.Core != nil || info2.Core != nil {
+		fmt.Fprintf(w, "Core Manifest\n%s\n", strings.Repeat("-", 13))
+		fmt.Fprintf(w, "Field\t%s\t%s\n", arg1, arg2)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.Repeat("-", 5), strings.Repeat("-", len(arg1)), strings.Repeat("-", len(arg2)))
+
+		// Operating System
+		os1 := getStringOrEmpty(info1.Core, func(c *CoreInfo) string { return c.OperatingSystem })
+		os2 := getStringOrEmpty(info2.Core, func(c *CoreInfo) string { return c.OperatingSystem })
+		fmt.Fprintf(w, "Operating System\t%s\t%s\n", os1, os2)
+
+		// Systemd Extensions
+		printFieldComparison(w, "Systemd Extensions",
+			getSliceOrEmpty(info1.Core, func(c *CoreInfo) []string { return c.SystemdExtensions }),
+			getSliceOrEmpty(info2.Core, func(c *CoreInfo) []string { return c.SystemdExtensions }))
+
+		// Helm Charts
+		printFieldComparison(w, "Helm Charts",
+			getSliceOrEmpty(info1.Core, func(c *CoreInfo) []string { return c.HelmCharts }),
+			getSliceOrEmpty(info2.Core, func(c *CoreInfo) []string { return c.HelmCharts }))
+
+		// Helm Repositories
+		printFieldComparison(w, "Helm Repositories",
+			getSliceOrEmpty(info1.Core, func(c *CoreInfo) []string { return c.HelmRepos }),
+			getSliceOrEmpty(info2.Core, func(c *CoreInfo) []string { return c.HelmRepos }))
+
+		fmt.Fprintln(w)
+	}
+
+	// Show Product comparison if either manifest has Product info
+	if info1.Product != nil || info2.Product != nil {
+		fmt.Fprintf(w, "Product Manifest\n%s\n", strings.Repeat("-", 16))
+		fmt.Fprintf(w, "Field\t%s\t%s\n", arg1, arg2)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", strings.Repeat("-", 5), strings.Repeat("-", len(arg1)), strings.Repeat("-", len(arg2)))
+
+		// Systemd Extensions
+		printFieldComparison(w, "Systemd Extensions",
+			getSliceOrEmpty(info1.Product, func(p *ProductInfo) []string { return p.SystemdExtensions }),
+			getSliceOrEmpty(info2.Product, func(p *ProductInfo) []string { return p.SystemdExtensions }))
+
+		// Helm Charts
+		printFieldComparison(w, "Helm Charts",
+			getSliceOrEmpty(info1.Product, func(p *ProductInfo) []string { return p.HelmCharts }),
+			getSliceOrEmpty(info2.Product, func(p *ProductInfo) []string { return p.HelmCharts }))
+
+		// Helm Repositories
+		printFieldComparison(w, "Helm Repositories",
+			getSliceOrEmpty(info1.Product, func(p *ProductInfo) []string { return p.HelmRepos }),
+			getSliceOrEmpty(info2.Product, func(p *ProductInfo) []string { return p.HelmRepos }))
+
+		fmt.Fprintln(w)
+	}
+
+	w.Flush()
+}
+
+func printFieldComparison(w io.Writer, fieldName string, items1, items2 []string) {
+	maxLen := len(items1)
+	if len(items2) > maxLen {
+		maxLen = len(items2)
+	}
+
+	// If both lists are empty, print a single row with empty values
+	if maxLen == 0 {
+		fmt.Fprintf(w, "%s\t\t\n", fieldName)
+		return
+	}
+
+	// Print first row with field name
+	val1 := ""
+	if len(items1) > 0 {
+		val1 = items1[0]
+	}
+	val2 := ""
+	if len(items2) > 0 {
+		val2 = items2[0]
+	}
+	fmt.Fprintf(w, "%s\t%s\t%s\n", fieldName, val1, val2)
+
+	// Print remaining rows with empty field name
+	for i := 1; i < maxLen; i++ {
+		val1 = ""
+		if i < len(items1) {
+			val1 = items1[i]
+		}
+		val2 = ""
+		if i < len(items2) {
+			val2 = items2[i]
+		}
+		fmt.Fprintf(w, "\t%s\t%s\n", val1, val2)
+	}
+}
+
+func getSliceOrEmpty[T any](ptr *T, getter func(*T) []string) []string {
+	if ptr == nil {
+		return []string{}
+	}
+	return getter(ptr)
+}
+
+func getStringOrEmpty[T any](ptr *T, getter func(*T) string) string {
+	if ptr == nil {
+		return ""
+	}
+	return getter(ptr)
 }

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -71,13 +71,13 @@ func ReleaseInfo(_ context.Context, cmd *cli.Command) error {
 	system := cmd.Root().Metadata["system"].(*sys.System)
 	args := &cmdpkg.ReleaseInfoArgs
 
-	system.Logger().Debug("release-info called with args: %+v", args)
-
 	if cmd.Args() == nil || cmd.Args().Len() == 0 {
 		system.Logger().Error("no file or OCI image provided")
 		return fmt.Errorf("refer usage: %s", cmd.UsageText)
 	}
-	arg := cmd.Args().Get(0)
+	system.Logger().Debug("release-info called with args: %+v", args)
+
+	arg := cmd.Args().First()
 	resolved, err := resolveManifest(system, arg, args.Local)
 	if err != nil {
 		return err
@@ -287,4 +287,38 @@ func manifestResolver(fs vfs.FS, out config.Output, local bool) (*resolver.Resol
 	}
 
 	return resolver.New(source.NewReader(extr)), nil
+}
+
+func Diff(_ context.Context, cmd *cli.Command) error {
+	if cmd.Root().Metadata == nil || cmd.Root().Metadata["system"] == nil {
+		return fmt.Errorf("setting up initial configuration")
+	}
+	system := cmd.Root().Metadata["system"].(*sys.System)
+	args := &cmdpkg.ReleaseInfoArgs
+
+	if cmd.Args() == nil || cmd.Args().Len() != 2 {
+		system.Logger().Error("insufficient files or OCI images provided for diff")
+		return fmt.Errorf("refer usage: %s", cmd.UsageText)
+	}
+	system.Logger().Debug("diff called with args: %+v", cmd.Args())
+
+	m1, m2 := cmd.Args().Get(0), cmd.Args().Get(1)
+	r1, err := resolveManifest(system, m1, args.Local)
+	if err != nil {
+		system.Logger().Error("resolving manifest %q", m1)
+		return err
+	}
+	r2, err := resolveManifest(system, m2, args.Local)
+	if err != nil {
+		system.Logger().Error("resolving manifest %q", m2)
+		return err
+	}
+
+	manifestInfo1 := buildManifestInfo(r1, args.Core, args.Product)
+	manifestInfo2 := buildManifestInfo(r2, args.Core, args.Product)
+
+	printManifestInfo(manifestInfo1, "", system.Logger().GetOutput())
+	printManifestInfo(manifestInfo2, "", system.Logger().GetOutput())
+
+	return nil
 }

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -275,7 +275,7 @@ func argSourceType(s *sys.System, arg string) (source.ReleaseManifestSourceType,
 	if ok, _ := vfs.Exists(s.FS(), arg); ok {
 		return source.File, nil
 	}
-	return source.OCI, nil
+	return 0, fmt.Errorf("file %q not found; if you meant to specify an OCI image, use the 'oci://' prefix (e.g., oci://registry.example.com/image:tag)", arg)
 }
 
 func manifestResolver(fs vfs.FS, out config.Output, local bool) (*resolver.Resolver, error) {

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -54,6 +54,7 @@ type CoreInfo struct {
 	Name              string   `json:"name" yaml:"name"`
 	Version           string   `json:"version" yaml:"version"`
 	OperatingSystem   string   `json:"operatingSystem" yaml:"operatingSystem"`
+	Kubernetes        string   `json:"kubernetes" yaml:"kubernetes"`
 	HelmCharts        []string `json:"helmCharts,omitempty" yaml:"helmCharts,omitempty"`
 	HelmRepos         []string `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
 	SystemdExtensions []string `json:"systemdExtensions,omitempty" yaml:"systemdExtensions,omitempty"`
@@ -188,6 +189,9 @@ func printTable(info *ManifestInfo, out io.Writer) {
 		fmt.Fprintf(w, "Name\t%s\n", info.Core.Name)
 		fmt.Fprintf(w, "Version\t%s\n", info.Core.Version)
 		fmt.Fprintf(w, "Operating System\t%s\n", info.Core.OperatingSystem)
+		if info.Core.Kubernetes != "" {
+			fmt.Fprintf(w, "Kubernetes\t%s\n", info.Core.Kubernetes)
+		}
 		if len(info.Core.SystemdExtensions) > 0 {
 			fmt.Fprintf(w, "Systemd Extensions\t%s\n", strings.Join(info.Core.SystemdExtensions, ", "))
 		}
@@ -212,7 +216,12 @@ func mapCoreInfo(cm *core.ReleaseManifest) *CoreInfo {
 		}
 	}
 
-	return &CoreInfo{
+	var kubernetes string
+	if cm.Components.Kubernetes != nil {
+		kubernetes = cm.Components.Kubernetes.Version
+	}
+
+	c := &CoreInfo{
 		Name:              cm.Metadata.Name,
 		Version:           cm.Metadata.Version,
 		OperatingSystem:   osName,
@@ -220,6 +229,10 @@ func mapCoreInfo(cm *core.ReleaseManifest) *CoreInfo {
 		HelmRepos:         mapHelmRepos(cm.Components.Helm.Repositories),
 		SystemdExtensions: mapSystemdExtensions(cm.Components.Systemd.Extensions),
 	}
+	if kubernetes != "" {
+		c.Kubernetes = kubernetes
+	}
+	return c
 }
 
 func mapProductInfo(pm *product.ReleaseManifest) *ProductInfo {
@@ -350,6 +363,12 @@ func printDiff(info1, info2 *ManifestInfo, out io.Writer) {
 		os1 := getStringOrEmpty(info1.Core, func(c *CoreInfo) string { return c.OperatingSystem })
 		os2 := getStringOrEmpty(info2.Core, func(c *CoreInfo) string { return c.OperatingSystem })
 		fmt.Fprintf(w, "Operating System\t%s\t%s\n", os1, os2)
+
+		if info1.Core.Kubernetes != "" || info2.Core.Kubernetes != "" {
+			k8s1 := getStringOrEmpty(info1.Core, func(c *CoreInfo) string { return c.Kubernetes })
+			k8s2 := getStringOrEmpty(info2.Core, func(c *CoreInfo) string { return c.Kubernetes })
+			fmt.Fprintf(w, "Kubernetes\t%s\t%s\n", k8s1, k8s2)
+		}
 
 		// Systemd Extensions
 		printFieldComparison(w, "Systemd Extensions",

--- a/internal/cli/action/release_info_test.go
+++ b/internal/cli/action/release_info_test.go
@@ -93,6 +93,15 @@ components:
 		Expect(action.ReleaseInfo(ctx, cliCmd)).ToNot(Succeed())
 	})
 
+	It("fails if inexistent file is passed as argument", func() {
+		manifestPath, err := tfs.RawPath("/etc/elemental3/nosuchfile.yaml")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("use the 'oci://' prefix"))
+	})
+
 	It("tests various options of release-info command", func() {
 		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/cli/action/release_info_test.go
+++ b/internal/cli/action/release_info_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,15 +17,14 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-var _ = Describe("Release info tests", Label("release-info"), func() {
-	var s *sys.System
-	var tfs vfs.FS
-	var cleanup func()
-	var err error
-	var cliCmd *cli.Command
-	var buffer *bytes.Buffer
-	var ctx context.Context
-	var manifest = `metadata:
+var s *sys.System
+var tfs vfs.FS
+var cleanup func()
+var err error
+var cliCmd *cli.Command
+var buffer *bytes.Buffer
+var ctx context.Context
+var manifest = `metadata:
   name: suse-core
   version: 0.6-rc.20260317
   creationDate: '2026-03-17'
@@ -58,12 +58,46 @@ components:
       url: https://metallb.github.io/metallb
     - name: suse-edge
       url: https://suse-edge.github.io/charts`
+var manifestPath = "/etc/elemental3/manifest.yaml"
 
+var invalidManifest = `metadata:
+  name: suse-core
+  version: 0.6-rc.20260317
+  creationDate: '2026-03-17'
+components:
+  systemd:
+    extensions:
+    - name: elemental3ctl
+      image: registry.suse.com/beta/uc/elemental3ctl:0.6_19.2-3.151
+      required: true
+    - name: rke2
+      image: registry.suse.com/beta/uc/rke2:1.35_1.42-1.77
+  helm:
+    charts:
+    - name: MetalLB
+      chart: metallb
+      version: 0.15.2
+      namespace: metallb-system
+      repository: metallb
+    - name: Endpoint Copier Operator
+      chart: endpoint-copier-operator
+      version: 0.3.0
+      namespace: endpoint-copier-operator
+      repository: suse-edge
+    repositories:
+    - name: metallb
+      url: https://metallb.github.io/metallb
+    - name: suse-edge
+      url: https://suse-edge.github.io/charts`
+var invalidManifestPath = "/etc/elemental3/invalidManifest.yaml"
+
+var _ = Describe("Release info tests", Label("release-info"), func() {
 	BeforeEach(func() {
 		cmd.ReleaseInfoArgs = cmd.ReleaseInfoFlags{}
 		buffer = &bytes.Buffer{}
 		tfs, cleanup, err = sysmock.TestFS(map[string]string{
-			"/etc/elemental3/manifest.yaml": manifest,
+			manifestPath:        manifest,
+			invalidManifestPath: invalidManifest,
 		})
 		Expect(err).ToNot(HaveOccurred())
 		s, err = sys.NewSystem(
@@ -94,20 +128,31 @@ components:
 	})
 
 	It("fails if inexistent file is passed as argument", func() {
-		manifestPath, err := tfs.RawPath("/etc/elemental3/nosuchfile.yaml")
+		rawPath, err := tfs.RawPath("/etc/elemental3/nosuchfile.yaml")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		err = cliCmd.Run(ctx, []string{"", rawPath})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("use the 'oci://' prefix"))
 	})
 
-	It("tests various options of release-info command", func() {
-		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
+	It("fails if invalid manifest is requested for parsing", func() {
+		rawPath, err := tfs.RawPath(invalidManifestPath)
 		Expect(err).ToNot(HaveOccurred())
-		manifestPath = "file://" + manifestPath
+		rawPath = "file://" + rawPath
 
-		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		err = cliCmd.Run(ctx, []string{"", rawPath})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unable to parse"))
+		Expect(err.Error()).To(ContainSubstring("field \"ReleaseManifest.components.operatingSystem\" is required"))
+	})
+
+	It("tests various options of release-info command", func() {
+		rawPath, err := tfs.RawPath(manifestPath)
+		Expect(err).ToNot(HaveOccurred())
+		rawPath = "file://" + rawPath
+
+		err = cliCmd.Run(ctx, []string{"", rawPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(buffer).To(ContainSubstring("Core Manifest"))
 		Expect(buffer).To(ContainSubstring("Helm Repositories"))
@@ -117,12 +162,12 @@ components:
 	})
 
 	It("tests for JSON output", func() {
-		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
+		rawPath, err := tfs.RawPath(manifestPath)
 		Expect(err).ToNot(HaveOccurred())
-		manifestPath = "file://" + manifestPath
+		rawPath = "file://" + rawPath
 
 		cmd.ReleaseInfoArgs.Output = "json"
-		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		err = cliCmd.Run(ctx, []string{"", rawPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(json.Valid(buffer.Bytes())).To(BeTrue())
 		Expect(buffer).To(ContainSubstring("core"))
@@ -132,16 +177,72 @@ components:
 	})
 
 	It("tests for YAML output", func() {
-		manifestPath, err := tfs.RawPath("/etc/elemental3/manifest.yaml")
+		rawPath, err := tfs.RawPath(manifestPath)
 		Expect(err).ToNot(HaveOccurred())
-		manifestPath = "file://" + manifestPath
+		rawPath = "file://" + rawPath
 
 		cmd.ReleaseInfoArgs.Output = "yaml"
-		err = cliCmd.Run(ctx, []string{"", manifestPath})
+		err = cliCmd.Run(ctx, []string{"", rawPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(buffer).To(ContainSubstring("core"))
 		Expect(buffer).To(ContainSubstring("helmRepos"))
 		Expect(buffer).To(ContainSubstring("helmCharts"))
 		Expect(buffer).To(ContainSubstring("systemdExtensions"))
+	})
+})
+
+var _ = Describe("Release info diff tests", Label("release-info diff"), func() {
+	BeforeEach(func() {
+		cmd.ReleaseInfoArgs = cmd.ReleaseInfoFlags{}
+		buffer = &bytes.Buffer{}
+		tfs, cleanup, err = sysmock.TestFS(map[string]string{
+			manifestPath:        manifest,
+			invalidManifestPath: invalidManifest,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs),
+			sys.WithLogger(log.New(log.WithBuffer(buffer))),
+		)
+		cliCmd = &cli.Command{
+			Metadata: map[string]any{
+				"system": s,
+			},
+		}
+		ctx = context.Background()
+		cmd.ReleaseInfoArgs.Local = true
+		cliCmd.Action = action.Diff
+		cliCmd.Writer = buffer
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("fails if no sys.System instance is available", func() {
+		cliCmd.Metadata["system"] = nil
+		Expect(action.Diff(ctx, cliCmd)).ToNot(Succeed())
+	})
+
+	It("fails if exactly two arguments aren't passed to it", func() {
+		err = cliCmd.Run(ctx, []string{""})
+		Expect(err).To(HaveOccurred())
+		Expect(buffer).To(ContainSubstring("insufficient files or OCI images provided for diff"))
+
+		rawPath, err := tfs.RawPath(manifestPath)
+		rawPath = "file://" + rawPath
+		Expect(err).To(BeNil())
+		err = cliCmd.Run(ctx, []string{"", rawPath})
+		Expect(err).To(HaveOccurred())
+		Expect(buffer).To(ContainSubstring("insufficient files or OCI images provided for diff"))
+	})
+
+	It("should generate expected output", func() {
+		rawPath, err := tfs.RawPath(manifestPath)
+		Expect(err).To(BeNil())
+		rawPath = "file://" + rawPath
+
+		err = cliCmd.Run(ctx, []string{"", rawPath, rawPath})
+		Expect(err).To(BeNil())
+		Expect(strings.Count(buffer.String(), "suse-core 0.6-rc.20260317")).To(Equal(2))
 	})
 })

--- a/internal/cli/cmd/release_info.go
+++ b/internal/cli/cmd/release_info.go
@@ -36,7 +36,17 @@ var ReleaseInfoArgs ReleaseInfoFlags
 var description = `release-info takes as argument either an OCI image containing a release manifest file in it
 or a local release manifest file and prints detailed information about components that make up the Core and Product manifest.`
 
-func NewReleaseInfoCommand(appName string, releaseInfoAction func(context.Context, *cli.Command) error) *cli.Command {
+func NewReleaseInfoCommand(appName string, releaseInfoAction, diffAction func(context.Context, *cli.Command) error) *cli.Command {
+	coreFlag := &cli.BoolFlag{
+		Name:        "core",
+		Usage:       "Print only the Core Release Manifest information; doesn't print details pertaining to Core Release Manifest",
+		Destination: &ReleaseInfoArgs.Core,
+	}
+	productFlag := &cli.BoolFlag{
+		Name:        "product",
+		Usage:       "Print only the Product Release Manifest information; doesn't print details pertaining to Core Release Manifest",
+		Destination: &ReleaseInfoArgs.Product,
+	}
 	localFlag := &cli.BoolFlag{
 		Name:        "local",
 		Usage:       "Load OCI images from the local container storage instead of a remote registry",
@@ -46,8 +56,9 @@ func NewReleaseInfoCommand(appName string, releaseInfoAction func(context.Contex
 		Name:        "release-info",
 		Usage:       "Prints details of components that make up a Core and Product release manifest file",
 		Description: fmt.Sprintf("%s %s", appName, description),
-		UsageText:   fmt.Sprintf("%s release-info [flags] <manifest-file>", appName),
-		Action:      releaseInfoAction,
+		UsageText: fmt.Sprintf("%s release-info [flags] /path/to/manifest/file\n"+
+			"%s release-info [flags] oci://registry.fqdn/repository/image", appName, appName),
+		Action: releaseInfoAction,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "output",
@@ -55,17 +66,30 @@ func NewReleaseInfoCommand(appName string, releaseInfoAction func(context.Contex
 				Usage:       "Output format. One of: (json, yaml)",
 				Destination: &ReleaseInfoArgs.Output,
 			},
-			&cli.BoolFlag{
-				Name:        "core",
-				Usage:       "Print only the Core Release Manifest information; doesn't print details pertaining to Core Release Manifest",
-				Destination: &ReleaseInfoArgs.Core,
-			},
-			&cli.BoolFlag{
-				Name:        "product",
-				Usage:       "Print only the Product Release Manifest information; doesn't print details pertaining to Core Release Manifest",
-				Destination: &ReleaseInfoArgs.Product,
-			},
+			coreFlag,
+			productFlag,
 			localFlag,
+		},
+		Commands: []*cli.Command{
+			{
+				Name:  "diff",
+				Usage: "Print the difference between two manifest files",
+				UsageText: fmt.Sprintf("%s release-info diff /path/to/manifest/file1 /path/to/manifest/file2\n"+
+					"%s release-info diff oci://registry.fqdn/repository/image1 oci://registry.fqdn/repository/image2\n"+
+					"%s release-info diff oci://registry.fqdn/repository/image /path/to/manifest/file\n", appName, appName, appName),
+				Action: diffAction,
+				Flags: []cli.Flag{
+					coreFlag,
+					productFlag,
+					localFlag,
+				},
+				Before: func(ctx context.Context, _ *cli.Command) (context.Context, error) {
+					if ReleaseInfoArgs.Output != "" {
+						return ctx, fmt.Errorf("diff command doesn't support %q flag", "--output")
+					}
+					return ctx, nil
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Example usage:

```sh
# can interchange positions of 'oci' and 'file' type parameters
# can also pass arguments of same type, i.e., both oci or both file
$ elemental3 release-info diff oci://registry.example.com/repo/image file:///path/to/manifest.yaml

# prints only core manifest info
$ elemental3 release-info diff oci://registry.example.com/repo/image file:///path/to/manifest.yaml --core

# prints only product manifest info
$ elemental3 release-info diff oci://registry.example.com/repo/image file:///path/to/manifest.yaml --product
```

Example output:
```sh
$ elemental3 release-info diff oci://registry.suse.com/beta/uc/release-manifest:0.6_rke2_1.35 examples/elemental/customize/single-node/suse-product-manifest.yaml --local
⠋ Extracting (2.6 kB, 11 MB/s) [0s]
⠋ Extracting (2.6 kB, 13 MB/s) [0s]
Core Manifest
-------------
Field               suse-core 0.6-rc.20260317                   suse-core 0.6-rc.20260317
-----               -------------------------                   -------------------------
Operating System    SLES 16.0                                   SLES 16.0
Systemd Extensions  elemental3ctl                               elemental3ctl
                    rke2                                        rke2
Helm Charts         metallb-0.15.2 (metallb)                    metallb-0.15.2 (metallb)
                    endpoint-copier-operator-0.3.0 (suse-edge)  endpoint-copier-operator-0.3.0 (suse-edge)
Helm Repositories   metallb                                     metallb
                    suse-edge                                   suse-edge

Product Manifest
----------------
Field                  suse-product 4.2.0
-----               -  ------------------
Systemd Extensions     longhorn
Helm Charts            cert-manager-v1.17.2 (jetstack)
                       rancher-2.13.0 (rancher)
                       longhorn-crd-107.0.0+up1.9.1 (rancher-charts)
                       longhorn-107.0.0+up1.9.1 (rancher-charts)
Helm Repositories      jetstack
                       rancher
                       rancher-charts