### PR TITLE
Fix first run of elemental failing in Macbook podman

### DIFF
--- a/pkg/repart/disk_repart.go
+++ b/pkg/repart/disk_repart.go
@@ -22,8 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -31,6 +33,7 @@ import (
 	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -190,6 +193,8 @@ func repartDisk(s *sys.System, d *deployment.Disk, empty string) (err error) {
 // the optional given flags. On success it parses systemd-repart output to get the generated partition UUIDs and update the
 // given partitions list with them.
 func runSystemdRepart(s *sys.System, target string, parts []Partition, flags ...string) error {
+	setupLoopDeviceNodes()
+
 	dir, err := vfs.TempDir(s.FS(), "", "elemental-repart.d")
 	if err != nil {
 		return fmt.Errorf("failed creating a temporary directory for systemd-repart configuration: %w", err)
@@ -288,4 +293,16 @@ func readOnlyPart(part *deployment.Partition) string {
 		}
 	}
 	return ""
+}
+
+// setupLoopDeviceNodes creates 4 loop device nodes for systemd-repart to use at runtime. This is only necessary on arm64
+// podman containers as, on first run, the container does not have enough loop device nodes available for systemd-repart to work.
+// This is not an issue in amd64 containers because enough loop device nodes are automatically available.
+func setupLoopDeviceNodes() {
+	if os.Getenv("container") != "" && runtime.GOARCH == "arm64" {
+		for i := 0; i < 4; i++ {
+			devPath := fmt.Sprintf("/dev/loop%d", i)
+			_ = unix.Mknod(devPath, unix.S_IFBLK|0660, 7*256+i)
+		}
+	}
 }


### PR DESCRIPTION
When you run `elemental3` through `podman` for the first time on a Macbook, the image fails with the following error:
```
INFO[0032] Partitioning image '/config/image-2026-03-31T14-34-44.raw' 
DEBU[0032] Running cmd: 'PATH=/sbin:/usr/sbin:/usr/bin:/bin systemd-repart --json=pretty --definitions=/tmp/elemental-repart.d146009211 --dry-run=no --empty=create --size=35840M /config/image-2026-03-31T14-34-44.raw' 
DEBU[0036] "systemd-repart" command reported an error: exit status 1 
DEBU[0036] "systemd-repart" command output:             
DEBU[0036] "systemd-repart" stderr: No machine ID set, using randomized partition UUIDs.
Sized '/config/image-2026-03-31T14-34-44.raw' to 35G.
Applying changes to /config/image-2026-03-31T14-34-44.raw.
Failed to make loopback device of future partition 0: Device or resource busy 
ERRO[0036] Customizing image media failed               
ERRO[0036] Customizing installer media failed           
DEBU[0036] Cleaning up working directory                
2026/03/31 14:35:21 failed partitioning disk '/config/image-2026-03-31T14-34-44.raw' with systemd-repart: exit status 1
```

If you immediately run it a second time, the image build will succeed. If you run a 3rd time, it will fail, if you run it a 4th time it will succeed...

The issue is that `systemd-repart` needs multiple loopback devices during the partitioning process. During the first run, it does not have the 2 device nodes that it needs, but it seems like it leaves behind some artifact that allows `systemd-repart` to succeed on the second run.

My proposed solution is within the `runSystemdRepart` function, we check if we are inside of an `arm64` container. If we are, we manually create some device nodes for `systemd-repart` to use. This seems to work in my tests where alternating success/fails no longer happen and it succeeds each time.