### PR TITLE
Get config digest instead of image digest

### DIFF
--- a/pkg/unpack/oci.go
+++ b/pkg/unpack/oci.go
@@ -144,7 +144,7 @@ func (o OCI) Unpack(ctx context.Context, destination string, excludes ...string)
 		return "", err
 	}
 
-	digest, err := img.Digest()
+	digest, err := img.ConfigName()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This commit switches the image digest we track as the image identifier to the config digest. This is aligned with what podman or docker tread as the image ID.