### PR TITLE
Remove elemental3ctl sysext image references

### DIFF
--- a/docs/building-linux-image.md
+++ b/docs/building-linux-image.md
@@ -28,20 +28,20 @@ This section provides an overview of how you build a Linux image that can includ
 
 ## Prepare basic configuration
 
-`elemental3ctl` can apply basic configuration and extensions at deployment time in the following ways:
+`elemental3ctl` can apply basic configuration and include extensions at deployment time in the following ways:
 
-* Through a [system extension image](#configuring-through-a-system-extension-image)
-* Through a [configuration script](#configuring-through-a-configuration-script)
+* Adding [system extension images](#adding-system-extension-images)
+* Apply configuration through a [configuration script](#configuring-through-a-configuration-script)
 
-### Configuring through a system extension image
+### Adding system extension images
 
-While we recommend reading through the complete document to understand system extensions in the context of elemental 
+While we recommend reading through the complete document to understand system extensions in the context of elemental
 project, please refer to the
 ["Create system extension images"](./systemd-system-extensions.md#create-system-extension-images) section for specific
 steps. After that continue further with the
 ["Configuring through a configuration script"](#configuring-through-a-configuration-script) section below.
 
-### Preparing the system extension image as an overlay
+#### Preparing the system extension image as an overlay
 
 Overlay is the way of merging contents of a system extension onto the host system such that it all looks like a part
 of the host system.
@@ -58,7 +58,7 @@ of the host system.
     tar -cavzf overlays.tar.gz -C overlays .
     ```
 
-You have now prepared an archive containing a system extension image for use during the installation process. This
+You have now prepared an archive containing a system extension images for use during the installation process. This
 adds the `kubectl` binary or `strace` package to the operating system after boot.
 
 
@@ -124,7 +124,7 @@ sudo elemental3ctl install \
 
 Note that:
 
-* The `overlays.tar.gz` tarball came from the system extension image [example configuration](#example-system-extension-image).
+* The `overlays.tar.gz` tarball came from the system extension image [example configuration](#adding-system-extension-images).
 * The `config.sh` script came from the [configuration script example](#example-configuration-script).
 * `/dev/nbd0` is the chosen block device from the `qemu-nbd -c` command in the [Prepare the Installation Target](#prepare-the-installation-target) section.
 
@@ -187,7 +187,7 @@ You should see the bootloader prompting you to start `openSUSE Tumbleweed`.
         journalctl -u example-oneshot.service
         ```
 
-4. Check that `elemental3ctl` binary is available and working:
+4. Check that any given extension image is merged as expected:
 
     * Check logs for the `systemd-sysext.service`:
 
@@ -195,11 +195,6 @@ You should see the bootloader prompting you to start `openSUSE Tumbleweed`.
         journalctl -u systemd-sysext.service
         ```
 
-    * Try calling the command:
-
-        ```shell
-        elemental3ctl version
-        ```
 
 ## Create an Installer Media
 
@@ -317,10 +312,9 @@ chmod +x config-live.sh
 
 #### Include Extensions in the Installer Media
 
-The provided OS does not include the `elemental3ctl` required to run the installation to the target disk. The `elemental3ctl` is delivered through a systemd extension image.
-To ensure it is available at ISO boot, it has to be included in the ISO filesystem and either copied or linked to `/run/extensions`.
+In case some extension are required at install time they have to be included in the ISO filesystem and either copied or linked to '/run/extensions' at boot time.
 
-This example shows how to prepare the ISO overlay directory tree and the configuration script to ensure the `elemental3ctl` extensions are
+This example shows how to prepare the ISO overlay directory tree and the configuration script to ensure a given systemd extension is
 available and loaded at boot.
 
 1. Create an `iso-overlay/extensions` directory:
@@ -329,10 +323,10 @@ available and loaded at boot.
     mkdir -p iso-overlay/extensions
     ```
 
-2. Create the [elemental3ctl](#example-system-extension-image) extension image and move it to this directory:
+2. Copy the given extension image to the `iso-overlay/extensions` directory:
 
     ```shell
-    mv example-extension/mkosi.output/elemental3ctl-3.0.x86-64.raw iso-overlay/extensions
+    mv example-extension/mkosi.output/example-extension_1.0_x86-64.raw iso-overlay/extensions
     ```
 
 3. Make sure the live configuration script links the `extensions` folder at `/run/extensions`
@@ -368,7 +362,7 @@ The RAW disk image only includes the ESP partition and a recovery partition. The
 squashfs OS image to boot from like a live ISO would.
 
 Note that:
-* The `overlays.tar.gz` tarball came from the system extension image [example configuration](#example-system-extension-image).
+* The `overlays.tar.gz` tarball came from the system extension image [example configuration](#adding-system-extension-images).
 * The `config.sh` script came from the [configuration script example](#example-configuration-script).
 * The `/dev/sda` is the target device you want the ISO to install to.
 * The `iso-overlay` is the directory tree [including extensions](#include-extensions-in-the-installer-media) that will be included in the ISO filesystem of the built image.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,25 @@ Elemental is a tool for installing, configuring and updating operating system im
 *   **Updates:** Update an existing OS installation from a newer image.
 *   **Extensibility:** Extend the OS installation image with extensions.
 
+## Elemental binaries
+
+The elemental project mainly consists of two binaries:
+- `elemental3`
+- `elemental3ctl`
+
+`elemental3` is a higher-level tool that takes as its input an OCI image containing an ISO artifact, adds payloads
+such as system extensions, Kubernetes definitions, first-boot configs, and generates an ISO or RAW file which can be
+used to boot a VM.
+
+`elemental3ctl` is a lower-level tool that can do various things like installing an OS (packaged as an OCI image) on a
+target system, upgrading such OS from an OCI image, manage kernel modules on a system, unpack an OCI image, build
+an installation media (generally an ISO file) from an OS image (packaged as OCI image), and more.
+
+`elemental3ctl` is a runtime management tool that helps deploy an OS image on disk, as well as helps manage such an
+installation by performing upgrades, managing kernel modules, perform factory reset, etc. `elemental3` complements
+it by building and configuring an OS image that could have additional artifacts and
+capabilities, making it a platform to build and deploy cloud-native applications.
+
 ## Guides
 
 * [Using Elemental for the first time](cookbook-first-time-use.md) - First use guide for the "UC" build of Elemental

--- a/docs/systemd-system-extensions.md
+++ b/docs/systemd-system-extensions.md
@@ -1,11 +1,11 @@
 # System extensions (systemd-sysext) in Elemental
 
-This chapter covers what a system extension (a.k.a. sysext) is, why it's relevant for Elemental, and how Elemental 
+This chapter covers what a system extension (a.k.a. sysext) is, why it's relevant for Elemental, and how Elemental
 uses it to provide extensibility in the image mode OS image.
 
 ## What is a system extension?
 
-[System extension images (or sysext images)](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html) 
+[System extension images (or sysext images)](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html)
 can be disk image files or simple folders that get loaded by
 `systemd-sysext.service`. They provide a way to dynamically extend the `/usr`
 and `/opt` directory hierarchies with additional files. When one or more system
@@ -14,32 +14,32 @@ combined via "overlayfs" with the same hierarchies of the host OS. This causes
 "merging" (or overmounting) of the `/usr` and `/opt` contents of the system
 extension image with that of the underlying host system.
 
-When a system extension image is deactivated, the `/usr` and `/opt` mountpoints are disassembled, thus revealing the 
+When a system extension image is deactivated, the `/usr` and `/opt` mountpoints are disassembled, thus revealing the
 unmodified original host version of the filesystem hierarchy.
 
-Merging or activating makes the system extension's resources appear below `/usr` and `/opt` as if they were 
-included in the base OS image itself. Unmerging or deactivating makes them disappear again, leaving in place only 
+Merging or activating makes the system extension's resources appear below `/usr` and `/opt` as if they were
+included in the base OS image itself. Unmerging or deactivating makes them disappear again, leaving in place only
 the files that were shipped with the base OS image itself.
 
-Note that files and directories contained in a system extension image outside the `/usr` and `/opt` hierarchies are 
-not merged. E.g., files in `/etc` and `/var` included in a system extension image will not appear under the 
+Note that files and directories contained in a system extension image outside the `/usr` and `/opt` hierarchies are
+not merged. E.g., files in `/etc` and `/var` included in a system extension image will not appear under the
 respective hierarchies after activation.
 
-To learn more about system extension images, refer to the 
+To learn more about system extension images, refer to the
 [official documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html) about it.
 
 ## When are system extensions required?
 
-A system extension is useful when working with an OS with an immutable base. Such an OS is usually shipped as an 
-image that contains all the essential software: bootloader, kernel and userspace utilities. However, it doesn't have 
-a package manager like `zypper` which can be used to install additional packages. System extensions help extend the 
+A system extension is useful when working with an OS with an immutable base. Such an OS is usually shipped as an
+image that contains all the essential software: bootloader, kernel and userspace utilities. However, it doesn't have
+a package manager like `zypper` which can be used to install additional packages. System extensions help extend the
 functionality and usability of those image mode OSes.
 
 ## Creating system extension images
 
-There are multiple tools to create a system extension image, e.g., `mksquashfs`, `mkerofs`, or `mkosi`. In this guide we 
-will use `mkosi`, which is a higher level tool than the other two. It builds bootable OS images, system 
-extension images, CPIO archives, and more. The way it differs from the other two is that `mkosi` has a wrapper 
+There are multiple tools to create a system extension image, e.g., `mksquashfs`, `mkerofs`, or `mkosi`. In this guide we
+will use `mkosi`, which is a higher level tool than the other two. It builds bootable OS images, system
+extension images, CPIO archives, and more. The way it differs from the other two is that `mkosi` has a wrapper
 around popular package managers that helps install and setup things without needing to install a package manager.
 
 In this guide, we will see two approaches to create a system extension image:
@@ -72,15 +72,15 @@ In this section, we will install the `kubectl` binary as a system extension on a
    ```
    - The `Distribution` section defines the Linux distribution to be installed in the image.
    - `SYSTEMD_REPART_OVERRIDE_FSTYPE_ROOT=squashfs` specifies the root filesystem type for the resulting disk image.
-   - The `Output` section defines various values for the result produced by `mkosi`. Besides `sysext`, it could 
+   - The `Output` section defines various values for the result produced by `mkosi`. Besides `sysext`, it could
      generate various other types of output.
 1. Prepare the `mkosi.extra` directory inside the `example-extension` directory:
    - Create the directory structure for kubectl:
         ```shell
         mkdir -p example-extension/mkosi.extra/usr/bin
-        ```       
+        ```
    - Get the `kubectl` binary by following the steps mentioned
-     [here](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/), make it executable, and copy it to the 
+     [here](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/), make it executable, and copy it to the
      directory created above:
         ```shell
         chmod +x kubectl
@@ -108,7 +108,7 @@ We now have a system extension image named `kubectl.x86-64.raw` ready under the 
 
 ### Installing RPMs in a system extension image
 
-The Elemental project's repository contains an [example](../examples/tools-sysext) that can be run directly to 
+The Elemental project's repository contains an [example](../examples/tools-sysext) that can be run directly to
 understand this. Check out the directory structure of [`examples/tools-sysext`](../examples/tools-sysext).
 
 ```shell
@@ -124,18 +124,18 @@ examples/tools-sysext
 ```
 The presence of the `mkosi.images` directory indicates that the configuration is meant for multiple images.
 
-Here there are three `mkosi.conf` files, relative to `examples/tools-sysext`. Below is a brief summary of the purpose of each of 
+Here there are three `mkosi.conf` files, relative to `examples/tools-sysext`. Below is a brief summary of the purpose of each of
 these files:
-- `mkosi.conf`: This is the global `mkosi` configuration file which contains distribution-level configuration. 
+- `mkosi.conf`: This is the global `mkosi` configuration file which contains distribution-level configuration.
 - `base/mkosi.conf`: This file is for the base layer that's used to install package(s) upon.
 - `tools/mkosi.conf`: This is the configuration for the tools layer.
 
-Creating the tools system extension requires "subtracting" the tools layer from the base layer. The base layer hence 
-needs to include any of the files that are already available on the host operating system, and the tools definition 
-defines the extensions over that. This approach ensures that the tools layer does not overwrite any files on the 
+Creating the tools system extension requires "subtracting" the tools layer from the base layer. The base layer hence
+needs to include any of the files that are already available on the host operating system, and the tools definition
+defines the extensions over that. This approach ensures that the tools layer does not overwrite any files on the
 operating system.
 
-You can build the system extension by invoking `mkosi` in the `examples/tools-sysext` directory. This will create a base 
+You can build the system extension by invoking `mkosi` in the `examples/tools-sysext` directory. This will create a base
 image and a tools image, and then assemble them into a system extension.
 ```shell
 cd examples/tools-sysext
@@ -147,24 +147,3 @@ Such systemd extensions can be included as an overlay in the Elemental customiza
 
 Further steps to build the image can be found in the document for
 [Building Linux image](./building-linux-image.md#preparing-the-system-extension-image-as-an-overlay).
-
-## How are systemd extensions used in Elemental?
-
-The elemental project mainly consists of two binaries:
-- `elemental3`
-- `elemental3ctl`
-
-`elemental3` is a higher-level tool that takes as its input an OCI image containing an ISO artifact, adds payloads
-such as system extensions, Kubernetes definitions, first-boot configs, and generates an ISO or RAW file which can be
-used to boot a VM.
-
-`elemental3ctl` is a lower-level tool that can do various things like installing an OS (packaged as an OCI image) on a
-target system, upgrading such OS from an OCI image, manage kernel modules on a system, unpack an OCI image, build
-an installation media (generally an ISO file) from an OS image (packaged as OCI image), and more.
-
-`elemental3ctl` is a runtime management tool that helps deploy an OS image on disk, as well as helps manage such an
-installation by performing upgrades, managing kernel modules, perform factory reset, etc. `elemental3` complements
-it by building and configuring an OS image that could have additional artifacts and
-capabilities, making it a platform to build and deploy cloud-native applications.
-
-`elemental3ctl` is provided on an image mode OS as a system extension.


### PR DESCRIPTION
This commits removes the referenes of elemental3ctl being provided as systemd-sysext image.

The generic systemd-sysext documentation is left as is.