### PR TITLE
Remove Integration Tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![golangci-lint](https://github.com/suse/elemental/actions/workflows/golangci_lint.yaml/badge.svg)](https://github.com/suse/elemental/actions/workflows/golangci_lint.yaml)
 [![CodeQL](https://github.com/SUSE/elemental/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/SUSE/elemental/actions/workflows/github-code-scanning/codeql)
 [![Unit Tests](https://github.com/SUSE/elemental/actions/workflows/unit_tests.yaml/badge.svg)](https://github.com/SUSE/elemental/actions/workflows/unit_tests.yaml)
-[![Integration Tests](https://github.com/SUSE/elemental/actions/workflows/integration_tests.yaml/badge.svg)](https://github.com/SUSE/elemental/actions/workflows/integration_tests.yaml)
-
 
 # Description
 


### PR DESCRIPTION
As PR #357 remove execution on `main`, the badge is not needed anymore.