### PR TITLE
Add schema version to release manifest

### DIFF
--- a/pkg/manifest/api/core/manifest.go
+++ b/pkg/manifest/api/core/manifest.go
@@ -29,8 +29,9 @@ import (
 )
 
 type ReleaseManifest struct {
-	Metadata   *api.Metadata `yaml:"metadata,omitempty"`
-	Components Components    `yaml:"components" validate:"required"`
+	Schema     api.SchemaVersion `yaml:"schema,omitempty"`
+	Metadata   *api.Metadata     `yaml:"metadata,omitempty"`
+	Components Components        `yaml:"components" validate:"required"`
 }
 
 type Components struct {
@@ -55,6 +56,10 @@ type Image struct {
 }
 
 func Parse(data []byte) (*ReleaseManifest, error) {
+	if _, err := api.LoadSchemaVersion(data); err != nil {
+		return nil, fmt.Errorf("parsing 'core' release manifest: %w", err)
+	}
+
 	rm := &ReleaseManifest{}
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)

--- a/pkg/manifest/api/core/manifest_test.go
+++ b/pkg/manifest/api/core/manifest_test.go
@@ -74,6 +74,8 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rm).ToNot(BeNil())
 
+		Expect(rm.Schema).To(BeEquivalentTo("v0"))
+
 		Expect(rm.Metadata).ToNot(BeNil())
 		Expect(rm.Metadata.Name).To(Equal("suse-core"))
 		Expect(rm.Metadata.Version).To(Equal("1.0"))
@@ -117,6 +119,49 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		rm, err := core.Parse(data)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(expErrMsg))
+		Expect(rm).To(BeNil())
+	})
+
+	It("defaults to schema v0 when schema field is missing", func() {
+		data := []byte(`
+components:
+  operatingSystem:
+    image:
+      base: "registry.com/foo/bar/os-base:6.2"
+      iso: "registry.com/foo/bar/installer-iso:6.2"
+`)
+		rm, err := core.Parse(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rm).ToNot(BeNil())
+	})
+
+	It("succeeds with explicit schema v0", func() {
+		data := []byte(`
+schema: v0
+components:
+  operatingSystem:
+    image:
+      base: "registry.com/foo/bar/os-base:6.2"
+      iso: "registry.com/foo/bar/installer-iso:6.2"
+`)
+		rm, err := core.Parse(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rm).ToNot(BeNil())
+		Expect(rm.Schema).To(BeEquivalentTo("v0"))
+	})
+
+	It("fails with unknown schema version", func() {
+		data := []byte(`
+schema: v99
+components:
+  operatingSystem:
+    image:
+      base: "registry.com/foo/bar/os-base:6.2"
+      iso: "registry.com/foo/bar/installer-iso:6.2"
+`)
+		rm, err := core.Parse(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`unsupported manifest schema version: "v99"`))
 		Expect(rm).To(BeNil())
 	})
 

--- a/pkg/manifest/api/product/manifest.go
+++ b/pkg/manifest/api/product/manifest.go
@@ -29,9 +29,10 @@ import (
 )
 
 type ReleaseManifest struct {
-	Metadata     *api.Metadata `yaml:"metadata,omitempty"`
-	CorePlatform *CorePlatform `yaml:"corePlatform" validate:"required"`
-	Components   Components    `yaml:"components,omitempty"`
+	Schema       api.SchemaVersion `yaml:"schema,omitempty"`
+	Metadata     *api.Metadata     `yaml:"metadata,omitempty"`
+	CorePlatform *CorePlatform     `yaml:"corePlatform" validate:"required"`
+	Components   Components        `yaml:"components,omitempty"`
 }
 
 type CorePlatform struct {
@@ -44,6 +45,10 @@ type Components struct {
 }
 
 func Parse(data []byte) (*ReleaseManifest, error) {
+	if _, err := api.LoadSchemaVersion(data); err != nil {
+		return nil, fmt.Errorf("parsing 'product' release manifest: %w", err)
+	}
+
 	rm := &ReleaseManifest{}
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)

--- a/pkg/manifest/api/product/manifest_test.go
+++ b/pkg/manifest/api/product/manifest_test.go
@@ -72,6 +72,8 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rm).ToNot(BeNil())
 
+		Expect(rm.Schema).To(BeEquivalentTo("v0"))
+
 		Expect(rm.Metadata).ToNot(BeNil())
 		Expect(rm.Metadata.Name).To(Equal("suse-edge"))
 		Expect(rm.Metadata.Version).To(Equal("3.2.0"))
@@ -103,6 +105,40 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		Expect(len(rm.Components.Helm.Repositories)).To(Equal(1))
 		Expect(rm.Components.Helm.Repositories[0].Name).To(Equal("bar-charts"))
 		Expect(rm.Components.Helm.Repositories[0].URL).To(Equal("https://bar.github.io/charts"))
+	})
+
+	It("defaults to schema v0 when schema field is missing", func() {
+		data := []byte(`
+corePlatform:
+  image: "foo.example.com/bar/release-manifest:1.0"
+`)
+		rm, err := product.Parse(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rm).ToNot(BeNil())
+	})
+
+	It("succeeds with explicit schema v0", func() {
+		data := []byte(`
+schema: v0
+corePlatform:
+  image: "foo.example.com/bar/release-manifest:1.0"
+`)
+		rm, err := product.Parse(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rm).ToNot(BeNil())
+		Expect(rm.Schema).To(BeEquivalentTo("v0"))
+	})
+
+	It("fails with unknown schema version", func() {
+		data := []byte(`
+schema: v99
+corePlatform:
+  image: "foo.example.com/bar/release-manifest:1.0"
+`)
+		rm, err := product.Parse(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`unsupported manifest schema version: "v99"`))
+		Expect(rm).To(BeNil())
 	})
 
 	It("fails when unknown field is introduced", func() {

--- a/pkg/manifest/api/shared.go
+++ b/pkg/manifest/api/shared.go
@@ -19,8 +19,44 @@ limitations under the License.
 package api
 
 import (
+	"bytes"
+	"fmt"
+
+	"go.yaml.in/yaml/v3"
+
 	"github.com/suse/elemental/v3/pkg/helm"
 )
+
+type SchemaVersion string
+
+const SchemaV0 SchemaVersion = "v0"
+
+type schemaHeader struct {
+	SchemaVersion SchemaVersion `yaml:"schema"`
+}
+
+func LoadSchemaVersion(data []byte) (SchemaVersion, error) {
+	var header schemaHeader
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(false)
+
+	if err := decoder.Decode(&header); err != nil {
+		return "", fmt.Errorf("extracting schema version: %w", err)
+	}
+
+	// TODO: remove default once we have added schema to the official manifests.
+	if header.SchemaVersion == "" {
+		return SchemaV0, nil
+	}
+
+	switch header.SchemaVersion {
+	case SchemaV0:
+		return SchemaV0, nil
+	default:
+		return "", fmt.Errorf("unsupported manifest schema version: %q", header.SchemaVersion)
+	}
+}
 
 type DependencyType string
 

--- a/pkg/manifest/api/shared_suite_test.go
+++ b/pkg/manifest/api/shared_suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSharedAPISuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Release Manifest Shared API test suite")
+}

--- a/pkg/manifest/api/shared_test.go
+++ b/pkg/manifest/api/shared_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/suse/elemental/v3/pkg/manifest/api"
+)
+
+var _ = Describe("LoadSchemaVersion", Label("release-manifest"), func() {
+	It("defaults to v0 when schema field is missing", func() {
+		data := []byte(`
+metadata:
+  name: "test"
+`)
+		version, err := api.LoadSchemaVersion(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(Equal(api.SchemaV0))
+	})
+
+	It("returns v0 when schema is explicitly set to v0", func() {
+		data := []byte(`
+schema: v0
+metadata:
+  name: "test"
+`)
+		version, err := api.LoadSchemaVersion(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(Equal(api.SchemaV0))
+	})
+
+	It("fails with an unsupported schema version", func() {
+		data := []byte(`
+schema: v99
+metadata:
+  name: "test"
+`)
+		version, err := api.LoadSchemaVersion(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`unsupported manifest schema version: "v99"`))
+		Expect(version).To(BeEquivalentTo(""))
+	})
+
+	It("fails with malformed YAML", func() {
+		data := []byte(`]]]`)
+		version, err := api.LoadSchemaVersion(data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("extracting schema version"))
+		Expect(version).To(BeEquivalentTo(""))
+	})
+})

--- a/pkg/manifest/testdata/full_core_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_core_release_manifest.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+schema: v0
 metadata:
   name: "suse-core"
   version: "1.0"

--- a/pkg/manifest/testdata/full_product_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_product_release_manifest.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+schema: v0
 metadata:
   name: "suse-edge"
   version: "3.2.0"


### PR DESCRIPTION
This commit adds a schema field to the top level of a release manifest.
Right now it defaults to "v0" to not break until the changes are done in
our production release manifests as well.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
