### PR TITLE
Add string format arguments in mocked runner

### DIFF
--- a/pkg/sys/mock/runner.go
+++ b/pkg/sys/mock/runner.go
@@ -171,14 +171,14 @@ func (r *Runner) SetLogger(logger log.Logger) {
 	r.Logger = logger
 }
 
-func (r Runner) error(msg string) {
+func (r Runner) error(msg string, args ...any) {
 	if r.Logger != nil {
-		r.Logger.Error(msg)
+		r.Logger.Error(msg, args...)
 	}
 }
 
-func (r Runner) debug(msg string) {
+func (r Runner) debug(msg string, args ...any) {
 	if r.Logger != nil {
-		r.Logger.Debug(msg)
+		r.Logger.Debug(msg, args...)
 	}
 }


### PR DESCRIPTION
This is to fix the lint errors from #424, in fact there was an error here, the arguments of the formatted log message were missing. Apparently with go 26 some checks are a bit more strict.