### PR TITLE
Fix runner mock debug messages

### DIFF
--- a/pkg/sys/mock/runner.go
+++ b/pkg/sys/mock/runner.go
@@ -50,7 +50,7 @@ func (r *Runner) RunEnv(command string, envs []string, args ...string) ([]byte, 
 	err := r.ReturnError
 	out := r.ReturnValue
 
-	r.debug(fmt.Sprintf("Running cmd: '%s %s'", command, strings.Join(args, " ")))
+	r.debug("Running cmd: '%s %s'", command, strings.Join(args, " "))
 	r.cmds = append(r.cmds, append([]string{command}, args...))
 	r.envs = append(r.envs, append([]string{command}, envs...))
 	if r.SideEffect != nil {
@@ -60,7 +60,7 @@ func (r *Runner) RunEnv(command string, envs []string, args ...string) ([]byte, 
 		}
 	}
 	if err != nil {
-		r.error(fmt.Sprintf("Error running command: %s", err.Error()))
+		r.error("Error running command: %s", err.Error())
 	}
 	return out, err
 }

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -59,7 +59,7 @@ func (r run) RunEnv(command string, env []string, args ...string) ([]byte, error
 	if len(env) > 0 {
 		displayEnv = strings.Join(env, " ") + " "
 	}
-	r.debug("Running cmd: '%s%s %s'", displayEnv, command, strings.Join(args, " "))
+	r.debug("Running cmd: '%s %s %s'", displayEnv, command, strings.Join(args, " "))
 	cmd := exec.Command(command, args...)
 	cmd.Env = env
 	out, err := cmd.Output()


### PR DESCRIPTION
After #426 a couple of more linting issues appeared. I did a run on my fork [re-based](https://github.com/davidcassany/elemental/pull/7) on #424 to ensure this time the lint is actually passing (for whatever reason the my local lint from TW does now report those, there might a slight config drift between GHA and my env).