### PR TITLE
Use compatible Rancher version

### DIFF
--- a/examples/elemental/customize/multi-node/suse-product-manifest.yaml
+++ b/examples/elemental/customize/multi-node/suse-product-manifest.yaml
@@ -20,7 +20,7 @@ components:
           crds:
             enabled: true
       - chart: "rancher"
-        version: "2.13.0"
+        version: "2.14.0"
         namespace: "cattle-system"
         repository: "rancher"
         values:
@@ -45,6 +45,6 @@ components:
       - name: "jetstack"
         url: "https://charts.jetstack.io"
       - name: "rancher"
-        url: "https://releases.rancher.com/server-charts/stable"
+        url: "https://releases.rancher.com/server-charts/latest"
       - name: "rancher-charts"
         url: "https://charts.rancher.io"

--- a/examples/elemental/customize/single-node/suse-product-manifest.yaml
+++ b/examples/elemental/customize/single-node/suse-product-manifest.yaml
@@ -21,7 +21,7 @@ components:
           crds:
             enabled: true
       - chart: "rancher"
-        version: "2.13.0"
+        version: "2.14.0"
         namespace: "cattle-system"
         repository: "rancher"
         values:
@@ -46,6 +46,6 @@ components:
       - name: "jetstack"
         url: "https://charts.jetstack.io"
       - name: "rancher"
-        url: "https://releases.rancher.com/server-charts/stable"
+        url: "https://releases.rancher.com/server-charts/latest"
       - name: "rancher-charts"
         url: "https://charts.rancher.io"


### PR DESCRIPTION
Using the current config, Rancher manager installation fails due to RKE2 being too new — 1.35. [Link to support matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-13-1/).

In my understanding, we could either downgrade the RKE2 version being used for compatibility with Rancher 2.13, or upgrade the Rancher version that works with RKE2 1.35. This PR does the latter.