### PR TITLE
Add support for registries file

### DIFF
--- a/docs/configuration-directory.md
+++ b/docs/configuration-directory.md
@@ -190,14 +190,16 @@ The directory's structure is as follows:
     │   └── local-manifest.yaml
     └── config
         ├── agent.yaml
-        └── server.yaml
+        ├── server.yaml
+        └── registries.yaml
 ```
 
 * `helm` - Optional; Contains locally provided Helm chart configurations
   * `values` - Optional; Contains [Helm values files](https://helm.sh/docs/chart_template_guide/values_files/). Helm charts that requirespecified values must have a values file included in this directory.
 * `manifests` - Optional; Contains locally provided Kubernetes manifests which will be applied to the cluster. Can
   be used separately or in combination with the manifests provided in the `cluster.yaml` file.
-* `config` - Optional; Contains locally provided Kubernetes configuration files, `server.yaml` for control-plane nodes and `agent.yaml` for workers.
+* `config` - Optional; Contains locally provided Kubernetes configuration files, `server.yaml` for control-plane nodes and `agent.yaml` for workers. The `registries.yaml` is the
+[private registry configuration](https://docs.rke2.io/install/private_registry), if present, it is applied for all nodes.
 
 ## Network
 

--- a/docs/image-customization.md
+++ b/docs/image-customization.md
@@ -519,6 +519,7 @@ The contents of the directory are the same as the contents for a [single-node Ku
 
 - [network/](../examples/elemental/customize/multi-node/network/) - add network configuration for each desired node. This example configures the static IPs `192.168.122.250`, `192.168.122.251`, `192.168.122.252` and `192.168.122.253` for machines with the respective `FE:C4:05:42:8B:01`, `FE:C4:05:42:8B:02`, `FE:C4:05:42:8B:03` and `FE:C4:05:42:8B:04` MAC addresses.
 - [kubernetes/config/agent.yaml](../examples/elemental/customize/multi-node/kubernetes/config/agent.yaml) - add configuration for the agent node.
+- [kubernetes/config/registries.yaml](../examples/elemental/customize/multi-node/kubernetes/config/registries.yaml) - add configuration for the embedded private registry. This example sets the embedded spegel registry to cache images from registry.suse.com. This way images such as the OS image is pulled only once from the remote registry during upgrades.
 - [kubernetes/cluster.yaml](../examples/elemental/customize/multi-node/kubernetes/cluster.yaml) - add multi-node cluster configuration that specifies the node's roles as well as the cluster's network setup.
 
 #### Producing the customized image

--- a/examples/elemental/customize/multi-node/kubernetes/config/agent.yaml
+++ b/examples/elemental/customize/multi-node/kubernetes/config/agent.yaml
@@ -1,2 +1,3 @@
 token: totally-not-generated-one
 debug: true
+embedded-registry: true

--- a/examples/elemental/customize/multi-node/kubernetes/config/registries.yaml
+++ b/examples/elemental/customize/multi-node/kubernetes/config/registries.yaml
@@ -1,0 +1,4 @@
+mirrors:
+  registry.suse.com:
+    endpoint:
+    - https://registry.suse.com/v2

--- a/examples/elemental/customize/multi-node/kubernetes/config/server.yaml
+++ b/examples/elemental/customize/multi-node/kubernetes/config/server.yaml
@@ -1,2 +1,3 @@
 token: totally-not-generated-one
 selinux: true
+embedded-registry: true

--- a/internal/config/ignition.go
+++ b/internal/config/ignition.go
@@ -239,6 +239,18 @@ func appendRke2Configuration(s *sys.System, config *butane.Config, k *kubernetes
 		})
 	}
 
+	if c.RegistriesConfig != nil {
+		registriesBytes, err := marshalConfig(c.RegistriesConfig)
+		if err != nil {
+			return fmt.Errorf("failed marshaling agent config: %w", err)
+		}
+
+		config.Storage.Files = append(config.Storage.Files, v0_6.File{
+			Path:     filepath.Join(k8sPath, "registries.yaml"),
+			Contents: v0_6.Resource{Inline: util.StrToPtr(string(registriesBytes))},
+		})
+	}
+
 	if k.Network.APIVIP4 != "" || k.Network.APIVIP6 != "" {
 		manifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
 

--- a/internal/config/ignition_test.go
+++ b/internal/config/ignition_test.go
@@ -26,6 +26,7 @@ import (
 
 	v0 "github.com/suse/elemental/v3/internal/config/v0"
 	"github.com/suse/elemental/v3/internal/image"
+	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
 	"github.com/suse/elemental/v3/pkg/sys"
@@ -48,7 +49,8 @@ var _ = Describe("Ignition configuration", func() {
 	BeforeEach(func() {
 		buffer = &bytes.Buffer{}
 		fs, cleanup, err = sysmock.TestFS(map[string]any{
-			"/etc/kubernetes/config/server.yaml": "",
+			"/etc/kubernetes/config/server.yaml":     "",
+			"/etc/kubernetes/config/registries.yaml": "key: 'value'\n",
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -110,7 +112,14 @@ passwd:
 	})
 
 	It("Configures kubernetes via Ignition with the given k8s script", func() {
-		conf := &image.Configuration{}
+		// includes registries configuration
+		conf := &image.Configuration{
+			Kubernetes: kubernetes.Kubernetes{
+				Config: kubernetes.Config{
+					RegistriesFilePath: "/etc/kubernetes/config/registries.yaml",
+				},
+			},
+		}
 		ignitionFile := filepath.Join(output.FirstbootConfigDir(), image.IgnitionFilePath())
 
 		k8sScript := filepath.Join(output.OverlaysDir(), "path/to/k8s/script.sh")
@@ -126,6 +135,7 @@ passwd:
 		Expect(ignition).NotTo(ContainSubstring("/etc/elemental/extensions.yaml"))
 		Expect(ignition).To(ContainSubstring("Kubernetes Resources Installer"))
 		Expect(ignition).To(ContainSubstring("Kubernetes Installation and Configuration"))
+		Expect(ignition).To(ContainSubstring("/var/lib/elemental/kubernetes/registries.yaml"))
 	})
 
 	It("Writes systemd extension via Ignition", func() {
@@ -149,6 +159,7 @@ passwd:
 		Expect(ignition).NotTo(ContainSubstring("merge"))
 		Expect(ignition).NotTo(ContainSubstring("Kubernetes Resources Installer"))
 		Expect(ignition).NotTo(ContainSubstring("Kubernetes Config Installer"))
+		Expect(ignition).NotTo(ContainSubstring("/var/lib/elemental/kubernetes/registries.yaml"))
 	})
 
 	It("Fails to translate a butaneConfig with a wrong version or variant", func() {

--- a/internal/config/templates/k8s_conf_deploy.sh.tpl
+++ b/internal/config/templates/k8s_conf_deploy.sh.tpl
@@ -15,6 +15,7 @@ HOSTNAME=$(</etc/hostname)
 
 NODETYPE="${hosts[${HOSTNAME}]:-server}"
 CONFIGFILE="{{ .KubernetesDir }}/${NODETYPE}.yaml"
+REGFILE="{{ .KubernetesDir }}/registries.yaml"
 
 if [[ "${HOSTNAME}" = "{{ .InitNode.Hostname }}" ]]; then
   echo "Setting up init node"
@@ -24,6 +25,10 @@ fi
 mkdir -p /etc/rancher/rke2
 echo "Copying RKE2 config file ${CONFIGFILE}"
 cp ${CONFIGFILE} /etc/rancher/rke2/config.yaml
+
+if [ -e "${REGFILE}" ]; then
+  cp "${REGFILE}" /etc/rancher/rke2/registries.yaml
+fi
 
 {{- if and .APIVIP4 .APIHost }}
 grep -q "{{ .APIVIP4 }} {{ .APIHost }}" /etc/hosts \

--- a/internal/config/v0/config.go
+++ b/internal/config/v0/config.go
@@ -69,6 +69,10 @@ func (dir Dir) KubernetesServerFilepath() string {
 	return filepath.Join(dir.KubernetesConfigDir(), "server.yaml")
 }
 
+func (dir Dir) KubernetesRegistriesFilepath() string {
+	return filepath.Join(dir.KubernetesConfigDir(), "registries.yaml")
+}
+
 func (dir Dir) KubernetesManifestsDir() string {
 	return filepath.Join(dir.kubernetesDir(), "manifests")
 }
@@ -265,6 +269,11 @@ func parseKubernetesDir(f vfs.FS, configDir Dir, k *kubernetes.Kubernetes, r *re
 	agentYamlPath := configDir.KubernetesAgentFilepath()
 	if exists, _ := vfs.Exists(f, agentYamlPath); exists {
 		k.Config.AgentFilePath = agentYamlPath
+	}
+
+	registriesYamlPath := configDir.KubernetesRegistriesFilepath()
+	if exists, _ := vfs.Exists(f, registriesYamlPath); exists {
+		k.Config.RegistriesFilePath = registriesYamlPath
 	}
 
 	return parseKubernetes(f, configDir, k, r)

--- a/internal/config/v0/config_test.go
+++ b/internal/config/v0/config_test.go
@@ -101,17 +101,18 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 
 	BeforeEach(func() {
 		fs, cleanup, err = sysmock.TestFS(map[string]any{
-			fmt.Sprintf("%s/install.yaml", configDir):                      installYAML,
-			fmt.Sprintf("%s/butane.yaml", configDir):                       butaneYAML,
-			fmt.Sprintf("%s/kubernetes/cluster.yaml", configDir):           kubernetesClusterYAML,
-			fmt.Sprintf("%s/release.yaml", configDir):                      releaseYAML,
-			fmt.Sprintf("%s/foo.yaml", configDir.HelmValuesDir()):          "",
-			fmt.Sprintf("%s/bar.yaml", configDir.KubernetesManifestsDir()): "",
-			fmt.Sprintf("%s/agent.yaml", configDir.KubernetesConfigDir()):  "",
-			fmt.Sprintf("%s/server.yaml", configDir.KubernetesConfigDir()): "",
-			fmt.Sprintf("%s/node1.foo.yaml", configDir.NetworkDir()):       "",
-			fmt.Sprintf("%s/scripts/foo.sh", configDir.CustomDir()):        "",
-			fmt.Sprintf("%s/files/foo", configDir.CustomDir()):             "",
+			fmt.Sprintf("%s/install.yaml", configDir):                          installYAML,
+			fmt.Sprintf("%s/butane.yaml", configDir):                           butaneYAML,
+			fmt.Sprintf("%s/kubernetes/cluster.yaml", configDir):               kubernetesClusterYAML,
+			fmt.Sprintf("%s/release.yaml", configDir):                          releaseYAML,
+			fmt.Sprintf("%s/foo.yaml", configDir.HelmValuesDir()):              "",
+			fmt.Sprintf("%s/bar.yaml", configDir.KubernetesManifestsDir()):     "",
+			fmt.Sprintf("%s/agent.yaml", configDir.KubernetesConfigDir()):      "",
+			fmt.Sprintf("%s/server.yaml", configDir.KubernetesConfigDir()):     "",
+			fmt.Sprintf("%s/registries.yaml", configDir.KubernetesConfigDir()): "",
+			fmt.Sprintf("%s/node1.foo.yaml", configDir.NetworkDir()):           "",
+			fmt.Sprintf("%s/scripts/foo.sh", configDir.CustomDir()):            "",
+			fmt.Sprintf("%s/files/foo", configDir.CustomDir()):                 "",
 		})
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -132,6 +133,7 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 
 		Expect(conf.Kubernetes.Config.AgentFilePath).To(Equal(configDir.KubernetesAgentFilepath()))
 		Expect(conf.Kubernetes.Config.ServerFilePath).To(Equal(configDir.KubernetesServerFilepath()))
+		Expect(conf.Kubernetes.Config.RegistriesFilePath).To(Equal(configDir.KubernetesRegistriesFilepath()))
 		Expect(conf.Kubernetes.Helm).ToNot(BeNil())
 		Expect(conf.Kubernetes.Helm.Charts).ToNot(BeNil())
 		Expect(conf.Kubernetes.Helm.Charts[0].Name).To(Equal("foo"))
@@ -261,14 +263,16 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 		Expect(err).To(MatchError("parsing custom directory: directory \"/tmp/config-dir/custom/files\" is empty"))
 	})
 
-	It("Parses {server,agent}.yaml without manifests subdir", func() {
+	It("Parses {server,agent}.yaml without manifests subdir or registries configuration", func() {
 		Expect(fs.RemoveAll(configDir.KubernetesManifestsDir())).To(Succeed())
+		Expect(fs.RemoveAll(configDir.KubernetesRegistriesFilepath())).To(Succeed())
 
 		cfg, err := Parse(fs, configDir)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cfg.Kubernetes.Config.ServerFilePath).To(Equal("/tmp/config-dir/kubernetes/config/server.yaml"))
 		Expect(cfg.Kubernetes.Config.AgentFilePath).To(Equal("/tmp/config-dir/kubernetes/config/agent.yaml"))
+		Expect(cfg.Kubernetes.Config.RegistriesFilePath).To(BeEmpty())
 	})
 
 	It("Fails on invalid configuration", func() {

--- a/internal/image/kubernetes/cluster.go
+++ b/internal/image/kubernetes/cluster.go
@@ -51,9 +51,16 @@ type Cluster struct {
 	InitServerConfig ConfigMap
 	// AgentConfig contains the agent configurations in multi node clusters.
 	AgentConfig ConfigMap
+	// RegistriesConfig contains the configurations for private or embedded registries
+	RegistriesConfig ConfigMap
 }
 
 func NewCluster(s *sys.System, kube *Kubernetes) (*Cluster, error) {
+	registriesConfig, err := ParseKubernetesConfig(s, kube.Config.RegistriesFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("parsing registries config: %w", err)
+	}
+
 	serverConfig, err := ParseKubernetesConfig(s, kube.Config.ServerFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("parsing server config: %w", err)
@@ -61,7 +68,10 @@ func NewCluster(s *sys.System, kube *Kubernetes) (*Cluster, error) {
 
 	if len(kube.Nodes) < 2 {
 		setSingleNodeConfigDefaults(s.Logger(), kube, serverConfig)
-		return &Cluster{ServerConfig: serverConfig}, nil
+		return &Cluster{
+			ServerConfig:     serverConfig,
+			RegistriesConfig: registriesConfig,
+		}, nil
 	}
 
 	var ip4 netip.Addr
@@ -105,6 +115,7 @@ func NewCluster(s *sys.System, kube *Kubernetes) (*Cluster, error) {
 		InitServerConfig: initConfig,
 		ServerConfig:     serverConfig,
 		AgentConfig:      agentConfig,
+		RegistriesConfig: registriesConfig,
 	}, err
 }
 

--- a/internal/image/kubernetes/cluster_test.go
+++ b/internal/image/kubernetes/cluster_test.go
@@ -36,6 +36,12 @@ debug: true
 server: cluster1.suse.com
 cni: canal
 `
+	exampleRegistriesYaml = `
+mirrors:
+  mirror.example.com:
+    endpoint:
+    - https://mirror.example.com
+`
 )
 
 var _ = Describe("Cluster", func() {
@@ -49,10 +55,11 @@ var _ = Describe("Cluster", func() {
 		var err error
 
 		fs, cleanup, err = sysmock.TestFS(map[string]any{
-			"/etc/kubernetes/single-node/server.yaml": exampleServerYaml,
-			"/etc/kubernetes/multi-node/server.yaml":  exampleServerYaml,
-			"/etc/kubernetes/multi-node/agent.yaml":   exampleAgentYaml,
-			"/etc/kubernetes/empty/server.yaml":       "",
+			"/etc/kubernetes/single-node/server.yaml":    exampleServerYaml,
+			"/etc/kubernetes/multi-node/server.yaml":     exampleServerYaml,
+			"/etc/kubernetes/multi-node/agent.yaml":      exampleAgentYaml,
+			"/etc/kubernetes/multi-node/registries.yaml": exampleRegistriesYaml,
+			"/etc/kubernetes/empty/server.yaml":          "",
 		})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -130,13 +137,25 @@ var _ = Describe("Cluster", func() {
 				},
 			},
 			Config: Config{
-				ServerFilePath: "/etc/kubernetes/multi-node/server.yaml",
-				AgentFilePath:  "/etc/kubernetes/multi-node/agent.yaml",
+				ServerFilePath:     "/etc/kubernetes/multi-node/server.yaml",
+				AgentFilePath:      "/etc/kubernetes/multi-node/agent.yaml",
+				RegistriesFilePath: "/etc/kubernetes/multi-node/registries.yaml",
 			},
 		}
 
 		cluster, err := NewCluster(s, kubernetes)
 		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.RegistriesConfig).ToNot(BeEmpty())
+		Expect(cluster.RegistriesConfig["mirrors"]).ToNot(BeEmpty())
+		mirrors, ok := cluster.RegistriesConfig["mirrors"].(ConfigMap)
+		Expect(ok).To(BeTrue())
+		Expect(mirrors["mirror.example.com"]).ToNot(BeEmpty())
+		example, ok := mirrors["mirror.example.com"].(ConfigMap)
+		Expect(ok).To(BeTrue())
+		Expect(example["endpoint"]).ToNot(BeEmpty())
+		_, ok = example["endpoint"].([]any)
+		Expect(ok).To(BeTrue())
 
 		Expect(cluster.ServerConfig).ToNot(BeEmpty())
 		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -46,6 +46,8 @@ type Config struct {
 	AgentFilePath string
 	// ServerFilePath path to server.yaml rke2 configuration file
 	ServerFilePath string
+	// RegistriesFilePath path to the registries.yaml rke2 configuration file
+	RegistriesFilePath string
 }
 
 type Helm struct {


### PR DESCRIPTION
This PR adds support for the [registries.yaml](https://docs.rke2.io/install/private_registry) file as part of the `kubernetes/config` folder. The propose implementation of this PR follows a perfectly parallel logic of what it is used for the `server.yaml` and `agent.yaml` files. So that the contents of the file, if present, are deserialized into a ConfigMap and then serialized back again to be embedded as an additional file created as part of the ignition configuration. Feels a bit like an overkill (it could be simply be copied to the overlay directory instead), however I followed this approach to make the rke2 configuration setup handling logic consistent (and arguably easier to maintain) and to also have all the pieces in place assuming we ever want to manipulate the registries file contents as part of the customize process (which I am not seeing at the moment, but probably there is some tweak required for airgap).