### PR TITLE
Drop name field from release.yaml

### DIFF
--- a/docs/configuration-directory.md
+++ b/docs/configuration-directory.md
@@ -23,7 +23,6 @@ Consumers can use the `release.yaml` file to configure the desired product that 
 ### release.yaml
 
 ```yaml
-name: suse-product
 manifestURI: file:///path/to/manifest/suse-product-manifest.yaml
 # manifestURI: oci://registry.suse.com/suse-product/release-manifest:0.0.1
 components:
@@ -35,7 +34,6 @@ components:
     - extension: bar
 ```
 
-* `name` - Optional; Name of the product that all other configurations will be based on.
 * `manifestURI` - Required; URI to a release manifest for the Core Platform or the Product that will be used as base. For more information, refer to the [Release Manifest](./release-manifest.md) guide. Supports both local file (file://) and OCI image (oci://) definitions.
 * `components` - Optional; Components to explicitly enable from the Core Platform base.
   * `kubernetes` - Optional; If set (even if empty), enables Kubernetes distribution installation. If you also define cluster configuration, Helm charts or Kubernetes manifests, a cluster will be automatically enabled and this field is not required.

--- a/examples/elemental/customize/linux-only/release.yaml
+++ b/examples/elemental/customize/linux-only/release.yaml
@@ -1,2 +1,1 @@
-name: suse-product
 manifestURI: oci://registry.suse.com/beta/uc/release-manifest:0.6_rke2_1.35

--- a/examples/elemental/customize/multi-node/release.yaml
+++ b/examples/elemental/customize/multi-node/release.yaml
@@ -1,4 +1,3 @@
-name: suse-product
 manifestURI: file://./suse-product-manifest.yaml
 # Alternatively, the product release manifest can be specified from an OCI image.
 # manifestURI: oci://registry.suse.com/suse-product/release-manifest:0.0.1

--- a/examples/elemental/customize/single-node/release.yaml
+++ b/examples/elemental/customize/single-node/release.yaml
@@ -1,4 +1,3 @@
-name: suse-product
 manifestURI: file://./suse-product-manifest.yaml
 # Alternatively, the product release manifest can be specified from an OCI image.
 # manifestURI: oci://registry.suse.com/suse-product/release-manifest:0.0.1

--- a/internal/cli/action/init.go
+++ b/internal/cli/action/init.go
@@ -75,7 +75,6 @@ func defaultConfiguration() *image.Configuration {
 			CryptoPolicy: crypto.DefaultPolicy,
 		},
 		Release: release.Release{
-			Name:        "my-product",
 			ManifestURI: "oci://registry.example.com/my-product/release-manifest:latest",
 		},
 		Kubernetes: kubernetes.Kubernetes{

--- a/internal/config/v0/config_test.go
+++ b/internal/config/v0/config_test.go
@@ -77,7 +77,6 @@ network:
 `
 
 var releaseYAML = `
-name: foo
 manifestURI: oci://registry.foo.bar/release-manifest:0.0.1
 components:
   systemd:
@@ -155,7 +154,6 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 		Expect(containsChart("metallb", conf.Release.Components.HelmCharts)).To(BeTrue())
 		Expect(containsChart("endpoint-copier-operator", conf.Release.Components.HelmCharts)).To(BeTrue())
 		Expect(conf.Release.ManifestURI).To(Equal("oci://registry.foo.bar/release-manifest:0.0.1"))
-		Expect(conf.Release.Name).To(Equal("foo"))
 
 		Expect(conf.ButaneConfig).NotTo(BeEmpty())
 		Expect(conf.ButaneConfig).To(Equal(map[string]any{
@@ -314,7 +312,6 @@ var _ = Describe("Write", Label("configuration", "write"), func() {
 				},
 			},
 			Release: release.Release{
-				Name:        "test-product",
 				ManifestURI: "oci://registry.example.com/test:latest",
 			},
 		}
@@ -335,7 +332,6 @@ var _ = Describe("Write", Label("configuration", "write"), func() {
 
 		var parsedRelease release.Release
 		Expect(ParseAny(data, &parsedRelease)).To(Succeed())
-		Expect(parsedRelease.Name).To(Equal("test-product"))
 		Expect(parsedRelease.ManifestURI).To(Equal("oci://registry.example.com/test:latest"))
 	})
 
@@ -436,7 +432,6 @@ var _ = Describe("Write", Label("configuration", "write"), func() {
 				},
 			},
 			Release: release.Release{
-				Name:        "roundtrip-product",
 				ManifestURI: "oci://registry.example.com/roundtrip:1.0",
 				Components: release.Components{
 					SystemdExtensions: []release.SystemdExtension{
@@ -465,7 +460,6 @@ var _ = Describe("Write", Label("configuration", "write"), func() {
 		Expect(parsed.Installation.Bootloader).To(Equal("grub"))
 		Expect(parsed.Installation.CryptoPolicy).To(Equal(crypto.FIPSPolicy))
 		Expect(parsed.Installation.RAW.DiskSize).To(Equal(install.DiskSize("35G")))
-		Expect(parsed.Release.Name).To(Equal("roundtrip-product"))
 		Expect(parsed.Release.ManifestURI).To(Equal("oci://registry.example.com/roundtrip:1.0"))
 		Expect(parsed.Release.Components.SystemdExtensions).To(HaveLen(1))
 		Expect(parsed.Release.Components.SystemdExtensions[0].Name).To(Equal("rke2"))

--- a/internal/image/release/release.go
+++ b/internal/image/release/release.go
@@ -18,7 +18,6 @@ limitations under the License.
 package release
 
 type Release struct {
-	Name        string     `yaml:"name,omitempty"`
 	ManifestURI string     `yaml:"manifestURI" validate:"required"`
 	Components  Components `yaml:"components,omitempty"`
 }


### PR DESCRIPTION
Simplifies the release.yaml schema dropping the optional "name" field which doesn't provide too much of a value.