### PR TITLE
Do not erase config.yaml in during K8s installation

### DIFF
--- a/internal/config/templates/k8s-config-installer.service.tpl
+++ b/internal/config/templates/k8s-config-installer.service.tpl
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubernetes Installation and Configuration
-ConditionPathExists=!/etc/rancher/rke2/config.yaml
+ConditionFirstBoot=true
 Requires=network-online.target
 
 [Service]

--- a/internal/config/templates/k8s_conf_deploy.sh.tpl
+++ b/internal/config/templates/k8s_conf_deploy.sh.tpl
@@ -22,11 +22,13 @@ if [[ "${HOSTNAME}" = "{{ .InitNode.Hostname }}" ]]; then
   CONFIGFILE={{ .KubernetesDir }}/init.yaml
 fi
 
+# Better to append if a file exist
+# Useful if some custom configuration are done at boot
 mkdir -p /etc/rancher/rke2
 echo "Copying RKE2 config file ${CONFIGFILE}"
-cp ${CONFIGFILE} /etc/rancher/rke2/config.yaml
+cat ${CONFIGFILE} >> /etc/rancher/rke2/config.yaml
 
-if [ -e "${REGFILE}" ]; then
+if [[ -e "${REGFILE}" ]]; then
   cp "${REGFILE}" /etc/rancher/rke2/registries.yaml
 fi
 


### PR DESCRIPTION
Better to append data in config.yaml instead of doing a copy. Useful if some custom configuration are done before (ignition/services).

Should fix #438.