### PR TITLE
Fix overlay dir with split mode

### DIFF
--- a/internal/customize/customize.go
+++ b/internal/customize/customize.go
@@ -220,12 +220,10 @@ func parseDeployment(
 		d.BootConfig.KernelCmdline = fips.AppendCommandLine(d.BootConfig.KernelCmdline)
 	}
 
-	overlaysURI := fmt.Sprintf("%s://%s", deployment.Dir, output.OverlaysDir())
-	overlaySource, err := deployment.NewSrcFromURI(overlaysURI)
-	if err != nil {
-		return nil, fmt.Errorf("parsing overlay source URI %q: %w", overlaysURI, err)
+	overlaysDir := output.OverlaysDir()
+	if exists, _ := vfs.Exists(fs, overlaysDir); exists {
+		d.OverlayTree = deployment.NewDirSrc(overlaysDir)
 	}
-	d.OverlayTree = overlaySource
 
 	// Make sure that we define a valid installer config script if such was not defined
 	// during the build process of the ISO that is currently being customized.

--- a/internal/customize/customize_test.go
+++ b/internal/customize/customize_test.go
@@ -192,7 +192,7 @@ disks:
 
 		err := customizeRunner.Run(context.Background(), def, output)
 		Expect(err).ToNot(HaveOccurred())
-		defaultCustomizeDeploymentValidation(customizeDeployment)
+		defaultCustomizeDeploymentValidation(customizeDeployment, def)
 
 		Expect(customizeDeployment.Disks[0].Device).To(Equal("/dev/sda"))
 		// [{}, {}, nil, ignition, SYSTEM]
@@ -266,7 +266,7 @@ disks:
 
 		err := customizeRunner.Run(context.Background(), def, output)
 		Expect(err).ToNot(HaveOccurred())
-		defaultCustomizeDeploymentValidation(customizeDeployment)
+		defaultCustomizeDeploymentValidation(customizeDeployment, def)
 		Expect(customizeDeployment.Disks[0].Device).To(BeEmpty())
 		Expect(len(customizeDeployment.Disks[0].Partitions)).To(Equal(0))
 	})
@@ -421,14 +421,19 @@ func (m *mediaMock) Customize(d *deployment.Deployment) error {
 	panic("not implemented")
 }
 
-func defaultCustomizeDeploymentValidation(dep *deployment.Deployment) {
+func defaultCustomizeDeploymentValidation(dep *deployment.Deployment, def *image.Definition) {
 	Expect(dep.BootConfig.Bootloader).To(Equal("grub"))
 
 	expectedCMD := fmt.Sprintf("console=ttyS0 %s %s", "fips=1", fmt.Sprintf("boot=LABEL=%s", deployment.EfiLabel))
 	Expect(dep.BootConfig.KernelCmdline).To(Equal(expectedCMD))
 	Expect(dep.Security.CryptoPolicy).To(Equal(crypto.FIPSPolicy))
 
-	expectedImgSrc := deployment.NewDirSrc("/_out/overlays")
-	Expect(dep.OverlayTree).To(Equal(expectedImgSrc))
+	if def.Image.ImageType == "iso" {
+		expectedImgSrc := deployment.NewDirSrc("/_out/overlays")
+		Expect(dep.OverlayTree).To(Equal(expectedImgSrc))
+	} else {
+		Expect(dep.OverlayTree).To(BeNil())
+	}
+
 	Expect(dep.Installer.CfgScript).To(Equal("/_out/auto_installer.sh"))
 }


### PR DESCRIPTION
Currently when you run split mode with no configuration that creates an overlay dir (e.g. kubernetes), the image build fails because it expects an overlay dir that doesn't exist. The new change now makes sure not to set `d.OverlayTree = overlaySource` if the overlay dir doesn't exist, which allows the image build to succeed.