### PR TITLE
Do not force relabel persistent volumes

### DIFF
--- a/pkg/installer/media.go
+++ b/pkg/installer/media.go
@@ -567,7 +567,7 @@ func (i Media) prepareOSRoot(sourceOS *deployment.ImageSource, rootDir string) e
 		return fmt.Errorf("OS source write failed: %w", err)
 	}
 
-	err = selinux.Relabel(i.ctx, i.s, rootDir)
+	err = selinux.SystemRelabel(i.ctx, i.s, rootDir)
 	if err != nil {
 		i.s.Logger().Warn("Error selinux relabelling: %s", err.Error())
 	}

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -20,10 +20,7 @@ package selinux
 import (
 	"container/ring"
 	"context"
-	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/suse/elemental/v3/pkg/chroot"
 	"github.com/suse/elemental/v3/pkg/sys"
@@ -37,69 +34,52 @@ const (
 	debugLines          = 10
 )
 
-// Relabel will relabel the system if it finds the context
-func Relabel(ctx context.Context, s *sys.System, rootDir string, extraPaths ...string) error {
+// SystemRelabel applies the SE Linux labels based on the targeted policy found within the given
+// root path. It force applies the labels under the given root except for the given RW paths
+// This is to prevent runtime changes during the upgrades as RW paths are potentially in use for current
+// processes.
+func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, rwPaths ...string) error {
 	contextFile := filepath.Join(rootDir, SelinuxTargetedContextFile)
 	contextExists, _ := vfs.Exists(s.FS(), contextFile)
 
 	if contextExists {
 		var err error
-		args := []string{"-i", "-F"}
+		args := []string{"-i"}
 
 		// We only keep last 10 lines of the stdout and stderr for debugging purposes
 		stdOut := ring.New(debugLines)
 		stdErr := ring.New(debugLines)
 
 		if rootDir == "/" || rootDir == "" {
-			args = append(args, contextFile, "/")
+			rootDir = "/"
 		} else {
-			args = append(args, "-r", rootDir, contextFile, rootDir)
+			args = append(args, "-r", rootDir)
 		}
-		args = append(args, extraPaths...)
+
+		args = append(args, "-F")
+		if len(rwPaths) > 0 {
+			for _, rwp := range rwPaths {
+				args = append(args, "-e", rwp)
+			}
+		}
+		args = append(args, contextFile, rootDir)
+
+		s.Logger().Info("Applying SE Linux labels to the read-only root tree, forced relabelling")
 		err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", args...)
 		logOutput(s, stdOut, stdErr)
+
 		return err
 	}
 
-	s.Logger().Debug("Not relabelling SELinux, no context found")
+	s.Logger().Warn("Not relabelling SE Linux, no context found")
 	return nil
 }
 
-// ChrootedRelabel relables with setfiles the given root in a chroot env. Additionally after the first
-// chrooted call it runs a non chrooted call to relabel any mountpoint used within the chroot.
-func ChrootedRelabel(ctx context.Context, s *sys.System, rootDir string, bind map[string]string, additionalPaths ...string) (err error) {
-	extraPaths := make([]string, 0, len(additionalPaths)+len(bind))
-	extraPaths = append(extraPaths, additionalPaths...)
-
-	for _, v := range bind {
-		if !canAddForRelabel(v, extraPaths) {
-			return fmt.Errorf("failed adding bind mount path '%s' for relabel: path already exists in or overlaps with existing relabel paths: '%s'", v, extraPaths)
-		}
-		extraPaths = append(extraPaths, v)
-	}
-
-	callback := func() error { return Relabel(ctx, s, "/", extraPaths...) }
-	err = chroot.ChrootedCallback(s, rootDir, bind, callback, chroot.WithoutDefaultBinds())
-	if err != nil {
-		return err
-	}
-
-	contextsFile := filepath.Join(rootDir, SelinuxTargetedContextFile)
-	existsCon, _ := vfs.Exists(s.FS(), contextsFile)
-
-	if existsCon && len(extraPaths) > 0 {
-		stdOut := ring.New(debugLines)
-		stdErr := ring.New(debugLines)
-
-		args := []string{"-i", "-F", "-r", rootDir, contextsFile}
-		for _, path := range extraPaths {
-			args = append(args, filepath.Join(rootDir, path))
-		}
-		err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", args...)
-		logOutput(s, stdOut, stdErr)
-	}
-
-	return err
+// ChrootedSystemRelabel applies the SE Linux labels based on the targeted policy found within the given
+// root path. Runs the same logic as RelabelSystem method but running inside a chroot environment.
+func ChrootedSystemRelabel(ctx context.Context, s *sys.System, rootDir string, rwPaths ...string) error {
+	callback := func() error { return SystemRelabel(ctx, s, "/", rwPaths...) }
+	return chroot.ChrootedCallback(s, rootDir, nil, callback, chroot.WithoutDefaultBinds())
 }
 
 func stdHander(r *ring.Ring) func(string) {
@@ -123,30 +103,5 @@ func logOutput(s *sys.System, stdOut, stdErr *ring.Ring) {
 		}
 	})
 	output += "----------------------\n"
-	s.Logger().Debug("SELinux setfile call stdout: %s", output)
-}
-
-// canAddForRelabel checks whether the provided src can be included
-// to an already existing list of relabel paths.
-//
-// To add src to existingRelabels, src must introduce a path that is
-// not already explicitly, or implicitly defined in existingRelabels.
-//
-// This ensures that src will not accidentally compromise the state of
-// an already defined relabel path.
-func canAddForRelabel(src string, existingRelabels []string) bool {
-	srcPath := filepath.Clean(src)
-	for _, p := range existingRelabels {
-		relabelPath := filepath.Clean(p)
-
-		if srcPath == relabelPath {
-			return false
-		}
-
-		if strings.HasPrefix(srcPath, relabelPath+string(os.PathSeparator)) {
-			return false
-		}
-	}
-
-	return true
+	s.Logger().Debug("SE Linux setfile call stdout: %s", output)
 }

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -75,16 +75,16 @@ var _ = Describe("Selinux", Label("selinux"), func() {
 	AfterEach(func() {
 		cleanup()
 	})
-	It("relabels the given paths for the targeted context", func() {
+	It("relabels the given path for the targeted context, including rw paths", func() {
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
-		Expect(selinux.Relabel(context.Background(), s, root)).To(Succeed())
+		Expect(selinux.SystemRelabel(context.Background(), s, root, root+"/etc")).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{
-			"setfiles", "-i", "-F", "-r", "/some/root",
+			"setfiles", "-i", "-r", "/some/root", "-F", "-e", "/some/root/etc",
 			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root",
 		}})).To(Succeed())
 	})
 	It("does nothing if the context is not found", func() {
-		Expect(selinux.Relabel(context.Background(), s, root)).To(Succeed())
+		Expect(selinux.SystemRelabel(context.Background(), s, root)).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{}}))
 		Expect(buffer.String()).To(ContainSubstring("no context found"))
 	})
@@ -96,43 +96,23 @@ var _ = Describe("Selinux", Label("selinux"), func() {
 			return []byte{}, nil
 		}
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
-		Expect(selinux.Relabel(context.Background(), s, root)).NotTo(Succeed())
+		Expect(selinux.SystemRelabel(context.Background(), s, root)).To(MatchError(ContainSubstring("setfiles failed")))
 	})
 	It("relabels the given paths for the targeted context in a chroot env", func() {
 		Expect(fs.WriteFile(selinux.SelinuxTargetedContextFile, []byte{}, vfs.FilePerm)).To(Succeed())
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
 		Expect(vfs.MkdirAll(fs, "/partition/var", vfs.DirPerm)).To(Succeed())
-		Expect(selinux.ChrootedRelabel(
-			context.Background(), s, root, map[string]string{"/partition/var": "/var"}, "/etc"),
+		Expect(selinux.ChrootedSystemRelabel(
+			context.Background(), s, root, "/etc", "/var"),
 		).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{
-			{"setfiles", "-i", "-F", "/etc/selinux/targeted/contexts/files/file_contexts", "/", "/etc", "/var"},
+			{"setfiles", "-i", "-F", "-e", "/etc", "-e", "/var", "/etc/selinux/targeted/contexts/files/file_contexts", "/"},
 			{"sync"},
-			{"setfiles", "-i", "-F", "-r", "/some/root", "/some/root/etc/selinux/targeted/contexts/files/file_contexts", fmt.Sprintf("%s/etc", root), "/some/root/var"},
 		})).To(Succeed())
 	})
-	It("fails to relabel in a chroot env if chroot mounts fail", func() {
-		Expect(fs.WriteFile(selinux.SelinuxTargetedContextFile, []byte{}, vfs.FilePerm)).To(Succeed())
-		// /partition/var does not exist
-		Expect(selinux.ChrootedRelabel(
-			context.Background(), s, root, map[string]string{"/partition/var": "/var"}),
-		).NotTo(Succeed())
-	})
-	It("fails when bind paths overlap with additional paths", func() {
-		By("failing when paths match exactly")
-		err := selinux.ChrootedRelabel(context.Background(), s, root, map[string]string{"/foo/etc": "/etc"}, "/etc")
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError("failed adding bind mount path '/etc' for relabel: path already exists in or overlaps with existing relabel paths: '[/etc]'"))
-
-		By("failing when paths overlap")
-		err = selinux.ChrootedRelabel(context.Background(), s, root, map[string]string{"/foo/etc": "/etc/elemental"}, "/etc")
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError("failed adding bind mount path '/etc/elemental' for relabel: path already exists in or overlaps with existing relabel paths: '[/etc]'"))
-	})
 	It("does nothing if the context is not found in chroot", func() {
-		Expect(vfs.MkdirAll(fs, "/partition/var", vfs.DirPerm)).To(Succeed())
-		Expect(selinux.ChrootedRelabel(
-			context.Background(), s, root, map[string]string{"/partition/var": "/var"}),
+		Expect(selinux.ChrootedSystemRelabel(
+			context.Background(), s, root),
 		).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{}}))
 		Expect(buffer.String()).To(ContainSubstring("no context found"))

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -147,7 +147,7 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 		}
 	}
 
-	err = selinux.ChrootedRelabel(u.ctx, u.s, trans.Path, nil, parseAdditionalRelabelPaths(d)...)
+	err = selinux.ChrootedSystemRelabel(u.ctx, u.s, trans.Path, parseAdditionalRelabelPaths(d)...)
 	if err != nil {
 		return fmt.Errorf("relabelling snapshot path '%s': %w", trans.Path, err)
 	}


### PR DESCRIPTION
This PR performs system relabel only for the immutable parts of the system.

This change is to prevent changing labels for files which are potentially in use at the time they are relabeled. This is to protect upgrades from runtime race conditions. Persistent volumes should be relabeled on first boot after upgrading and not by elemental3ctl upgrade command.

In addition the PR also renames the SE Linux methods to SystemRelabel and ChrootedSystemRelabel. The reason for that is that those methods are assuming a full system root tree relabel, so they are not supposed to be used to relabel any given path, that's why I added the `System`, if we ever need to relabel a specific path only we can always extend the package API.

I also removed the possibility of adding additional bind mounts for the chrooted call (e.g. to mount in the tree some additional partition or volume) as we are only using this method during the upgrade process and in that process the root-tree already has all the mounts set in place and so we were not using this feature at all. This feature was the responsible of having some additional checks and convoluted logic as part of the chrooted relabel, since this was unused I removed it.