### PR TITLE
Trigger .autorelabel if there were paths excluded

### DIFF
--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -33,6 +33,7 @@ const (
 	SelinuxTargetedContextFile = selinuxTargetedPath + "/contexts/files/file_contexts"
 
 	selinuxTargetedPath = "/etc/selinux/targeted"
+	selinuxAutoRelabel  = "/etc/selinux/.autorelabel"
 	debugLines          = 10
 )
 
@@ -41,6 +42,8 @@ const (
 // This is to prevent runtime changes during the upgrades as RW paths are potentially in use for current
 // processes. For snapshotted RW paths it applies SE Linux labels without force flag as it might include
 // customized content merged with stock OS content.
+// If at least one shared RW path is provided it also sets the .autorelabel file to trigger
+// relabelling at boot and relabel the excluded paths.
 func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, snapshotted []string, shared []string) error {
 	contextFile := filepath.Join(rootDir, SelinuxTargetedContextFile)
 	contextExists, _ := vfs.Exists(s.FS(), contextFile)
@@ -69,6 +72,10 @@ func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, snapshott
 		if len(shared) > 0 {
 			for _, path := range shared {
 				args = append(args, "-e", path)
+			}
+			err = s.FS().WriteFile(filepath.Join(rootDir, selinuxAutoRelabel), []byte{}, vfs.FilePerm)
+			if err != nil {
+				return fmt.Errorf("creating .autorelabel file: %w", err)
 			}
 		}
 		args = append(args, contextFile, rootDir)

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Selinux", Label("selinux"), func() {
 	AfterEach(func() {
 		cleanup()
 	})
-	It("relabels the given path for the targeted context, no shared paths", func() {
+	It("relabels the given path for the targeted context, no shared paths no .autorelabel file", func() {
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
 		Expect(selinux.SystemRelabel(context.Background(), s, root, []string{root + "/etc"}, nil)).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{
@@ -85,14 +85,16 @@ var _ = Describe("Selinux", Label("selinux"), func() {
 			"setfiles", "-i", "-r", "/some/root",
 			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root/etc",
 		}})).To(Succeed())
+		Expect(vfs.Exists(s.FS(), filepath.Join(root, "/etc/selinux/.autorelabel"))).To(BeFalse())
 	})
-	It("relabels the given path for the targeted context, including shared paths", func() {
+	It("relabels the given path for the targeted context, including shared paths sets the .autorelabel file", func() {
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
 		Expect(selinux.SystemRelabel(context.Background(), s, root, nil, []string{root + "/var"})).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{
 			"setfiles", "-i", "-r", "/some/root", "-F", "-e", "/some/root/var",
 			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root",
 		}})).To(Succeed())
+		Expect(vfs.Exists(s.FS(), filepath.Join(root, "/etc/selinux/.autorelabel"))).To(BeTrue())
 	})
 	It("does nothing if the context is not found", func() {
 		Expect(selinux.SystemRelabel(context.Background(), s, root, nil, nil)).To(Succeed())


### PR DESCRIPTION
This PR generates the /etc/selinux/.autorelabel file if there were some paths excluded during the relaballing at upgrade time. Persistent shared paths are excluded to prevent runtime race conditions. With this change after every upgrade the system gets relabelled at boot (feature provided by `selinux-autorelabel` on SUSE systems). Since each snapshot has its own snapshotted /etc the relabelling only happens when the new updated snapshot boots for the first time.