### PR TITLE
docs: fix typo in podman command syntax

### DIFF
--- a/docs/cookbook-first-time-use.md
+++ b/docs/cookbook-first-time-use.md
@@ -276,7 +276,7 @@ Feel free to adjust these values as you see fit, e.g. by adding an SSH key or an
 Let’s customize a RAW disk image:
 
 ```shell
-sudo podman run -it --rm\
+sudo podman run -it --rm \
 --network host \
 -v ${ELEMENTAL_PATH}/single-node:/config:Z \
 -v /run/podman/podman.sock:/var/run/docker.sock \


### PR DESCRIPTION
Add missing space before the backslash in the podman run command to prevent execution failure

Error:

```
sudo podman run -it --rm\
--network host \
-v ${ELEMENTAL_PATH}/single-node:/config:Z \
-v /run/podman/podman.sock:/var/run/docker.sock \
${ELEMENTAL_IMAGE} customize --type raw
Error: unknown flag: --rm--network
See 'podman run --help'
```