### PR TITLE
SE Linux: distinguish snapshotted vs shared RW paths

### DIFF
--- a/pkg/installer/media.go
+++ b/pkg/installer/media.go
@@ -567,7 +567,8 @@ func (i Media) prepareOSRoot(sourceOS *deployment.ImageSource, rootDir string) e
 		return fmt.Errorf("OS source write failed: %w", err)
 	}
 
-	err = selinux.SystemRelabel(i.ctx, i.s, rootDir)
+	// We relabel the whole system, as this will all be squashed in single image
+	err = selinux.SystemRelabel(i.ctx, i.s, rootDir, nil, nil)
 	if err != nil {
 		i.s.Logger().Warn("Error selinux relabelling: %s", err.Error())
 	}

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -20,7 +20,9 @@ package selinux
 import (
 	"container/ring"
 	"context"
+	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/suse/elemental/v3/pkg/chroot"
 	"github.com/suse/elemental/v3/pkg/sys"
@@ -35,16 +37,18 @@ const (
 )
 
 // SystemRelabel applies the SE Linux labels based on the targeted policy found within the given
-// root path. It force applies the labels under the given root except for the given RW paths
+// root path. It force applies the labels under the given root except for the given shared RW paths.
 // This is to prevent runtime changes during the upgrades as RW paths are potentially in use for current
-// processes.
-func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, rwPaths ...string) error {
+// processes. For snapshotted RW paths it applies SE Linux labels without force flag as it might include
+// customized content merged with stock OS content.
+func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, snapshotted []string, shared []string) error {
 	contextFile := filepath.Join(rootDir, SelinuxTargetedContextFile)
 	contextExists, _ := vfs.Exists(s.FS(), contextFile)
 
 	if contextExists {
 		var err error
-		args := []string{"-i"}
+
+		baseArgs := []string{"-i"}
 
 		// We only keep last 10 lines of the stdout and stderr for debugging purposes
 		stdOut := ring.New(debugLines)
@@ -53,20 +57,35 @@ func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, rwPaths .
 		if rootDir == "/" || rootDir == "" {
 			rootDir = "/"
 		} else {
-			args = append(args, "-r", rootDir)
+			baseArgs = append(baseArgs, "-r", rootDir)
 		}
 
-		args = append(args, "-F")
-		if len(rwPaths) > 0 {
-			for _, rwp := range rwPaths {
-				args = append(args, "-e", rwp)
+		args := []string{"-F"}
+		if len(snapshotted) > 0 {
+			for _, path := range snapshotted {
+				args = append(args, "-e", path)
+			}
+		}
+		if len(shared) > 0 {
+			for _, path := range shared {
+				args = append(args, "-e", path)
 			}
 		}
 		args = append(args, contextFile, rootDir)
 
 		s.Logger().Info("Applying SE Linux labels to the read-only root tree, forced relabelling")
-		err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", args...)
+		err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", slices.Concat(baseArgs, args)...)
 		logOutput(s, stdOut, stdErr)
+
+		if len(snapshotted) > 0 {
+			s.Logger().Info("Applying SE Linux labels to snapshotted RW volumes")
+			for _, path := range snapshotted {
+				stdOut = ring.New(debugLines)
+				stdErr = ring.New(debugLines)
+				err = s.Runner().RunContextParseOutput(ctx, stdHander(stdOut), stdHander(stdErr), "setfiles", append(baseArgs, contextFile, path)...)
+				logOutput(s, stdOut, stdErr)
+			}
+		}
 
 		return err
 	}
@@ -77,9 +96,13 @@ func SystemRelabel(ctx context.Context, s *sys.System, rootDir string, rwPaths .
 
 // ChrootedSystemRelabel applies the SE Linux labels based on the targeted policy found within the given
 // root path. Runs the same logic as RelabelSystem method but running inside a chroot environment.
-func ChrootedSystemRelabel(ctx context.Context, s *sys.System, rootDir string, rwPaths ...string) error {
-	callback := func() error { return SystemRelabel(ctx, s, "/", rwPaths...) }
-	return chroot.ChrootedCallback(s, rootDir, nil, callback, chroot.WithoutDefaultBinds())
+func ChrootedSystemRelabel(ctx context.Context, s *sys.System, rootDir string, snapshotted []string, shared []string) error {
+	callback := func() error { return SystemRelabel(ctx, s, "/", snapshotted, shared) }
+	err := chroot.ChrootedCallback(s, rootDir, nil, callback, chroot.WithoutDefaultBinds())
+	if err != nil {
+		return fmt.Errorf("chrooted system relabel: %w", err)
+	}
+	return nil
 }
 
 func stdHander(r *ring.Ring) func(string) {

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -75,16 +75,27 @@ var _ = Describe("Selinux", Label("selinux"), func() {
 	AfterEach(func() {
 		cleanup()
 	})
-	It("relabels the given path for the targeted context, including rw paths", func() {
+	It("relabels the given path for the targeted context, no shared paths", func() {
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
-		Expect(selinux.SystemRelabel(context.Background(), s, root, root+"/etc")).To(Succeed())
+		Expect(selinux.SystemRelabel(context.Background(), s, root, []string{root + "/etc"}, nil)).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{
 			"setfiles", "-i", "-r", "/some/root", "-F", "-e", "/some/root/etc",
+			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root",
+		}, {
+			"setfiles", "-i", "-r", "/some/root",
+			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root/etc",
+		}})).To(Succeed())
+	})
+	It("relabels the given path for the targeted context, including shared paths", func() {
+		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
+		Expect(selinux.SystemRelabel(context.Background(), s, root, nil, []string{root + "/var"})).To(Succeed())
+		Expect(runner.CmdsMatch([][]string{{
+			"setfiles", "-i", "-r", "/some/root", "-F", "-e", "/some/root/var",
 			"/some/root/etc/selinux/targeted/contexts/files/file_contexts", "/some/root",
 		}})).To(Succeed())
 	})
 	It("does nothing if the context is not found", func() {
-		Expect(selinux.SystemRelabel(context.Background(), s, root)).To(Succeed())
+		Expect(selinux.SystemRelabel(context.Background(), s, root, nil, nil)).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{}}))
 		Expect(buffer.String()).To(ContainSubstring("no context found"))
 	})
@@ -96,23 +107,25 @@ var _ = Describe("Selinux", Label("selinux"), func() {
 			return []byte{}, nil
 		}
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
-		Expect(selinux.SystemRelabel(context.Background(), s, root)).To(MatchError(ContainSubstring("setfiles failed")))
+		Expect(selinux.SystemRelabel(context.Background(), s, root, []string{}, []string{})).
+			To(MatchError(ContainSubstring("setfiles failed")))
 	})
 	It("relabels the given paths for the targeted context in a chroot env", func() {
 		Expect(fs.WriteFile(selinux.SelinuxTargetedContextFile, []byte{}, vfs.FilePerm)).To(Succeed())
 		Expect(fs.WriteFile(contextFile, []byte{}, vfs.FilePerm)).To(Succeed())
 		Expect(vfs.MkdirAll(fs, "/partition/var", vfs.DirPerm)).To(Succeed())
 		Expect(selinux.ChrootedSystemRelabel(
-			context.Background(), s, root, "/etc", "/var"),
+			context.Background(), s, root, []string{"/etc"}, []string{"/var"}),
 		).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{
 			{"setfiles", "-i", "-F", "-e", "/etc", "-e", "/var", "/etc/selinux/targeted/contexts/files/file_contexts", "/"},
+			{"setfiles", "-i", "/etc/selinux/targeted/contexts/files/file_contexts", "/etc"},
 			{"sync"},
 		})).To(Succeed())
 	})
 	It("does nothing if the context is not found in chroot", func() {
 		Expect(selinux.ChrootedSystemRelabel(
-			context.Background(), s, root),
+			context.Background(), s, root, nil, nil),
 		).To(Succeed())
 		Expect(runner.CmdsMatch([][]string{{}}))
 		Expect(buffer.String()).To(ContainSubstring("no context found"))

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -147,7 +147,8 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 		}
 	}
 
-	err = selinux.ChrootedSystemRelabel(u.ctx, u.s, trans.Path, parseAdditionalRelabelPaths(d)...)
+	shared, snapshotted := parsePersistentPaths(d)
+	err = selinux.ChrootedSystemRelabel(u.ctx, u.s, trans.Path, snapshotted, shared)
 	if err != nil {
 		return fmt.Errorf("relabelling snapshot path '%s': %w", trans.Path, err)
 	}
@@ -253,9 +254,7 @@ func logOutput(s *sys.System, stdOut, stdErr string) {
 	s.Logger().Debug("Install config hook output:\n%s", output)
 }
 
-func parseAdditionalRelabelPaths(d *deployment.Deployment) []string {
-	var paths []string
-
+func parsePersistentPaths(d *deployment.Deployment) (shared, snapshotted []string) {
 	isRO := func(opts []string) bool {
 		return slices.ContainsFunc(opts, func(s string) bool {
 			return s == "ro" || strings.HasPrefix(s, "ro=")
@@ -264,13 +263,17 @@ func parseAdditionalRelabelPaths(d *deployment.Deployment) []string {
 
 	for _, part := range d.GetSELinuxSupportedPartitions() {
 		if part.MountPoint != "" && !isRO(part.MountOpts) {
-			paths = append(paths, part.MountPoint)
+			shared = append(shared, part.MountPoint)
 		}
 
 		for _, rwVol := range part.RWVolumes {
-			paths = append(paths, rwVol.Path)
+			if !rwVol.Snapshotted {
+				shared = append(shared, rwVol.Path)
+			} else {
+				snapshotted = append(snapshotted, rwVol.Path)
+			}
 		}
 	}
 
-	return paths
+	return shared, snapshotted
 }


### PR DESCRIPTION
When relabelling a new OS snapshot this commits sets a force relabelling for all immutable parts and a non forced relabelling for RW and snapshotted paths (e.g. /etc). These are also a new snapshot hence there is no risk of interfering with the running system. Shared persistent volumes (e.g. /var) are excluded from this relabelling as they could be already in use by some other process in the running system.