### PR TITLE
Do not set sector size for systemd-repart on reset

### DIFF
--- a/pkg/repart/disk_repart.go
+++ b/pkg/repart/disk_repart.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/suse/elemental/v3/pkg/block/lsblk"
 	"github.com/suse/elemental/v3/pkg/deployment"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
@@ -172,21 +171,12 @@ func notifyKernel(s *sys.System, device string) {
 // repartDisk generates the systemd-repart configuration according to the given disk and runs systemd-repart with the given
 // empty flag.
 func repartDisk(s *sys.System, d *deployment.Disk, empty string) (err error) {
-	lsblkWrapper := lsblk.NewLsDevice(s)
-	sSize, err := lsblkWrapper.GetDeviceSectorSize(d.Device)
-	if err != nil {
-		return err
-	}
-
 	parts := make([]Partition, len(d.Partitions))
 	for i, part := range d.Partitions {
 		parts[i] = Partition{Partition: part}
 	}
 
-	flags := []string{
-		fmt.Sprintf("--empty=%s", empty), fmt.Sprintf("--sector-size=%d", sSize),
-	}
-	return runSystemdRepart(s, d.Device, parts, flags...)
+	return runSystemdRepart(s, d.Device, parts, fmt.Sprintf("--empty=%s", empty))
 }
 
 // runSystemdRepart runs systemd-repart for the given partitions and target device. It appends to the generated command the

--- a/pkg/repart/disk_repart_test.go
+++ b/pkg/repart/disk_repart_test.go
@@ -43,15 +43,6 @@ const systemdRepartJson = `[
 	{"uuid" : "ddb334a8-48a2-c4de-ddb3-849eb2443e92", "file" : "/tmp/elemental-repart.d/1-system.conf"}
 ]`
 
-const sectorSizeJson = `{
-   "blockdevices": [
-      {
-         "name": "device",
-         "phy-sec": 512
-      }
-   ]
-}`
-
 var _ = Describe("Systemd-repart tests", Label("systemd-repart"), func() {
 	var runner *sysmock.Runner
 	var fs vfs.FS
@@ -74,9 +65,6 @@ var _ = Describe("Systemd-repart tests", Label("systemd-repart"), func() {
 		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
 			if cmd == "systemd-repart" {
 				return []byte(systemdRepartJson), runner.ReturnError
-			}
-			if cmd == "lsblk" {
-				return []byte(sectorSizeJson), runner.ReturnError
 			}
 			return []byte{}, runner.ReturnError
 		}
@@ -183,7 +171,7 @@ var _ = Describe("Systemd-repart tests", Label("systemd-repart"), func() {
 		Expect(d.Disks[0].Partitions[1].UUID).To(Equal("ddb334a8-48a2-c4de-ddb3-849eb2443e92"))
 		Expect(runner.MatchMilestones([][]string{{
 			"systemd-repart", "--json=pretty", "--definitions=/tmp/elemental-repart.d",
-			"--dry-run=no", "--empty=force", "--sector-size=512", "/dev/device",
+			"--dry-run=no", "--empty=force", "/dev/device",
 		}}))
 	})
 
@@ -205,15 +193,12 @@ var _ = Describe("Systemd-repart tests", Label("systemd-repart"), func() {
 		Expect(repart.ReconcileDevicePartitions(s, d.Disks[0])).To(Succeed())
 		Expect(runner.MatchMilestones([][]string{{
 			"systemd-repart", "--json=pretty", "--definitions=/tmp/elemental-repart.d",
-			"--dry-run=no", "--empty=allow", "--sector-size=512", "/dev/device",
+			"--dry-run=no", "--empty=allow", "/dev/device",
 		}}))
 	})
 
 	It("fails if systemd-repart does not return a valid json", func() {
 		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
-			if cmd == "lsblk" {
-				return []byte(sectorSizeJson), runner.ReturnError
-			}
 			return []byte{}, runner.ReturnError
 		}
 		d := deployment.DefaultDeployment()


### PR DESCRIPTION
This commit removes the sector-size flag systemd-repart calls on install and reset processes. The former logic used to set the value at the physical sector size of the target device, however this could eventually mismatch with the sector size used at RAW image creation.

This change prevents mismatches at reset time. At install time we just relay on systemd-repart autodetecting the appropriate value.

Fixes #456