### PR TITLE
Use uint64 instead of casting to uint

### DIFF
--- a/internal/image/install/install.go
+++ b/internal/image/install/install.go
@@ -36,9 +36,9 @@ func (d DiskSize) IsValid() bool {
 }
 
 // returns the size in MiB
-func (d DiskSize) ToMiB() (uint, error) {
+func (d DiskSize) ToMiB() (uint64, error) {
 	size := strings.TrimSpace(string(d))
-	dimension := uint(1)
+	dimension := uint64(1)
 	switch unicode.ToUpper(rune(size[len(size)-1])) {
 	case 'K':
 		dimension = units.KiB
@@ -55,7 +55,7 @@ func (d DiskSize) ToMiB() (uint, error) {
 		return 0, err
 	}
 
-	return uint(value) * dimension / units.MiB, nil
+	return value * dimension / units.MiB, nil
 }
 
 type Installation struct {

--- a/internal/image/install/install_test.go
+++ b/internal/image/install/install_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/docker/go-units"
+
 	"github.com/suse/elemental/v3/internal/image/install"
 )
 
@@ -42,8 +43,8 @@ var _ = Describe("DiskSize", func() {
 	})
 
 	It("ToMiB() tests", func() {
-		Expect(install.DiskSize("10G").ToMiB()).To(Equal(uint(10 * units.GiB / units.MiB)))
+		Expect(install.DiskSize("10G").ToMiB()).To(Equal(uint64(10 * units.GiB / units.MiB)))
 
-		Expect(install.DiskSize("8M").ToMiB()).To(Equal(uint(8)))
+		Expect(install.DiskSize("8M").ToMiB()).To(Equal(uint64(8)))
 	})
 })

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -46,7 +46,7 @@ const (
 	contextKeySkipDiskDeviceExists contextKey = "skip_disk_device_exists"
 )
 
-type MiB uint
+type MiB uint64
 
 const (
 	EfiLabel     = "EFI"


### PR DESCRIPTION
This fixes a code-scanning warning [1] for converting between integer
types without checking for the upper bound.

[1] https://github.com/SUSE/elemental/security/code-scanning/3

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
