### PR TITLE
Dependabot security fixes for release-3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
     labels:
       - dependencies
 
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    open-pull-requests-limit: 0 # https://stackoverflow.com/a/68254421/395670
+    target-branch: release-3.0
+    labels:
+      - dependencies
+      - security
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
According to https://stackoverflow.com/a/68254421/395670 setting `open-pull-requests-limit` to 0 in dependabot.yml configures it to open only security fixes.