### PR TITLE
Fixes make clean on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 .PHONY: clean
 clean:
 	@rm -rfv $(BUILD_DIR)
-	@find . -type f -executable -name '*.test' -exec rm -f {} \+
+	@find . -type f -name '*.test' -exec test -x {} \; -exec rm -f {} \+
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
This patch fixes a very simple issue when building the `elemental3` and `elemental3ctl` binaries on macOS, where calling `make clean` results in an error:

```
% make clean
find: -executable: unknown primary or operator
make: *** [clean] Error 1
```

The problem is that the `Makefile` expects to be using a Linux-based `find` utility, where the `-executable` switch works just fine, but this is not available on macOS. Here's the original line:

```
@find . -type f -executable -name '*.test' -exec rm -f {} \+
```

A simple fix here is to introduce a new check as part of the `find` call, where it actually uses `test` to see if each file it encounters is executable, and if so, *then* pass it over to `rm -f`. This bypasses the OS-specific parameter entirely.

Testing of this patch, firstly on Linux:

```
% grep -i pretty /etc/os-release
PRETTY_NAME="openSUSE Tumbleweed"

% uname -r
7.0.11-1-default

% make
go build -ldflags '-w -s -X "github.com/suse/elemental/v3/internal/cli/cmd.version=v3.1.0-alpha.20260528" -X "github.com/suse/elemental/v3/internal/cli/cmd.gitCommit=be4a555ace67e1e30967b10f0331d902bc6fd496"' -o build/elemental3 ./cmd/elemental
go build -ldflags '-w -s -X "github.com/suse/elemental/v3/internal/cli/cmd.version=v3.1.0-alpha.20260528" -X "github.com/suse/elemental/v3/internal/cli/cmd.gitCommit=be4a555ace67e1e30967b10f0331d902bc6fd496"' -o build/elemental3ctl ./cmd/elemental3ctl

% make clean
removed './build/elemental3'
removed './build/elemental3ctl'
removed directory './build'
```

Then on macOS:

```
% uname -v
Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:09 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6020

% make
go build -ldflags '-w -s -X "github.com/suse/elemental/v3/internal/cli/cmd.version=v0.0.1" -X "github.com/suse/elemental/v3/internal/cli/cmd.gitCommit=17228df94e58c6a7f13daf10deb5146b98aba7a0"' -o build/elemental3 ./cmd/elemental
go build -ldflags '-w -s -X "github.com/suse/elemental/v3/internal/cli/cmd.version=v0.0.1" -X "github.com/suse/elemental/v3/internal/cli/cmd.gitCommit=17228df94e58c6a7f13daf10deb5146b98aba7a0"' -o build/elemental3ctl ./cmd/elemental3ctl

% make clean
./build/elemental3ctl
./build/elemental3
./build
```

Fixes: #493