### PR TITLE
Fix openQA jobgroups

### DIFF
--- a/tests/cfg/openqa_elemental_16.0_jobgroup.yaml
+++ b/tests/cfg/openqa_elemental_16.0_jobgroup.yaml
@@ -18,6 +18,7 @@
 
 .common_settings: &common_settings
   CONSOLE: ttyS0
+  CONTAINER_RUNTIMES: podman
   K8S: rke2
   KERNEL_CMD_LINE: 'console=%CONSOLE% testframework=openqa net.ifnames=0'
   TEST_PASSWORD: Elemental@R00t
@@ -31,7 +32,6 @@
 
 .common_microos_boot_settings: &common_microos_boot_settings
   BOOTFROM: disk
-  CONTAINER_RUNTIMES: podman
   DESKTOP: textmode
   EXCLUDE_MODULES: suseconnect_scc
   HDD_1: 'SL-Micro.%ARCH%-6.2-Default-Updated.qcow2'

--- a/tests/cfg/openqa_elemental_main_jobgroup.yaml
+++ b/tests/cfg/openqa_elemental_main_jobgroup.yaml
@@ -18,6 +18,7 @@
 
 .common_settings: &common_settings
   CONSOLE: ttyS0
+  CONTAINER_RUNTIMES: podman
   K8S: rke2
   KERNEL_CMD_LINE: 'console=%CONSOLE% testframework=openqa net.ifnames=0'
   TEST_PASSWORD: Elemental@R00t
@@ -31,7 +32,6 @@
 
 .common_microos_boot_settings: &common_microos_boot_settings
   BOOTFROM: disk
-  CONTAINER_RUNTIMES: podman
   DESKTOP: textmode
   EXCLUDE_MODULES: suseconnect_scc
   HDD_1: 'SL-Micro.%ARCH%-6.2-Default-Updated.qcow2'


### PR DESCRIPTION
`CONTAINER_RUNTIMES` should be defined in the common section.

There's also a fix [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25949) to add a default value if this variable is not set.