### PR TITLE
Stackable initrd

### DIFF
--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -25,9 +25,33 @@ import (
 )
 
 type Bootloader interface {
-	Install(rootPath, espDir, espLabel, entryID, kernelCmdline, recKernelCmdline string) error
-	InstallLive(rootPath, espDir, kernelCmdline string) error
+	Install(i InstallCtx) error
+	InstallLive(i InstallCtx) error
 	Prune(rootPath, espDir string, keepEntryIDs []int) error
+}
+
+// InstallCtx defines the parameters requierd by the bootloader to perform an installation
+type InstallCtx struct {
+	// RootDir is the path for the root tree of the system to install the bootloader for. This path
+	// is expected to be a full OS including the kernel, initrd and bootloader binaries at default
+	// known locations.
+	RootDir string
+
+	// Target is the path where the bootloader binaries and configuration should be installed. This is
+	// typically the mountpoint of the ESP partition.
+	Target string
+
+	// ESPLabel is the filesystem label of the ESP partition.
+	ESPLabel string
+
+	// EntryID this is the ID if the current bootloader entry to be installed.
+	EntryID string
+
+	// KernelCmdline is the full kernel command line we want to set for this specific entry.
+	KernelCmdline string
+
+	// RecKernelCmdline is the full kernel command line for the recovery entry, if any.
+	RecKernelCmdline string
 }
 
 const (
@@ -43,12 +67,12 @@ func NewNone(s *sys.System) *None {
 	return &None{s}
 }
 
-func (n *None) Install(_, _, _, _, _, _ string) error {
+func (n *None) Install(_ InstallCtx) error {
 	n.s.Logger().Info("Skipping bootloader installation")
 	return nil
 }
 
-func (n *None) InstallLive(_, _, _ string) error {
+func (n *None) InstallLive(_ InstallCtx) error {
 	n.s.Logger().Info("Skipping bootloader installation")
 	return nil
 }

--- a/pkg/bootloader/bootloader.go
+++ b/pkg/bootloader/bootloader.go
@@ -52,6 +52,10 @@ type InstallCtx struct {
 
 	// RecKernelCmdline is the full kernel command line for the recovery entry, if any.
 	RecKernelCmdline string
+
+	// InitrdExtensions is the list of CPIO files to stack into the stock initrd. These CPIO files are mostly
+	// used to inject additional setup into the stock initrd.
+	InitrdExtensions []string
 }
 
 const (

--- a/pkg/bootloader/grub.go
+++ b/pkg/bootloader/grub.go
@@ -137,7 +137,7 @@ func (g *Grub) Install(i InstallCtx) error {
 		return fmt.Errorf("installing grub config: %w", err)
 	}
 
-	entry, err := g.installKernelInitrd(i.RootDir, i.Target, "")
+	entry, err := g.installKernelInitrd(i.RootDir, i.Target, "", i.InitrdExtensions...)
 	if err != nil {
 		return fmt.Errorf("installing kernel+initrd: %w", err)
 	}
@@ -523,7 +523,8 @@ func (g *Grub) installKernelInitrd(rootPath, espDir, subfolder string, extension
 		return entry, fmt.Errorf("initrd not found")
 	}
 
-	err = vfs.CopyFile(g.s.FS(), initrdPath, targetDir)
+	g.s.Logger().Debug("Concatenating extensions %v and initrd %q", extensions, initrdPath)
+	err = vfs.ConcatFiles(g.s.FS(), append(extensions, initrdPath), filepath.Join(targetDir, Initrd))
 	if err != nil {
 		return entry, fmt.Errorf("copying initrd '%s': %w", initrdPath, err)
 	}

--- a/pkg/bootloader/grub.go
+++ b/pkg/bootloader/grub.go
@@ -38,6 +38,8 @@ import (
 
 const grubImg = "grub.efi"
 
+var _ Bootloader = (*Grub)(nil)
+
 type Grub struct {
 	s *sys.System
 }
@@ -82,40 +84,40 @@ var grubLiveEFICfg []byte
 var grubLiveCfg []byte
 
 // InstallLive installs the live bootloader to the specified target.
-func (g *Grub) InstallLive(rootPath, target, kernelCmdLine string) error {
+func (g *Grub) InstallLive(i InstallCtx) error {
 	g.s.Logger().Info("Preparing GRUB bootloader for live media")
 
-	err := g.installGrub(rootPath, filepath.Join(target, liveBootPath))
+	err := g.installGrub(i.RootDir, filepath.Join(i.Target, liveBootPath))
 	if err != nil {
 		return fmt.Errorf("installing grub config: %w", err)
 	}
 
-	entry, err := g.installKernelInitrd(rootPath, target, liveBootPath)
+	entry, err := g.installKernelInitrd(i.RootDir, i.Target, liveBootPath)
 	if err != nil {
 		return fmt.Errorf("installing kernel+initrd: %w", err)
 	}
-	entry.CmdLine = kernelCmdLine
+	entry.CmdLine = i.KernelCmdline
 
-	err = g.writeGrubConfig(filepath.Join(target, liveBootPath, "grub2"), grubLiveCfg, entry)
+	err = g.writeGrubConfig(filepath.Join(i.Target, liveBootPath, "grub2"), grubLiveCfg, entry)
 	if err != nil {
 		return fmt.Errorf("failed writing grub config file: %w", err)
 	}
 
 	// update cmdline variable in /boot/grubenv
-	grubEnvPath := filepath.Join(target, liveBootPath, grubEnvFile)
-	_, err = g.s.Runner().Run("grub2-editenv", grubEnvPath, "set", fmt.Sprintf("cmdline=%s", kernelCmdLine))
+	grubEnvPath := filepath.Join(i.Target, liveBootPath, grubEnvFile)
+	_, err = g.s.Runner().Run("grub2-editenv", grubEnvPath, "set", fmt.Sprintf("cmdline=%s", i.KernelCmdline))
 	if err != nil {
 		return fmt.Errorf("failed setting kernel command line for grub: %w", err)
 	}
 
-	randomID, err := g.generateIDFile(filepath.Join(target, liveBootPath))
+	randomID, err := g.generateIDFile(filepath.Join(i.Target, liveBootPath))
 	if err != nil {
 		return fmt.Errorf("failed creating identifier file for the bootloader: %w", err)
 	}
 
-	efiEntryDir := filepath.Join(target, "EFI", "BOOT")
+	efiEntryDir := filepath.Join(i.Target, "EFI", "BOOT")
 	data := map[string]string{"IDFile": filepath.Join(liveBootPath, randomID)}
-	err = g.installEFIEntry(rootPath, efiEntryDir, grubLiveEFICfg, data)
+	err = g.installEFIEntry(i.RootDir, efiEntryDir, grubLiveEFICfg, data)
 	if err != nil {
 		return fmt.Errorf("installing elemental EFI apps: %w", err)
 	}
@@ -124,29 +126,29 @@ func (g *Grub) InstallLive(rootPath, target, kernelCmdLine string) error {
 }
 
 // Install installs the bootloader to the specified root.
-func (g *Grub) Install(rootPath, espDir, espLabel, entryID, kernelCmdline, recKernelCmdline string) error {
-	err := g.installElementalEFI(rootPath, espDir, espLabel)
+func (g *Grub) Install(i InstallCtx) error {
+	err := g.installElementalEFI(i.RootDir, i.Target, i.ESPLabel)
 	if err != nil {
 		return fmt.Errorf("installing elemental EFI apps: %w", err)
 	}
 
-	err = g.installGrub(rootPath, espDir)
+	err = g.installGrub(i.RootDir, i.Target)
 	if err != nil {
 		return fmt.Errorf("installing grub config: %w", err)
 	}
 
-	entry, err := g.installKernelInitrd(rootPath, espDir, "")
+	entry, err := g.installKernelInitrd(i.RootDir, i.Target, "")
 	if err != nil {
 		return fmt.Errorf("installing kernel+initrd: %w", err)
 	}
 
 	displayName := entry.DisplayName
-	entry.ID = entryID
-	entry.CmdLine = kernelCmdline
+	entry.ID = i.EntryID
+	entry.CmdLine = i.KernelCmdline
 	entries := []*grubBootEntry{&entry}
 
 	// append default entry
-	entry.DisplayName = fmt.Sprintf("%s (%s)", displayName, entryID)
+	entry.DisplayName = fmt.Sprintf("%s (%s)", displayName, i.EntryID)
 	defaultEntry := grubBootEntry{
 		Linux:       entry.Linux,
 		Initrd:      entry.Initrd,
@@ -156,18 +158,18 @@ func (g *Grub) Install(rootPath, espDir, espLabel, entryID, kernelCmdline, recKe
 	}
 	entries = append(entries, &defaultEntry)
 
-	if recKernelCmdline != "" {
+	if i.RecKernelCmdline != "" {
 		recoveryEntry := grubBootEntry{
 			Linux:       entry.Linux,
 			Initrd:      entry.Initrd,
 			DisplayName: fmt.Sprintf("%s (%s)", displayName, RecoveryBootID),
-			CmdLine:     recKernelCmdline,
+			CmdLine:     i.RecKernelCmdline,
 			ID:          RecoveryBootID,
 		}
 		entries = append(entries, &recoveryEntry)
 	}
 
-	err = g.updateBootEntries(espDir, entries...)
+	err = g.updateBootEntries(i.Target, entries...)
 	if err != nil {
 		return fmt.Errorf("updating boot entries: %w", err)
 	}
@@ -480,7 +482,7 @@ func (g *Grub) readIDAndName(rootPath string) (osID string, displayName string, 
 // for the generated grubBootEntries.
 //
 // Returns a grubBootEntry list with two items, one defined as a default entry and another one identified with the provided ID.
-func (g *Grub) installKernelInitrd(rootPath, espDir, subfolder string) (grubBootEntry, error) {
+func (g *Grub) installKernelInitrd(rootPath, espDir, subfolder string, extensions ...string) (grubBootEntry, error) {
 	g.s.Logger().Info("Installing kernel/initrd")
 	entry := grubBootEntry{}
 

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 	var syscall *sysmock.Syscall
 	var mounter *sysmock.Mounter
 	var i bootloader.InstallCtx
+	var extensionBytes []byte
 	BeforeEach(func() {
 		var err error
 		tfs, cleanup, err = sysmock.TestFS(map[string]any{
@@ -49,6 +50,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 			"/proc/empty":    []byte{},
 			"/sys/empty":     []byte{},
 		})
+		extensionBytes = []byte("this is an extension")
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -108,14 +110,18 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/vmlinuz", []byte("6.14.4-1-default vmlinux"), vfs.FilePerm)).To(Succeed())
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/.vmlinuz.hmac", []byte("6.14.4-1-default .vmlinux.hmac"), vfs.FilePerm)).To(Succeed())
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/initrd", []byte("6.14.4-1-default initrd"), vfs.FilePerm)).To(Succeed())
+		// Setup an initrd extension
+		Expect(vfs.MkdirAll(tfs, "/tmp/extensions", vfs.DirPerm)).To(Succeed())
+		Expect(tfs.WriteFile("/tmp/extensions/initrdExt", extensionBytes, vfs.FilePerm)).To(Succeed())
 
 		// Define the bootloader install parameters
 		i = bootloader.InstallCtx{
-			RootDir:       "/target/dir",
-			Target:        "/target/dir/boot",
-			ESPLabel:      "EFI",
-			EntryID:       "1",
-			KernelCmdline: "kernel-cmdline",
+			RootDir:          "/target/dir",
+			Target:           "/target/dir/boot",
+			ESPLabel:         "EFI",
+			EntryID:          "1",
+			KernelCmdline:    "kernel-cmdline",
+			InitrdExtensions: []string{"/tmp/extensions/initrdExt"},
 		}
 	})
 	AfterEach(func() {
@@ -136,6 +142,10 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(vfs.Exists(tfs, "/target/dir/boot/opensuse-tumbleweed/6.14.4-1-default/vmlinuz")).To(BeTrue())
 		Expect(vfs.Exists(tfs, "/target/dir/boot/opensuse-tumbleweed/6.14.4-1-default/.vmlinuz.hmac")).To(BeTrue())
 		Expect(vfs.Exists(tfs, "/target/dir/boot/opensuse-tumbleweed/6.14.4-1-default/initrd")).To(BeTrue())
+		// Initrd extension is pre-appended
+		data, err := tfs.ReadFile("/target/dir/boot/opensuse-tumbleweed/6.14.4-1-default/initrd")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data[:len(extensionBytes)]).To(Equal(extensionBytes))
 
 		// Grub env and loader entries files exist, no recovery entry
 		Expect(vfs.Exists(tfs, "/target/dir/boot/grubenv")).To(BeTrue())

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 	var runner *sysmock.Runner
 	var syscall *sysmock.Syscall
 	var mounter *sysmock.Mounter
+	var i bootloader.InstallCtx
 	BeforeEach(func() {
 		var err error
 		tfs, cleanup, err = sysmock.TestFS(map[string]any{
@@ -107,6 +108,15 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/vmlinuz", []byte("6.14.4-1-default vmlinux"), vfs.FilePerm)).To(Succeed())
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/.vmlinuz.hmac", []byte("6.14.4-1-default .vmlinux.hmac"), vfs.FilePerm)).To(Succeed())
 		Expect(tfs.WriteFile("/target/dir/usr/lib/modules/6.14.4-1-default/initrd", []byte("6.14.4-1-default initrd"), vfs.FilePerm)).To(Succeed())
+
+		// Define the bootloader install parameters
+		i = bootloader.InstallCtx{
+			RootDir:       "/target/dir",
+			Target:        "/target/dir/boot",
+			ESPLabel:      "EFI",
+			EntryID:       "1",
+			KernelCmdline: "kernel-cmdline",
+		}
 	})
 	AfterEach(func() {
 		cleanup()
@@ -114,7 +124,7 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 
 	It("Copies EFI applications to ESP", func() {
 		// without providing a recovery kernel cmdline the recovery entry is not created
-		err := grub.Install("/target/dir", "/target/dir/boot", "EFI", "1", "kernel cmdline", "")
+		err := grub.Install(i)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Shim, MokManager and grub.efi should exist.
@@ -133,7 +143,8 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(vfs.Exists(tfs, "/target/dir/boot/loader/entries/recovery")).To(BeFalse())
 	})
 	It("Installs grub for LiveOS image", func() {
-		err := grub.InstallLive("/target/dir", "/iso/dir", "kernel cmdline")
+		i.Target = "/iso/dir"
+		err := grub.InstallLive(i)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Shim, MokManager and grub.efi should exist.
@@ -155,15 +166,20 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		err := tfs.Remove("/target/dir/usr/lib/modules/6.14.4-1-default/initrd")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = grub.Install("/target/dir", "/target/dir/boot", "EFI", "1", "kernel cmdline", "")
+		err = grub.Install(i)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("installing kernel+initrd: initrd not found"))
 	})
 	It("Leaves old snapshots and overwrites 'active' entry", func() {
-		err := grub.Install("/target/dir", "/target/dir/boot", "EFI", "1", "snapshot1", "recovery cmdline")
+		i.EntryID = "1"
+		i.KernelCmdline = "snapshot1"
+		i.RecKernelCmdline = "recovery cmdline"
+		err := grub.Install(i)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = grub.Install("/target/dir", "/target/dir/boot", "EFI", "2", "snapshot2", "recovery cmdline")
+		i.EntryID = "2"
+		i.KernelCmdline = "snapshot2"
+		err = grub.Install(i)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Entries 1, 2 and 'active' should exist
@@ -198,10 +214,16 @@ var _ = Describe("Grub tests", Label("bootloader", "grub"), func() {
 		Expect(tfs.WriteFile("/target/dir/boot/opensuse-tumbleweed/6.6.99-1-default/.vmlinuz.hmac", []byte("6.6.99-1-default vmlinux"), vfs.FilePerm)).To(Succeed())
 		Expect(tfs.WriteFile("/target/dir/boot/opensuse-tumbleweed/6.6.99-1-default/initrd", []byte("6.6.99-1-default vmlinux"), vfs.FilePerm)).To(Succeed())
 
-		err := grub.Install("/target/dir", "/target/dir/boot", "EFI", "1", "snapshot1", "recoverycmd")
+		i.EntryID = "1"
+		i.KernelCmdline = "snapshot1"
+		i.RecKernelCmdline = "recoverycmd"
+		err := grub.Install(i)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = grub.Install("/target/dir", "/target/dir/boot", "EFI", "2", "snapshot2", "recoverycmd")
+		i.EntryID = "2"
+		i.KernelCmdline = "snapshot2"
+		i.RecKernelCmdline = "recoverycmd"
+		err = grub.Install(i)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Entries 1, 2, 'active' and 'recovery' should exist

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -230,6 +230,10 @@ type Disk struct {
 type BootConfig struct {
 	Bootloader    string `yaml:"name"`
 	KernelCmdline string `yaml:"kernelCmdline"`
+
+	// InitrdExtensions represents a list of CPIO files which are added in the
+	// bootloader initrd call in addition to the stock initrd included within the OS
+	InitrdExtensions []string `yaml:"initrdExtensions,omitempty"`
 }
 
 type FirmwareConfig struct {
@@ -926,6 +930,11 @@ func (d *Deployment) WriteDeploymentFile(s *sys.System, root string) error {
 	dep.OverlayTree = nil
 	dep.CfgScript = ""
 	dep.Installer = LiveInstaller{}
+
+	// omit initrd extensions as this is a runtime information which might not be consistent on reboots
+	if dep.BootConfig != nil {
+		dep.BootConfig.InitrdExtensions = nil
+	}
 
 	data, err := yaml.Marshal(dep)
 	if err != nil {

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -171,11 +171,18 @@ var _ = Describe("Deployment", Label("deployment"), func() {
 			d := deployment.DefaultDeployment()
 			d.Disks[0].Device = "/dev/device"
 			d.SourceOS = deployment.NewDirSrc("/some/image")
+			d.BootConfig = &deployment.BootConfig{
+				Bootloader:       "grub",
+				KernelCmdline:    "kernel parameters",
+				InitrdExtensions: []string{"/path/to/initrd/extension"},
+			}
 			Expect(d.WriteDeploymentFile(s, "/some/dir")).To(Succeed())
 			rD, err := deployment.Parse(s, "/some/dir")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(rD.Disks)).To(Equal(1))
 			Expect(rD.Disks[0].Device).To(BeEmpty())
+			Expect(rD.BootConfig).NotTo(BeNil())
+			Expect(rD.BootConfig.InitrdExtensions).To(BeEmpty())
 			Expect(len(rD.Disks[0].Partitions)).To(Equal(2))
 			Expect(rD.Sanitize(s, deployment.CheckDiskDevice)).To(Succeed())
 		})

--- a/pkg/installer/media.go
+++ b/pkg/installer/media.go
@@ -640,12 +640,13 @@ func (i Media) addInstallationAssets(root string, d *deployment.Deployment) erro
 
 	if d.BootConfig != nil && len(d.BootConfig.InitrdExtensions) > 0 {
 		extensions := []string{}
-		for _, extension := range d.BootConfig.InitrdExtensions {
-			err = vfs.CopyFile(i.s.FS(), extension, installPath)
+		for j, extension := range d.BootConfig.InitrdExtensions {
+			extFile := fmt.Sprintf("%d-%s", j, filepath.Base(extension))
+			err = vfs.CopyFile(i.s.FS(), extension, filepath.Join(installPath, extFile))
 			if err != nil {
 				return fmt.Errorf("copying initrd extension %q: %w", extension, err)
 			}
-			extensions = append(extensions, filepath.Join(LiveMountPoint, installDir, filepath.Base(extension)))
+			extensions = append(extensions, filepath.Join(LiveMountPoint, installDir, extFile))
 		}
 		d.BootConfig.InitrdExtensions = extensions
 	}

--- a/pkg/installer/media.go
+++ b/pkg/installer/media.go
@@ -638,6 +638,18 @@ func (i Media) addInstallationAssets(root string, d *deployment.Deployment) erro
 		}
 	}
 
+	if d.BootConfig != nil && len(d.BootConfig.InitrdExtensions) > 0 {
+		extensions := []string{}
+		for _, extension := range d.BootConfig.InitrdExtensions {
+			err = vfs.CopyFile(i.s.FS(), extension, installPath)
+			if err != nil {
+				return fmt.Errorf("copying initrd extension %q: %w", extension, err)
+			}
+			extensions = append(extensions, filepath.Join(LiveMountPoint, installDir, filepath.Base(extension)))
+		}
+		d.BootConfig.InitrdExtensions = extensions
+	}
+
 	return nil
 }
 

--- a/pkg/installer/media.go
+++ b/pkg/installer/media.go
@@ -767,7 +767,7 @@ func (i Media) buildDisk(tempDir, liveRoot, osRoot string, d *deployment.Deploym
 
 	// include the reset flag so it can be detected at boot this is an installer image
 	cmdline := fmt.Sprintf("%s %s %s", d.RecoveryKernelCmdline(), deployment.ResetMark, d.Installer.KernelCmdline)
-	err = i.bl.InstallLive(osRoot, espDir, cmdline)
+	err = i.bl.InstallLive(bootloader.InstallCtx{RootDir: osRoot, Target: espDir, KernelCmdline: cmdline})
 	if err != nil {
 		return fmt.Errorf("failed installing the bootloader for a installer raw image: %w", err)
 	}
@@ -790,7 +790,7 @@ func (i Media) buildDisk(tempDir, liveRoot, osRoot string, d *deployment.Deploym
 
 // buildISO creates an ISO image from the prepared root
 func (i Media) buildISO(tempDir, isoDir, osRoot, kernelCmdline string) error {
-	err := i.bl.InstallLive(osRoot, isoDir, kernelCmdline)
+	err := i.bl.InstallLive(bootloader.InstallCtx{RootDir: osRoot, Target: isoDir, KernelCmdline: kernelCmdline})
 	if err != nil {
 		return fmt.Errorf("failed installing bootloader in ISO directory tree: %w", err)
 	}

--- a/pkg/installer/media_test.go
+++ b/pkg/installer/media_test.go
@@ -88,6 +88,10 @@ var _ = Describe("InstallerMedia", Label("installermedia"), func() {
 		d.Installer.OverlayTree = deployment.NewDirSrc("/some/dir/iso-overlay")
 		d.Installer.CfgScript = "/some/dir/config-live.sh"
 		d.Installer.KernelCmdline = "console=ttyS0"
+		d.BootConfig = &deployment.BootConfig{
+			Bootloader:       "grub",
+			InitrdExtensions: []string{"/some/dir/initrdExt"},
+		}
 
 		iso := installer.NewMedia(context.Background(), s, installer.ISO, installer.WithBootloader(bootloader.NewNone(s)))
 
@@ -99,6 +103,7 @@ var _ = Describe("InstallerMedia", Label("installermedia"), func() {
 		Expect(vfs.MkdirAll(fs, "/some/dir/install-overlay", vfs.DirPerm)).To(Succeed())
 		Expect(fs.WriteFile("/some/dir/config-live.sh", []byte("live config script"), vfs.FilePerm)).To(Succeed())
 		Expect(fs.WriteFile("/some/dir/config.sh", []byte("install config script"), vfs.FilePerm)).To(Succeed())
+		Expect(fs.WriteFile("/some/dir/initrdExt", []byte("initrd extension"), vfs.FilePerm)).To(Succeed())
 
 		Expect(iso.Build(d)).To(Succeed())
 		Expect(runner.MatchMilestones([][]string{

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -184,8 +184,10 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 	}
 
 	cmdline := ""
+	initrdExts := []string{}
 	if d.BootConfig != nil {
 		cmdline = d.BootConfig.KernelCmdline
+		initrdExts = d.BootConfig.InitrdExtensions
 	}
 
 	kernelCmdline := strings.TrimSpace(fmt.Sprintf("%s %s %s", d.BaseKernelCmdline(), uh.GenerateKernelCmdline(trans), cmdline))
@@ -202,6 +204,7 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 		EntryID:          strconv.Itoa(trans.ID),
 		KernelCmdline:    kernelCmdline,
 		RecKernelCmdline: recKernelCmdline,
+		InitrdExtensions: initrdExts,
 	})
 	if err != nil {
 		return fmt.Errorf("installing bootloader: %w", err)

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -195,7 +195,14 @@ func (u Upgrader) Upgrade(d *deployment.Deployment) (err error) {
 	}
 
 	espDir := filepath.Join(trans.Path, esp.MountPoint)
-	err = u.b.Install(trans.Path, espDir, esp.Label, strconv.Itoa(trans.ID), kernelCmdline, recKernelCmdline)
+	err = u.b.Install(bootloader.InstallCtx{
+		RootDir:          trans.Path,
+		Target:           espDir,
+		ESPLabel:         esp.Label,
+		EntryID:          strconv.Itoa(trans.ID),
+		KernelCmdline:    kernelCmdline,
+		RecKernelCmdline: recKernelCmdline,
+	})
 	if err != nil {
 		return fmt.Errorf("installing bootloader: %w", err)
 	}


### PR DESCRIPTION
This PR extends the bootloader interface and the deployment struct to support additional initrds to be stacked at install time.

With this change `elemental3ctl` is capable to concatenate initrds with a setup such as:
```yaml
bootloader:
  name: grub
  kernelCmdline: "console=ttyS0"
  initrdExtensions:
  - /path/to/initrd/extension.cpio
```

Extensions a pre-appended to the initrd found in the OS image, this prevents extensions to modify any pre-existing file, it can only append.

Note for the reviewers, easier to follow changes by looking commits individually, note most of the line changes are caused by a simple bootloader API refactor to make it more readable and extendable.