### PR TITLE
CPIO files utility

### DIFF
--- a/internal/cpio/cpio.go
+++ b/internal/cpio/cpio.go
@@ -1,0 +1,97 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+
+	"path/filepath"
+
+	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+// CreateCPIO walks a directory and streams the contents into the given generated CPIO file.
+// Requires cpio binary present in the current PATH.
+func CreateCPIO(ctx context.Context, s *sys.System, sourceDir, outputPath string) (err error) {
+	outFile, err := s.FS().Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("creating output file: %w", err)
+	}
+	defer func() {
+		e := outFile.Close()
+		if err == nil && e != nil {
+			err = e
+		}
+	}()
+
+	callback := func(stdin io.Writer) error {
+		return vfs.WalkDirFs(s.FS(), sourceDir, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Extract relative path to maintain directory structure
+			relPath, err := filepath.Rel(sourceDir, path)
+			if err != nil {
+				return err
+			}
+
+			// Feed the relative path to cpio, terminated by a null byte (\x00)
+			_, writeErr := io.WriteString(stdin, relPath+"\x00")
+			return writeErr
+		})
+	}
+
+	realSource, err := s.FS().RawPath(sourceDir)
+	if err != nil {
+		return fmt.Errorf("defining the real path for %q: %w", sourceDir, err)
+	}
+
+	err = s.Runner().RunContextWithPipe(ctx, callback, outFile, nil, realSource, nil, "cpio", "-0", "-o", "-H", "newc")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExtractCPIO streams the given cpio file to cpio command to extract the contents to the target directory.
+// Target directory is created if it does not exist.
+func ExtractCPIO(ctx context.Context, s *sys.System, cpioFile, targetDir string) error {
+	err := vfs.MkdirAll(s.FS(), targetDir, vfs.DirPerm)
+	if err != nil {
+		return err
+	}
+
+	cpioFile, err = s.FS().RawPath(cpioFile)
+	if err != nil {
+		return fmt.Errorf("defining the real path for %q: %w", cpioFile, err)
+	}
+
+	targetDir, err = s.FS().RawPath(targetDir)
+	if err != nil {
+		return fmt.Errorf("defining the real path for %q: %w", targetDir, err)
+	}
+
+	_, err = s.Runner().RunContext(ctx, "cpio", "-i", "--file", cpioFile, "-d", "-m", "--directory", targetDir)
+	return err
+}

--- a/internal/cpio/cpio_test.go
+++ b/internal/cpio/cpio_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright © 2025-2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpio_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/internal/cpio"
+	"github.com/suse/elemental/v3/pkg/log"
+	"github.com/suse/elemental/v3/pkg/sys"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
+)
+
+func TestCPIOSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CPIO test suite")
+}
+
+var _ = Describe("CPIO files creator with mock runner", Label("cpio"), func() {
+	var tfs vfs.FS
+	var runner *sysmock.Runner
+	var cleanup func()
+	var err error
+	var s *sys.System
+
+	BeforeEach(func() {
+		tfs, cleanup, err = sysmock.TestFS(map[string]any{
+			"/some/root/file1":        []byte("file1"),
+			"/some/root/file2":        []byte("file2"),
+			"/some/root/subdir/file3": []byte("file3"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		runner = sysmock.NewRunner()
+
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs), sys.WithRunner(runner),
+			sys.WithLogger(log.New(log.WithDiscardAll())),
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("creates a CPIO file with the given root", func() {
+		Expect(vfs.MkdirAll(tfs, "/output", vfs.DirPerm)).To(Succeed())
+
+		Expect(cpio.CreateCPIO(context.Background(), s, "/some/root", "/output/cpiofile")).To(Succeed())
+
+		data, err := tfs.ReadFile("/output/cpiofile")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(".\x00file1\x00file2\x00subdir\x00subdir/file3\x00"))
+	})
+
+	It("extracts a CPIO file to the given target", func() {
+		Expect(cpio.ExtractCPIO(context.Background(), s, "/tmp/someFile", "/tmp/extraction")).To(Succeed())
+		exists, _ := vfs.Exists(s.FS(), "/tmp/extraction")
+		Expect(exists).To(BeTrue())
+		Expect(runner.CmdsMatch([][]string{{"cpio", "-i", "--file"}})).To(Succeed())
+	})
+})
+
+// This test assumes cpio command to be available in PATH, it actually calls the real command
+var _ = Describe("CPIO files creator with real runner", Label("cpio"), func() {
+	var tfs vfs.FS
+	var cleanup func()
+	var err error
+	var s *sys.System
+
+	BeforeEach(func() {
+		tfs, cleanup, err = sysmock.TestFS(map[string]any{
+			"/some/root/file1":        []byte("file1"),
+			"/some/root/file2":        []byte("file2"),
+			"/some/root/subdir/file3": []byte("file3"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		s, err = sys.NewSystem(
+			sys.WithFS(tfs), sys.WithLogger(log.New(log.WithDiscardAll())),
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	It("creates a CPIO file with the given root and it extracts it back somewhere else", func() {
+		Expect(vfs.MkdirAll(tfs, "/output", vfs.DirPerm)).To(Succeed())
+
+		Expect(cpio.CreateCPIO(context.Background(), s, "/some/root", "/output/cpiofile")).To(Succeed())
+		Expect(cpio.ExtractCPIO(context.Background(), s, "/output/cpiofile", "/extraction")).To(Succeed())
+
+		data, err := tfs.ReadFile("/extraction/subdir/file3")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(Equal([]byte("file3")))
+	})
+})

--- a/pkg/sys/mock/runner.go
+++ b/pkg/sys/mock/runner.go
@@ -83,7 +83,13 @@ func (r *Runner) RunContextWithPipe(
 
 	callErrChan := make(chan error, 1)
 	go func() {
-		_, e := io.Copy(stdout, pr)
+		var e error
+		if stdout != nil {
+			_, e = io.Copy(stdout, pr)
+		}
+		if r.ReturnError != nil {
+			e = r.ReturnError
+		}
 		callErrChan <- e
 	}()
 

--- a/pkg/sys/mock/runner.go
+++ b/pkg/sys/mock/runner.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/suse/elemental/v3/pkg/log"
@@ -67,6 +68,37 @@ func (r *Runner) RunEnv(command string, envs []string, args ...string) ([]byte, 
 
 func (r *Runner) RunContext(_ context.Context, command string, args ...string) ([]byte, error) {
 	return r.Run(command, args...)
+}
+
+func (r *Runner) RunContextWithPipe(
+	_ context.Context, stdinPipeFn func(io.Writer) error, stdout, _ io.Writer,
+	_ string, envs []string, command string, args ...string,
+) error {
+	var err error
+
+	r.cmds = append(r.cmds, append([]string{command}, args...))
+	r.envs = append(r.envs, append([]string{command}, envs...))
+
+	pr, pw := io.Pipe()
+
+	callErrChan := make(chan error, 1)
+	go func() {
+		_, e := io.Copy(stdout, pr)
+		callErrChan <- e
+	}()
+
+	if err = stdinPipeFn(pw); err != nil {
+		_ = pw.Close()
+		<-callErrChan
+		return err
+	}
+
+	_ = pw.Close()
+	if err = <-callErrChan; err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *Runner) RunContextParseOutput(_ context.Context, stdoutH, _ func(string), command string, args ...string) error {

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -180,8 +180,8 @@ func (r run) RunContextWithPipe(
 
 	if err = stdinPipeFn(stdinPipe); err != nil {
 		_ = stdinPipe.Close()
-		_ = cmd.Wait()
-		return fmt.Errorf("callback returned an error: %w", err)
+		cErr := cmd.Wait()
+		return fmt.Errorf("command returned error: %w, pipe closed with: %w", cErr, err)
 	}
 
 	if err = stdinPipe.Close(); err != nil {

--- a/pkg/sys/runner/runner.go
+++ b/pkg/sys/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
@@ -140,6 +141,56 @@ func (r run) RunContextParseOutput(ctx context.Context, stdoutH, stderrH func(st
 	if err != nil {
 		r.debug("'%s' command exited with error: %s", command, err.Error())
 		return err
+	}
+
+	return nil
+}
+
+func (r run) RunContextWithPipe(
+	ctx context.Context, stdinPipeFn func(io.Writer) error, stdout,
+	stderr io.Writer, workDir string, env []string, command string, args ...string,
+) (err error) {
+	r.debug("Running cmd: '%s %s'", command, strings.Join(args, " "))
+
+	if stdinPipeFn == nil {
+		return fmt.Errorf("undefined stdin pipe function (stdinPipeFn)")
+	}
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+
+	if len(env) > 0 {
+		cmd.Env = env
+	}
+
+	var stdinPipe io.WriteCloser
+	if stdinPipe, err = cmd.StdinPipe(); err != nil {
+		return fmt.Errorf("could not pipe stdin for command %q: %w", command, err)
+	}
+
+	if err = cmd.Start(); err != nil {
+		_ = stdinPipe.Close()
+		return fmt.Errorf("%q command reported an error on start: %w", command, err)
+	}
+
+	if err = stdinPipeFn(stdinPipe); err != nil {
+		_ = stdinPipe.Close()
+		_ = cmd.Wait()
+		return fmt.Errorf("callback returned an error: %w", err)
+	}
+
+	if err = stdinPipe.Close(); err != nil {
+		_ = cmd.Wait()
+		return fmt.Errorf("closing stdin pipe: %w", err)
+	}
+
+	if err = cmd.Wait(); err != nil {
+		return fmt.Errorf("%q command returned an error: %w", command, err)
 	}
 
 	return nil

--- a/pkg/sys/runner/runner_test.go
+++ b/pkg/sys/runner/runner_test.go
@@ -20,6 +20,9 @@ package runner_test
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"path/filepath"
 	"slices"
 	"sync"
 	"testing"
@@ -29,7 +32,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/suse/elemental/v3/pkg/log"
+	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
 	"github.com/suse/elemental/v3/pkg/sys/runner"
+	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
 func TestRunnerSuite(t *testing.T) {
@@ -125,5 +130,41 @@ var _ = Describe("Runner", Label("runner"), func() {
 		Expect(slices.Contains(stdout, "stdout")).To(BeTrue())
 		Expect(len(stderr)).To(Equal(3))
 		Expect(slices.Contains(stderr, "stderr")).To(BeTrue())
+	})
+	It("runs a command getting input from a pipe in a specific working directory", func() {
+		tfs, cleanup, err := sysmock.TestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+		defer cleanup()
+
+		workDir := "/tmp/workDir"
+		Expect(vfs.MkdirAll(tfs, workDir, vfs.DirPerm)).To(Succeed())
+		Expect(tfs.WriteFile(filepath.Join(workDir, "secondLine"), []byte("Second line\n"), vfs.FilePerm)).To(Succeed())
+
+		// buffer to store the stdout of the command
+		buff := &bytes.Buffer{}
+
+		r := runner.NewRunner()
+
+		callback := func(stdin io.Writer) error {
+			_, err := io.WriteString(stdin, "First line\n")
+			return err
+		}
+		workDir, err = tfs.RawPath(workDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Reads first line from the standard input and the second line from a fine in the working directory
+		Expect(r.RunContextWithPipe(context.Background(), callback, buff, nil, workDir, nil, "cat", "-", "secondLine")).To(Succeed())
+		Expect(buff.String()).To(ContainSubstring("First line\nSecond line\n"))
+	})
+	It("runs a command getting input from a pipe in a specific working directory", func() {
+		r := runner.NewRunner()
+
+		callback := func(_ io.Writer) error {
+			return fmt.Errorf("testing error out")
+		}
+
+		Expect(r.RunContextWithPipe(context.Background(), callback, nil, nil, "", nil, "cat", "-")).To(
+			MatchError(ContainSubstring("testing error out")),
+		)
 	})
 })

--- a/pkg/sys/runner/runner_test.go
+++ b/pkg/sys/runner/runner_test.go
@@ -152,11 +152,11 @@ var _ = Describe("Runner", Label("runner"), func() {
 		workDir, err = tfs.RawPath(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Reads first line from the standard input and the second line from a fine in the working directory
+		// Reads first line from the standard input and the second line from a file in the working directory
 		Expect(r.RunContextWithPipe(context.Background(), callback, buff, nil, workDir, nil, "cat", "-", "secondLine")).To(Succeed())
 		Expect(buff.String()).To(ContainSubstring("First line\nSecond line\n"))
 	})
-	It("runs a command getting input from a pipe in a specific working directory", func() {
+	It("runs a command getting input from a piped process and the input process fails", func() {
 		r := runner.NewRunner()
 
 		callback := func(_ io.Writer) error {

--- a/pkg/sys/system.go
+++ b/pkg/sys/system.go
@@ -19,6 +19,7 @@ package sys
 
 import (
 	"context"
+	"io"
 	"os/exec"
 	"runtime"
 
@@ -35,6 +36,10 @@ type Runner interface {
 	RunEnv(cmd string, env []string, args ...string) ([]byte, error)
 	RunContext(ctx context.Context, cmd string, args ...string) ([]byte, error)
 	RunContextParseOutput(ctx context.Context, stdoutH, stderrH func(line string), cmd string, args ...string) error
+	RunContextWithPipe(
+		ctx context.Context, stdinPipeFn func(io.Writer) error, stdout,
+		stderr io.Writer, workDir string, env []string, cmd string, args ...string,
+	) error
 }
 
 type Syscall interface {


### PR DESCRIPTION
This PR extends the runner interface to support piped input and outputs and it also creates a small internal utility to create and extract CPIO files.