### PR TITLE
Fixes Release Date string

### DIFF
--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -253,7 +253,7 @@ func printBasicData(cm *core.ReleaseManifest, sm *solution.ReleaseManifest, arg 
 		table.Header([]string{"Attribute", "Core Platform (Base)"})
 		data = append(data, []string{"Name", cmBasic.Name})
 		data = append(data, []string{versionHdr, cmBasic.Version})
-		data = append(data, []string{"Release Data", cmBasic.CreationDate})
+		data = append(data, []string{"Release Date", cmBasic.CreationDate})
 		data = append(data, []string{sourceHdr, cmBasic.Source})
 
 	}


### PR DESCRIPTION
There's a typo in `release-info` where it shows `Release Data` rather than `Release Date`:

```
% ./build/elemental3 release-info oci://registry.suse.com/elemental/rke2/rke2-manifest:1.35.5-35.1
⠋ Extracting (2.6 kB, 28 kB/s) [0s]
┌──────────────┬──────────────────────────────────────────────────────────────────┐
│  ATTRIBUTE   │                     CORE PLATFORM  ( BASE )                      │
├──────────────┼──────────────────────────────────────────────────────────────────┤
│ Name         │ suse-core                                                        │
│ Version      │ 1.0-rc.20260709                                                  │
│ Release Data │ 2026-07-09                                                       │         <------
│ Source       │ oci://registry.suse.com/elemental/rke2/rke2-manifest:1.35.5-35.1 │
└──────────────┴──────────────────────────────────────────────────────────────────┘
(snip)
```

With this super simple patch, this is fixed:

```
% ./build/elemental3 release-info oci://registry.suse.com/elemental/rke2/rke2-manifest:1.35.5-35.1
⠋ Extracting (2.6 kB, 39 kB/s) [0s]
┌──────────────┬──────────────────────────────────────────────────────────────────┐
│  ATTRIBUTE   │                     CORE PLATFORM  ( BASE )                      │
├──────────────┼──────────────────────────────────────────────────────────────────┤
│ Name         │ suse-core                                                        │
│ Version      │ 1.0-rc.20260709                                                  │
│ Release Date │ 2026-07-09                                                       │         <------
│ Source       │ oci://registry.suse.com/elemental/rke2/rke2-manifest:1.35.5-35.1 │
└──────────────┴──────────────────────────────────────────────────────────────────┘
(snip)
```

Fixes: #526