### PR TITLE
Automatically create and label /opt/cni and /etc/cni/net.d directories

### DIFF
--- a/internal/config/templates/k8s-config-installer.service.tpl
+++ b/internal/config/templates/k8s-config-installer.service.tpl
@@ -10,6 +10,7 @@ Restart=on-failure
 RestartSec=60
 # TODO (atanasdinov): Figure out a declarative, non-hardcoded approach for installing selinux modules
 ExecStartPre=/bin/sh -c "semodule -i /usr/share/selinux/packages/rke2.pp"
+ExecStartPre=/bin/sh -c "mkdir -pZ /etc/cni/net.d /opt/cni/bin"
 ExecStart=/bin/bash "{{ .ConfigDeployScript }}"
 ExecStartPost=/bin/sh -c "systemctl disable k8s-config-installer.service"
 ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-config-installer.service"


### PR DESCRIPTION
This commit automatically creates the `/opt/cni` and `/etc/cni/net.d` directories ahead of the RKE2 installer running. This ensures that the correct SELinux labels are applied as per `rke2-selinux` (https://github.com/rancher/rke2-selinux/blob/master/policy/slemicro/rke2.fc#L15-L16) for these directories, and ensures that CNIs such as Cilium can copy in the required binaries without SELinux AVC errors. The default behaviour of SELinux inherits the underlying `/opt` and `/etc` labels when sub-directories are created, thus not allowing the installation to complete successfully.

Fixes: #529