### PR TITLE
Drop elemental3ctl sysext references

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -14,14 +14,6 @@ pr:
         target_project: devel:UnifiedCore:Tumbleweed:PRs
     - link_package:
         source_project: devel:UnifiedCore:Tumbleweed
-        source_package: elemental3ctl-sysext
-        target_project: devel:UnifiedCore:Tumbleweed:PRs
-    - link_package:
-        source_project: devel:UnifiedCore:Tumbleweed
-        source_package: elemental3ctl-sysext-image
-        target_project: devel:UnifiedCore:Tumbleweed:PRs
-    - link_package:
-        source_project: devel:UnifiedCore:Tumbleweed
         source_package: release-manifest-image
         target_project: devel:UnifiedCore:Tumbleweed:PRs
     - set_flags:

--- a/internal/config/systemd_sysext_test.go
+++ b/internal/config/systemd_sysext_test.go
@@ -88,8 +88,8 @@ var _ = Describe("Systemd extensions", func() {
 						Systemd: api.Systemd{
 							Extensions: []api.SystemdExtension{
 								{
-									Name:     "elemental3ctl",
-									Image:    "https://example.com/elemental3ctl.raw",
+									Name:     "example-ext",
+									Image:    "https://example.com/example-ext.raw",
 									Required: true,
 								},
 								{
@@ -163,7 +163,7 @@ var _ = Describe("Systemd extensions", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(extensions).To(HaveLen(3))
 
-			Expect(extensions).To(ContainElement(api.SystemdExtension{Name: "elemental3ctl", Image: "https://example.com/elemental3ctl.raw", Required: true}), "Required by release")
+			Expect(extensions).To(ContainElement(api.SystemdExtension{Name: "example-ext", Image: "https://example.com/example-ext.raw", Required: true}), "Required by release")
 			Expect(extensions).To(ContainElement(api.SystemdExtension{Name: "longhorn", Image: "https://example.com/longhorn.raw"}), "Required as a dependency of enabled Helm chart")
 			Expect(extensions).To(ContainElement(api.SystemdExtension{Name: "nvidia-toolkit", Image: "https://example.com/nvidia-toolkit.raw"}), "Explicitly requested")
 		})

--- a/pkg/manifest/api/core/manifest_test.go
+++ b/pkg/manifest/api/core/manifest_test.go
@@ -86,10 +86,7 @@ var _ = Describe("ReleaseManifest", Label("release-manifest"), func() {
 		Expect(rm.Components.OperatingSystem.Image.Base).To(Equal("registry.com/foo/bar/os-base:6.2"))
 		Expect(rm.Components.OperatingSystem.Image.ISO).To(Equal("registry.com/foo/bar/installer-iso:6.2"))
 
-		Expect(rm.Components.Systemd.Extensions).To(HaveLen(1))
-		Expect(rm.Components.Systemd.Extensions[0].Name).To(Equal("elemental3ctl"))
-		Expect(rm.Components.Systemd.Extensions[0].Image).To(Equal("https://example.com/elemental3ctl_0.0.raw"))
-		Expect(rm.Components.Systemd.Extensions[0].Required).To(BeTrue())
+		Expect(rm.Components.Systemd.Extensions).To(BeEmpty())
 
 		Expect(rm.Components.Kubernetes).ToNot(BeNil())
 		Expect(rm.Components.Kubernetes.Version).To(Equal("v1.35.0+rke2r1"))

--- a/pkg/manifest/resolver/resolver_test.go
+++ b/pkg/manifest/resolver/resolver_test.go
@@ -155,10 +155,7 @@ func validateResolvedManifest(rm *resolver.ResolvedManifest, coreOnly bool) {
 	Expect(rm.CorePlatform.Components.OperatingSystem.Image.Base).To(Equal("registry.com/foo/bar/os-base:6.2"))
 	Expect(rm.CorePlatform.Components.OperatingSystem.Image.ISO).To(Equal("registry.com/foo/bar/installer-iso:6.2"))
 
-	Expect(rm.CorePlatform.Components.Systemd.Extensions).To(HaveLen(1))
-	Expect(rm.CorePlatform.Components.Systemd.Extensions[0].Name).To(Equal("elemental3ctl"))
-	Expect(rm.CorePlatform.Components.Systemd.Extensions[0].Image).To(Equal("https://example.com/elemental3ctl_0.0.raw"))
-	Expect(rm.CorePlatform.Components.Systemd.Extensions[0].Required).To(BeTrue())
+	Expect(rm.CorePlatform.Components.Systemd.Extensions).To(BeEmpty())
 
 	Expect(rm.CorePlatform.Components.Kubernetes).ToNot(BeNil())
 	Expect(rm.CorePlatform.Components.Kubernetes.Version).To(Equal("v1.35.0+rke2r1"))

--- a/pkg/manifest/testdata/full_core_release_manifest.yaml
+++ b/pkg/manifest/testdata/full_core_release_manifest.yaml
@@ -23,11 +23,6 @@ components:
     image:
       base: "registry.com/foo/bar/os-base:6.2"
       iso: "registry.com/foo/bar/installer-iso:6.2"
-  systemd:
-    extensions:
-      - name: "elemental3ctl"
-        image: "https://example.com/elemental3ctl_0.0.raw"
-        required: true
   kubernetes:
     version: "v1.35.0+rke2r1"
     image: "registry.example.com/rke2:1.35_1.0"


### PR DESCRIPTION
elemental3ctl is no longer built and published as a sysext, so this change attempts to drop misleading references and simplify and optimise our integration testing.