### PR TITLE
Correct paths for ovmf code & vars files

### DIFF
--- a/docs/cookbook-first-time-use.md
+++ b/docs/cookbook-first-time-use.md
@@ -317,7 +317,7 @@ sudo virt-install --name single-node \
                   --network network=default,model=virtio,mac=FE:C4:05:42:8B:AB \
                   --virt-type kvm \
                   --import \
-                  --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+                  --boot uefi
 ```
 
 After a few seconds, a new VM will be created, booted and the terminal will be connected to the console (to disconnect from the console you can use *ctrl+\]*). You should see the VM booting.
@@ -411,7 +411,7 @@ sudo virt-install --name node1.example.com \
              --network network=default,model=virtio,mac=FE:C4:05:42:8B:AB \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 
 sudo virt-install --name node2.example.com \
              --ram 16000 \
@@ -424,7 +424,7 @@ sudo virt-install --name node2.example.com \
              --network network=default,model=virtio,mac=FE:C4:05:42:8B:AC \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 
 sudo virt-install --name node3.example.com \
              --ram 16000 \
@@ -437,7 +437,7 @@ sudo virt-install --name node3.example.com \
              --network network=default,model=virtio,mac=FE:C4:05:42:8B:AD \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 
 sudo virt-install --name node4.example.com \
              --ram 16000 \
@@ -450,7 +450,7 @@ sudo virt-install --name node4.example.com \
              --network network=default,model=virtio,mac=FE:C4:05:42:8B:AE \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 
 ```
 

--- a/docs/image-customization.md
+++ b/docs/image-customization.md
@@ -124,7 +124,7 @@ The customized image can be booted as any other regular image. Below you can fin
                --network network=default,model=virtio,mac=FE:C4:05:42:8B:01 \
                --virt-type kvm \
                --import \
-               --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+               --boot uefi
    ```
 
 * ISO media:
@@ -133,13 +133,6 @@ The customized image can be booted as any other regular image. Below you can fin
 
      ```shell
      truncate -s 20G disk.img
-     ```
-
-   * Create a local copy of the EFI variable store:
-
-     > **NOTE:** This is needed in order to persist any new EFI entries included during the ISO installer boot.
-     ```shell
-     cp /usr/share/qemu/ovmf-x86_64-vars.bin .
      ```
 
    * Boot a VM using the previously created resources, namely the `customized.iso`, `disk.img` and local EFI store:
@@ -151,7 +144,7 @@ The customized image can be booted as any other regular image. Below you can fin
                 --import \
                 --disk path=disk.img,format=raw \
                 --cdrom "customized.iso" \
-                --boot loader=/usr/share/qemu/ovmf-x86_64-code.bin,loader.readonly=yes,loader.type=pflash,nvram=ovmf-x86_64-vars.bin \
+                --boot uefi \
                 --graphics none \
                 --console pty,target_type=serial \
                 --network network=default,model=virtio,mac=FE:C4:05:42:8B:01 \
@@ -239,7 +232,7 @@ virt-install --name linux-only-example \
              --network network=default,model=virtio,mac=FE:C4:05:42:8B:01 \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 ```
 
 > **NOTE:** Based on the `FE:C4:05:42:8B:01` MAC address, during first boot this will apply the network configuration defined in the [network/example-libvirt.yaml](../examples/elemental/customize/linux-only/network/example-libvirt.yaml) file on the machine.
@@ -362,7 +355,7 @@ virt-install --name single-node-example \
              --network network=default,model=virtio,mac=FE:C4:05:42:8B:01 \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 ```
 
 > **NOTE:** Based on the `FE:C4:05:42:8B:01` MAC address, during first boot this will apply the network configuration defined in the [network/single-node-example.yaml](../examples/elemental/customize/single-node/network/single-node-example.yaml) file on the machine.
@@ -568,7 +561,7 @@ virt-install --name <machine-name> \
              --network network=default,model=virtio,mac=<node-MAC> \
              --virt-type kvm \
              --import \
-             --boot uefi,loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,nvram.template=/usr/share/qemu/ovmf-x86_64-ms-vars.bin
+             --boot uefi
 ```
 
 Where:


### PR DESCRIPTION
The files `ovmf-x86_64-ms-code.bin` and `ovmf-x86_64-ms-vars.bin` were recently removed from Tumbleweed. However, cookbook still carries the now inexistent file paths which are removed in this PR because:
1. libvirt chooses helpful defaults by itself
2. paths to these files could differ between distros, making libvirt the best judge to find and determine the required firmware files.