### PR TITLE
Do not overlay kubernetes files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/containerd/containerd/v2 v2.3.3
 	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/coreos/butane v0.29.0
-	github.com/coreos/ignition/v2 v2.26.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/go-units v0.5.0
 	github.com/go-playground/validator/v10 v10.30.3
@@ -55,6 +54,7 @@ require (
 	github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
+	github.com/coreos/ignition/v2 v2.26.0 // indirect
 	github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/cli v29.6.2+incompatible // indirect

--- a/internal/butane/config.go
+++ b/internal/butane/config.go
@@ -18,7 +18,10 @@ limitations under the License.
 package butane
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"path/filepath"
 
 	base "github.com/coreos/butane/base/v0_6"
@@ -29,6 +32,8 @@ import (
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
+
+const maxResourceSize int64 = 16 * 1024 * 1024
 
 // Config represents a basic butane configuration
 type Config struct {
@@ -47,6 +52,35 @@ func (c *Config) MergeInlineIgnition(ignitionConf string) {
 	merge.Inline = &ignitionConf
 
 	c.Ignition.Config.Merge = append(c.Ignition.Config.Merge, merge)
+}
+
+// AddFileInline adds the given filepath and inline content to the butane config
+func (c *Config) AddFileInline(filename string, data *string, mode fs.FileMode) {
+	c.Storage.Files = append(c.Storage.Files, base.File{
+		Path: filename,
+		Contents: base.Resource{
+			Inline: data,
+		},
+		Mode: toButaneMode(mode),
+	})
+}
+
+// AddFileInlineFromReader adds the given filepath and inline content from the given reader, closes the reader.
+// It does not support data payloads bigger than 16MiB as this is meant for text files
+func (c *Config) AddFileInlineFromReader(filename string, rc io.ReadCloser, mode fs.FileMode) error {
+
+	resource, err := resourceFromText(rc, maxResourceSize)
+	if err != nil {
+		return nil
+	}
+
+	c.Storage.Files = append(c.Storage.Files, base.File{
+		Path:     filename,
+		Contents: resource,
+		Mode:     toButaneMode(mode),
+	})
+
+	return nil
 }
 
 // AddSystemdUnit adds an inline unit object in butane configuration
@@ -98,4 +132,48 @@ func TranslateBytes(s *sys.System, butane any) ([]byte, error) {
 	}
 	s.Logger().Debug("Butane configuration translated:\n--- Generated Ignition Config ---\n%s", string(ignitionBytes))
 	return ignitionBytes, nil
+}
+
+// toButaneMode converts fs.FileMode into *int
+func toButaneMode(fm fs.FileMode) *int {
+	// Start with the standard 9 permissions
+	mode := uint32(fm.Perm())
+
+	// Add special bits back if they exist in the fs.FileMode
+	if fm&fs.ModeSetuid != 0 {
+		mode |= 04000
+	}
+	if fm&fs.ModeSetgid != 0 {
+		mode |= 02000
+	}
+	if fm&fs.ModeSticky != 0 {
+		mode |= 01000
+	}
+
+	modeInt := int(mode)
+	return &modeInt
+}
+
+// resourceFromText is meant for plain text files, closes the reader
+func resourceFromText(rc io.ReadCloser, maxBytes int64) (_ base.Resource, err error) {
+	defer func() {
+		err = errors.Join(err, rc.Close())
+	}()
+
+	// Limit to maxBytes + 1 so we can detect if it overflows
+	lr := io.LimitReader(rc, maxBytes+1)
+
+	data, err := io.ReadAll(lr)
+	if err != nil {
+		return base.Resource{}, err
+	}
+
+	// If we read more than maxBytes, the source was too large
+	if int64(len(data)) > maxBytes {
+		return base.Resource{}, fmt.Errorf("input exceeds maximum allowed size of %d bytes", maxBytes)
+	}
+
+	return base.Resource{
+		Inline: new(string(data)),
+	}, nil
 }

--- a/internal/cli/action/build.go
+++ b/internal/cli/action/build.go
@@ -34,7 +34,6 @@ import (
 	v0 "github.com/suse/elemental/v3/internal/config/v0"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/pkg/helm"
-	"github.com/suse/elemental/v3/pkg/http"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/platform"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
@@ -89,8 +88,7 @@ func Build(ctx context.Context, cmd *cli.Command) error {
 
 	configManager := config.NewManager(
 		system,
-		config.NewHelm(system.FS(), valuesResolver, logger, output.OverlaysDir()),
-		config.WithDownloadFunc(http.DownloadFile),
+		config.NewHelm(valuesResolver, logger),
 		config.WithLocal(args.Local),
 	)
 

--- a/internal/cli/action/customize.go
+++ b/internal/cli/action/customize.go
@@ -35,7 +35,6 @@ import (
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/pkg/extractor"
 	"github.com/suse/elemental/v3/pkg/helm"
-	"github.com/suse/elemental/v3/pkg/http"
 	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/platform"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
@@ -127,12 +126,12 @@ func setupCustomizeRunner(
 
 	return &customize.Runner{
 		System:        s,
-		ConfigManager: setupConfigManager(s, args.ConfigDir, output, args.Local),
+		ConfigManager: setupConfigManager(s, args.ConfigDir, args.Local),
 		FileExtractor: extr,
 	}, nil
 }
 
-func setupConfigManager(s *sys.System, configDir string, output config.Output, local bool) *config.Manager {
+func setupConfigManager(s *sys.System, configDir string, local bool) *config.Manager {
 	valuesResolver := &helm.ValuesResolver{
 		FS:        s.FS(),
 		ValuesDir: v0.Dir(configDir).HelmValuesDir(),
@@ -140,8 +139,7 @@ func setupConfigManager(s *sys.System, configDir string, output config.Output, l
 
 	return config.NewManager(
 		s,
-		config.NewHelm(s.FS(), valuesResolver, s.Logger(), output.OverlaysDir()),
-		config.WithDownloadFunc(http.DownloadFile),
+		config.NewHelm(valuesResolver, s.Logger()),
 		config.WithLocal(local),
 	)
 }

--- a/internal/config/helm.go
+++ b/internal/config/helm.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"go.yaml.in/yaml/v3"
@@ -35,7 +36,6 @@ import (
 	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
 	"github.com/suse/elemental/v3/pkg/manifest/resolver"
-	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
 type helmValuesResolver interface {
@@ -50,24 +50,20 @@ type helmChart interface {
 }
 
 type Helm struct {
-	FS             vfs.FS
 	RelativePath   string
-	DestinationDir string
 	ValuesResolver helmValuesResolver
 	Logger         log.Logger
 }
 
-func NewHelm(fs vfs.FS, valuesResolver helmValuesResolver, logger log.Logger, destinationDir string) *Helm {
+func NewHelm(valuesResolver helmValuesResolver, logger log.Logger) *Helm {
 	return &Helm{
-		FS:             fs,
 		RelativePath:   image.HelmPath(),
-		DestinationDir: destinationDir,
 		ValuesResolver: valuesResolver,
 		Logger:         logger,
 	}
 }
 
-func (h *Helm) Configure(conf *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+func (h *Helm) Configure(conf *image.Configuration, rm *resolver.ResolvedManifest, butaneCfg *butane.Config) ([]string, error) {
 	if len(conf.Release.Components.HelmCharts) > 0 {
 		var charts []string
 		for _, c := range conf.Release.Components.HelmCharts {
@@ -79,27 +75,23 @@ func (h *Helm) Configure(conf *image.Configuration, rm *resolver.ResolvedManifes
 
 	charts, secrets, err := h.retrieveHelmCharts(rm, conf)
 	if err != nil {
-		return nil, nil, fmt.Errorf("retrieving helm charts: %w", err)
+		return nil, fmt.Errorf("retrieving helm charts: %w", err)
 	}
 
-	chartFiles, err := h.writeHelmCharts(charts)
+	chartFiles, err := h.writeHelmCharts(butaneCfg, charts)
 	if err != nil {
-		return nil, nil, fmt.Errorf("writing helm chart resources: %w", err)
+		return nil, fmt.Errorf("writing helm chart resources: %w", err)
 	}
 
-	helmSecrets, err := h.createHelmSecretFileMap(secrets)
+	err = h.writeHelmSecrets(secrets, butaneCfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating helm secrets: %w", err)
+		return nil, fmt.Errorf("creating helm secrets: %w", err)
 	}
 
-	return chartFiles, helmSecrets, nil
+	return chartFiles, nil
 }
 
-func (h *Helm) writeHelmCharts(crds []*helm.CRD) ([]string, error) {
-	if err := vfs.MkdirAll(h.FS, filepath.Join(h.DestinationDir, h.RelativePath), vfs.DirPerm); err != nil {
-		return nil, fmt.Errorf("creating directory: %w", err)
-	}
-
+func (h *Helm) writeHelmCharts(butaneCfg *butane.Config, crds []*helm.CRD) ([]string, error) {
 	var charts []string
 
 	for _, crd := range crds {
@@ -110,10 +102,8 @@ func (h *Helm) writeHelmCharts(crds []*helm.CRD) ([]string, error) {
 
 		chartName := fmt.Sprintf("%s.yaml", crd.Metadata.Name)
 		relativePath := filepath.Join("/", h.RelativePath, chartName)
-		fullPath := filepath.Join(h.DestinationDir, relativePath)
-		if err = h.FS.WriteFile(fullPath, data, 0o644); err != nil {
-			return nil, fmt.Errorf("writing helm chart: %w", err)
-		}
+
+		butaneCfg.AddFileInline(relativePath, new(string(data)), 0o644)
 
 		charts = append(charts, relativePath)
 	}
@@ -121,19 +111,19 @@ func (h *Helm) writeHelmCharts(crds []*helm.CRD) ([]string, error) {
 	return charts, nil
 }
 
-func (h *Helm) createHelmSecretFileMap(secrets []*helm.Secret) (map[string][]byte, error) {
-	helmSecrets := make(map[string][]byte)
+func (h *Helm) writeHelmSecrets(secrets []*helm.Secret, butaneCfg *butane.Config) error {
+
 	for _, secret := range secrets {
 		data, err := yaml.Marshal(secret)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling secret %s: %w", secret.Metadata.Name, err)
+			return fmt.Errorf("marshaling secret %s: %w", secret.Metadata.Name, err)
 		}
 
 		secretName := fmt.Sprintf("%s-priority.yaml", secret.Metadata.Name)
-		helmSecrets[secretName] = data
+		butaneCfg.AddFileInline(filepath.Join("/", image.KubernetesManifestsPath(), secretName), new(string(data)), 0o644)
 	}
 
-	return helmSecrets, nil
+	return nil
 }
 
 func (h *Helm) retrieveHelmCharts(rm *resolver.ResolvedManifest, conf *image.Configuration) ([]*helm.CRD, []*helm.Secret, error) {

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
@@ -53,11 +54,18 @@ func (v *valuesResolverMock) Resolve(*helm.ValueSource) ([]byte, error) {
 }
 
 var _ = Describe("Helm tests", Label("helm"), func() {
+
 	logger := log.New(log.WithDiscardAll())
 	overlaysPath := "/etc/overlays"
 	helmPath := "helm"
 
 	Describe("Complete setup", func() {
+		var config *butane.Config
+
+		BeforeEach(func() {
+			config = &butane.Config{}
+		})
+
 		rm := &resolver.ResolvedManifest{
 			CorePlatform: &core.ReleaseManifest{
 				Components: core.Components{
@@ -154,11 +162,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver, Logger: logger}
 
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting helm charts: resolving values for chart metallb: resolving failed"))
 			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
+			Expect(len(config.Storage.Files)).To(Equal(0))
 		})
 
 		It("Fails resolving values of solution Helm chart", func() {
@@ -177,11 +185,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver, Logger: logger}
 
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting helm charts: resolving values for chart neuvector-crd: resolving failed"))
 			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
+			Expect(len(config.Storage.Files)).To(Equal(0))
 		})
 
 		It("Fails resolving values of user Helm chart", func() {
@@ -210,11 +218,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver}
 
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting user helm charts: resolving values for chart apache: resolving failed"))
 			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
+			Expect(len(config.Storage.Files)).To(Equal(0))
 		})
 
 		It("Fails to collect chart with a missing repository", func() {
@@ -236,11 +244,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 			}
 
 			h := &Helm{ValuesResolver: resolver}
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: collecting user helm charts: repository not found for chart: apache"))
 			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
+			Expect(len(config.Storage.Files)).To(Equal(0))
 		})
 
 		It("Fails with same repository defined multiple times", func() {
@@ -272,11 +280,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 			}
 
 			h := &Helm{ValuesResolver: resolver}
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: creating helm chart auth map: helm repository 'apache-repo' defined multiple times"))
 			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
+			Expect(len(config.Storage.Files)).To(Equal(0))
 		})
 
 		It("Fails enabling a missing release chart", func() {
@@ -295,35 +303,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 
 			h := &Helm{ValuesResolver: resolver, Logger: logger}
 
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("retrieving helm charts: filtering enabled helm charts: adding helm chart 'rancher': helm chart does not exist"))
 			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
-		})
-
-		It("Fails writing Helm charts to the FS", func() {
-			fs, cleanup, err := sysmock.TestFS(nil)
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(cleanup)
-
-			fs, err = sysmock.ReadOnlyTestFS(fs)
-			Expect(err).NotTo(HaveOccurred())
-
-			conf := &image.Configuration{}
-
-			h := &Helm{
-				FS:             fs,
-				ValuesResolver: &valuesResolverMock{},
-				DestinationDir: overlaysPath,
-				RelativePath:   helmPath,
-			}
-
-			charts, secrets, err := h.Configure(conf, rm)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError("writing helm chart resources: creating directory: Mkdir /etc/overlays/helm: operation not permitted"))
-			Expect(charts).To(BeNil())
-			Expect(secrets).To(BeNil())
+			Expect(len(config.Storage.Files)).To(Equal(0))
 		})
 
 		It("Collects and writes core, solution and user Helm charts to the FS", func() {
@@ -382,16 +366,13 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 			}
 
 			h := &Helm{
-				FS:             fs,
 				ValuesResolver: resolver,
-				DestinationDir: overlaysPath,
 				RelativePath:   helmPath,
 				Logger:         logger,
 			}
 
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(secrets).To(BeEmpty())
 			Expect(charts).To(ConsistOf(
 				"/helm/metallb.yaml",
 				"/helm/endpoint-copier-operator.yaml",
@@ -400,6 +381,8 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 				"/helm/kubevirt.yaml",
 				"/helm/apache.yaml",
 				"/helm/nginx.yaml"))
+
+			Expect(len(config.Storage.Files)).To(Equal(7))
 
 			// Verify the contents of the various written Helm resources
 			contents := `apiVersion: helm.cattle.io/v1
@@ -415,9 +398,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err := fs.ReadFile(filepath.Join(overlaysPath, helmPath, "neuvector.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data := findFileContentsInConfig(config, filepath.Join("/", helmPath, "neuvector.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -432,9 +415,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "neuvector-crd.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "neuvector-crd.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -454,9 +437,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "metallb.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "metallb.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -470,9 +453,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "endpoint-copier-operator.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "endpoint-copier-operator.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -486,9 +469,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "kubevirt.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "kubevirt.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -507,9 +490,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "apache.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "apache.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -523,9 +506,10 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "nginx.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "nginx.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 		})
 
 		It("Collects and writes core, solution and user Helm charts with auth to the FS", func() {
@@ -617,14 +601,12 @@ spec:
 			}
 
 			h := &Helm{
-				FS:             fs,
 				ValuesResolver: resolver,
-				DestinationDir: overlaysPath,
 				RelativePath:   helmPath,
 				Logger:         logger,
 			}
 
-			charts, secrets, err := h.Configure(conf, rm)
+			charts, err := h.Configure(conf, rm, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(charts).To(ConsistOf(
 				"/helm/metallb.yaml",
@@ -634,15 +616,28 @@ spec:
 				"/helm/postgres.yaml",
 				"/helm/suse-storage.yaml"))
 
+			Expect(len(config.Storage.Files)).To(Equal(10))
+
 			apacheAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: apache-auth\ntype: kubernetes.io/basic-auth\ndata:\n    username: YXBhY2hlLXVzZXI=\n    password: YXBhY2hlLXBhc3M=\n"
 			postgresAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: postgres-auth\ntype: kubernetes.io/basic-auth\ndata:\n    username: cG9zdGdyZXMtdXNlcg==\n    password: cG9zdGdyZXMtcGFzcw==\n"
 			storageAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: suse-storage-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoic3RvcmFnZS11c2VyIiwicGFzc3dvcmQiOiJzdG9yYWdlLXBhc3MiLCJhdXRoIjoiYzNSdmNtRm5aUzExYzJWeU9uTjBiM0poWjJVdGNHRnpjdz09In19fQ==\n"
 			ecoAuthSecret := "apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: endpoint-copier-operator-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoiZWNvLXVzZXIiLCJwYXNzd29yZCI6ImVjby1wYXNzIiwiYXV0aCI6IlpXTnZMWFZ6WlhJNlpXTnZMWEJoYzNNPSJ9fX0=\n"
 
-			Expect(string(secrets["apache-auth-priority.yaml"])).To(Equal(apacheAuthSecret))
-			Expect(string(secrets["postgres-auth-priority.yaml"])).To(Equal(postgresAuthSecret))
-			Expect(string(secrets["endpoint-copier-operator-auth-priority.yaml"])).To(Equal(ecoAuthSecret))
-			Expect(string(secrets["suse-storage-auth-priority.yaml"])).To(Equal(storageAuthSecret))
+			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesManifestsPath(), "apache-auth-priority.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(apacheAuthSecret))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.KubernetesManifestsPath(), "postgres-auth-priority.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(postgresAuthSecret))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.KubernetesManifestsPath(), "endpoint-copier-operator-auth-priority.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(ecoAuthSecret))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.KubernetesManifestsPath(), "suse-storage-auth-priority.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(storageAuthSecret))
 
 			// Verify the contents of the various written Helm resources
 			contents := `apiVersion: helm.cattle.io/v1
@@ -661,9 +656,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err := fs.ReadFile(filepath.Join(overlaysPath, helmPath, "metallb.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "metallb.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -679,10 +674,9 @@ spec:
     dockerRegistrySecret:
         name: endpoint-copier-operator-auth
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "endpoint-copier-operator.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents), "full actual:\n%s", string(b))
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "endpoint-copier-operator.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -699,9 +693,10 @@ spec:
     authSecret:
         name: apache-auth
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "apache.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "apache.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -715,9 +710,9 @@ spec:
     createNamespace: true
     backOffLimit: 20
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "nginx.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(Equal(contents))
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "nginx.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 
 			contents = `apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -735,11 +730,10 @@ spec:
         name: postgres-auth
     insecureSkipTLSVerify: true
 `
-			b, err = fs.ReadFile(filepath.Join(overlaysPath, helmPath, "postgres.yaml"))
-			Expect(err).NotTo(HaveOccurred())
-			fmt.Println(string(b))
-			Expect(string(b)).To(Equal(contents))
 
+			data = findFileContentsInConfig(config, filepath.Join("/", helmPath, "postgres.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(Equal(contents))
 		})
 	})
 

--- a/internal/config/ignition.go
+++ b/internal/config/ignition.go
@@ -23,18 +23,12 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/coreos/butane/base/v0_6"
-	"github.com/coreos/ignition/v2/config/util"
-	"go.yaml.in/yaml/v3"
-
 	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/cpio"
 	"github.com/suse/elemental/v3/internal/image"
-	"github.com/suse/elemental/v3/internal/image/kubernetes"
-	"github.com/suse/elemental/v3/internal/template"
 	"github.com/suse/elemental/v3/pkg/extensions"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
-	"github.com/suse/elemental/v3/pkg/sys"
+	"github.com/suse/elemental/v3/pkg/manifest/resolver"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
@@ -42,8 +36,6 @@ const (
 	ensureSysextUnitName        = "ensure-sysext.service"
 	reloadKernelModulesUnitName = "reload-kernel-modules.service"
 	updateLinkerCacheUnitName   = "update-linker-cache.service"
-	k8sResourcesUnitName        = "k8s-resource-installer.service"
-	k8sConfigUnitName           = "k8s-config-installer.service"
 	ignitionFileName            = "10-elemental.ign"
 	ignitionFromButaneFileName  = "90-butane.ign"
 )
@@ -57,68 +49,44 @@ var (
 
 	//go:embed templates/update-linker-cache.service
 	updateLinkerCacheUnit string
-
-	//go:embed templates/k8s-resource-installer.service.tpl
-	k8sResourceUnitTpl string
-
-	//go:embed templates/k8s-config-installer.service.tpl
-	k8sConfigUnitTpl string
-
-	//go:embed templates/k8s-vip.yaml.tpl
-	k8sVIPManifestTpl string
 )
 
-// configureIgnition writes the Ignition configuration file including:
+// configureSystem writes the Ignition configuration file including:
 // * Predefined Butane configuration
 // * Kubernetes configuration and deployment files
 // * Systemd extensions
-// * Kubernetes distribution installation
+// * Kubernetes distribution installation service
 //
-// it builds a CPIO file containing the Ignition configuration at /usr/lib/ignition/base.d the CPIO file can be used as an initrd extension
-// allowing the user to provide user configuration that is merged on top.
-func (m *Manager) configureIgnition(conf *image.Configuration, output Output, k8sScript, k8sConfScript string, ext []api.SystemdExtension) error {
+// it builds a CPIO file containing the Ignition configuration at /usr/lib/ignition/base.d, then the CPIO file
+// is used as an initrd extension allowing the user to provide additional user configuration to be merged on top.
+func (m *Manager) configureSystem(ctx context.Context, conf *image.Configuration, output Output, manifest *resolver.ResolvedManifest, ext []api.SystemdExtension) error {
+	const (
+		variant = "fcos"
+		version = "1.6.0"
+	)
+	var butaneCfg butane.Config
+
+	butaneCfg.Variant = variant
+	butaneCfg.Version = version
+
+	k8sEnabled := isKubernetesEnabled(conf)
+
 	if len(conf.ButaneConfig) == 0 &&
-		k8sScript == "" &&
-		k8sConfScript == "" &&
+		!k8sEnabled &&
 		len(ext) == 0 {
 		m.system.Logger().Info("No ignition configuration required")
 		return nil
 	}
 
-	const (
-		variant = "fcos"
-		version = "1.6.0"
-	)
-	var config butane.Config
-
-	config.Variant = variant
-	config.Version = version
-
-	if k8sScript != "" {
-		initHostname := "*"
-		if len(conf.Kubernetes.Nodes) > 0 {
-			initNode, err := kubernetes.FindInitNode(conf.Kubernetes.Nodes)
-			if err != nil {
-				return err
-			}
-
-			if initNode != nil {
-				initHostname = initNode.Hostname
-			}
+	if k8sEnabled {
+		err := m.unpackKubernetesArtifacts(ctx, manifest, output)
+		if err != nil {
+			return fmt.Errorf("unpacking k8s: %w", err)
 		}
 
-		k8sResourcesUnit, err := generateK8sResourcesUnit(k8sScript, initHostname)
+		err = m.configureKubernetes(ctx, conf, manifest, &butaneCfg)
 		if err != nil {
 			return err
-		}
-
-		config.AddSystemdUnit(k8sResourcesUnitName, k8sResourcesUnit, true)
-	}
-
-	if k8sConfScript != "" {
-		err := appendRke2Configuration(m.system, &config, &conf.Kubernetes, k8sConfScript)
-		if err != nil {
-			return fmt.Errorf("failed appending rke2 configuration: %w", err)
 		}
 	}
 
@@ -128,17 +96,14 @@ func (m *Manager) configureIgnition(conf *image.Configuration, output Output, k8
 			return fmt.Errorf("serializing extensions: %w", err)
 		}
 
-		config.Storage.Files = append(config.Storage.Files, v0_6.File{
-			Path:     extensions.File,
-			Contents: v0_6.Resource{Inline: util.StrToPtr(data)},
-		})
+		butaneCfg.AddFileInline(extensions.File, &data, 0o644)
 
-		config.AddSystemdUnit(ensureSysextUnitName, ensureSysextUnit, true)
-		config.AddSystemdUnit(reloadKernelModulesUnitName, reloadKernelModulesUnit, true)
-		config.AddSystemdUnit(updateLinkerCacheUnitName, updateLinkerCacheUnit, true)
+		butaneCfg.AddSystemdUnit(ensureSysextUnitName, ensureSysextUnit, true)
+		butaneCfg.AddSystemdUnit(reloadKernelModulesUnitName, reloadKernelModulesUnit, true)
+		butaneCfg.AddSystemdUnit(updateLinkerCacheUnitName, updateLinkerCacheUnit, true)
 	}
 
-	return m.writeBaseIgnitionConfig(output, config, conf.ButaneConfig)
+	return m.writeBaseIgnitionConfig(output, butaneCfg, conf.ButaneConfig)
 }
 
 // writeBaseIgnitionConfig renders the generated Ignition configuration including the user provided butane configuration
@@ -173,135 +138,4 @@ func (m *Manager) writeBaseIgnitionConfig(output Output, config butane.Config, b
 	}
 
 	return cpio.CreateCPIO(context.Background(), m.system, tmpDir, output.InitrdExtensionFile())
-}
-
-func generateK8sResourcesUnit(deployScript, initHostname string) (string, error) {
-	values := struct {
-		KubernetesDir        string
-		ManifestDeployScript string
-		InitHostname         string
-	}{
-		KubernetesDir:        filepath.Dir(deployScript),
-		ManifestDeployScript: deployScript,
-		InitHostname:         initHostname,
-	}
-
-	data, err := template.Parse(k8sResourcesUnitName, k8sResourceUnitTpl, &values)
-	if err != nil {
-		return "", fmt.Errorf("parsing config script template: %w", err)
-	}
-	return data, nil
-}
-
-func generateK8sConfigUnit(deployScript string) (string, error) {
-	values := struct {
-		ConfigDeployScript string
-	}{
-		ConfigDeployScript: deployScript,
-	}
-
-	data, err := template.Parse(k8sConfigUnitName, k8sConfigUnitTpl, &values)
-	if err != nil {
-		return "", fmt.Errorf("parsing config script template: %w", err)
-	}
-	return data, nil
-}
-
-func kubernetesVIPManifest(k *kubernetes.Kubernetes) (string, error) {
-	vars := struct {
-		APIAddress4 string
-		APIAddress6 string
-	}{
-		APIAddress4: k.Network.APIVIP4,
-		APIAddress6: k.Network.APIVIP6,
-	}
-
-	return template.Parse("k8s-vip", k8sVIPManifestTpl, &vars)
-}
-
-func appendRke2Configuration(s *sys.System, config *butane.Config, k *kubernetes.Kubernetes, configScript string) error {
-	c, err := kubernetes.NewCluster(s, k)
-	if err != nil {
-		return fmt.Errorf("failed parsing cluster: %w", err)
-	}
-
-	k8sConfigUnit, err := generateK8sConfigUnit(configScript)
-	if err != nil {
-		return fmt.Errorf("failed generating k8s config unit: %w", err)
-	}
-
-	config.AddSystemdUnit(k8sConfigUnitName, k8sConfigUnit, true)
-
-	k8sPath := filepath.Join("/", image.KubernetesPath())
-
-	serverBytes, err := marshalConfig(c.ServerConfig)
-	if err != nil {
-		return fmt.Errorf("failed marshaling server config: %w", err)
-	}
-
-	config.Storage.Files = append(config.Storage.Files, v0_6.File{
-		Path:     filepath.Join(k8sPath, "server.yaml"),
-		Contents: v0_6.Resource{Inline: util.StrToPtr(string(serverBytes))},
-	})
-
-	if c.InitServerConfig != nil {
-		initServerBytes, err := marshalConfig(c.InitServerConfig)
-		if err != nil {
-			return fmt.Errorf("failed marshaling init-server config: %w", err)
-		}
-
-		config.Storage.Files = append(config.Storage.Files, v0_6.File{
-			Path:     filepath.Join(k8sPath, "init.yaml"),
-			Contents: v0_6.Resource{Inline: util.StrToPtr(string(initServerBytes))},
-		})
-	}
-
-	if c.AgentConfig != nil {
-		agentBytes, err := marshalConfig(c.AgentConfig)
-		if err != nil {
-			return fmt.Errorf("failed marshaling agent config: %w", err)
-		}
-
-		config.Storage.Files = append(config.Storage.Files, v0_6.File{
-			Path:     filepath.Join(k8sPath, "agent.yaml"),
-			Contents: v0_6.Resource{Inline: util.StrToPtr(string(agentBytes))},
-		})
-	}
-
-	if c.RegistriesConfig != nil {
-		registriesBytes, err := marshalConfig(c.RegistriesConfig)
-		if err != nil {
-			return fmt.Errorf("failed marshaling agent config: %w", err)
-		}
-
-		config.Storage.Files = append(config.Storage.Files, v0_6.File{
-			Path:     filepath.Join(k8sPath, "registries.yaml"),
-			Contents: v0_6.Resource{Inline: util.StrToPtr(string(registriesBytes))},
-		})
-	}
-
-	if k.Network.APIVIP4 != "" || k.Network.APIVIP6 != "" {
-		manifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
-
-		vip, err := kubernetesVIPManifest(k)
-		if err != nil {
-			return fmt.Errorf("failed marshaling agent config: %w", err)
-		}
-
-		config.Storage.Files = append(config.Storage.Files, v0_6.File{
-			Path:     filepath.Join(manifestsPath, "k8s-vip.yaml"),
-			Contents: v0_6.Resource{Inline: util.StrToPtr(string(vip))},
-		})
-	}
-
-	return nil
-}
-
-func marshalConfig(config map[string]any) ([]byte, error) {
-	data, err := yaml.Marshal(config)
-	if err != nil {
-		return nil, fmt.Errorf("serializing kubernetes config: %w", err)
-	}
-
-	return data, nil
 }

--- a/internal/config/ignition_test.go
+++ b/internal/config/ignition_test.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,8 +28,11 @@ import (
 	v0 "github.com/suse/elemental/v3/internal/config/v0"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
+	"github.com/suse/elemental/v3/internal/image/release"
 	"github.com/suse/elemental/v3/pkg/log"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
+	"github.com/suse/elemental/v3/pkg/manifest/api/core"
+	"github.com/suse/elemental/v3/pkg/manifest/resolver"
 	"github.com/suse/elemental/v3/pkg/sys"
 	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
@@ -45,8 +49,10 @@ var _ = Describe("Ignition configuration", func() {
 	var err error
 	var m *Manager
 	var buffer *bytes.Buffer
+	var ctx context.Context
 
 	BeforeEach(func() {
+		ctx = context.Background()
 		buffer = &bytes.Buffer{}
 		fs, cleanup, err = sysmock.TestFS(map[string]any{
 			"/etc/kubernetes/config/server.yaml":     "",
@@ -62,7 +68,12 @@ var _ = Describe("Ignition configuration", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		m = NewManager(system, nil)
+		m = NewManager(system, nil,
+			WithUnpackFunc(func(ctx context.Context, imageRef, destDir string) error {
+				installSh := filepath.Join(destDir, "install.sh")
+				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+			}),
+		)
 	})
 
 	AfterEach(func() {
@@ -74,7 +85,7 @@ var _ = Describe("Ignition configuration", func() {
 
 		ignitionFile := filepath.Join(output.FirstbootConfigDir(), image.IgnitionFilePath())
 
-		Expect(m.configureIgnition(conf, output, "", "", nil)).To(Succeed())
+		Expect(m.configureSystem(ctx, conf, output, nil, nil)).To(Succeed())
 		ok, err := vfs.Exists(system.FS(), ignitionFile)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeFalse())
@@ -100,7 +111,7 @@ passwd:
 
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(m.configureIgnition(conf, output, "", "", nil)).To(Succeed())
+		Expect(m.configureSystem(ctx, conf, output, nil, nil)).To(Succeed())
 		ok, err := vfs.Exists(system.FS(), output.InitrdExtensionFile())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeTrue())
@@ -112,6 +123,11 @@ passwd:
 	It("Configures kubernetes via Ignition with the given k8s script", func() {
 		// includes registries configuration
 		conf := &image.Configuration{
+			Release: release.Release{
+				Components: release.Components{
+					Kubernetes: &struct{}{},
+				},
+			},
 			Kubernetes: kubernetes.Kubernetes{
 				Config: kubernetes.Config{
 					RegistriesFilePath: "/etc/kubernetes/config/registries.yaml",
@@ -119,18 +135,25 @@ passwd:
 			},
 		}
 
-		k8sScript := filepath.Join(output.OverlaysDir(), "path/to/k8s/script.sh")
-		k8sConfScript := filepath.Join(output.OverlaysDir(), "path/to/k8s/conf_script.sh")
+		rm := &resolver.ResolvedManifest{
+			CorePlatform: &core.ReleaseManifest{
+				Components: core.Components{
+					Kubernetes: &core.Kubernetes{},
+				},
+			},
+		}
 
-		Expect(m.configureIgnition(conf, output, k8sScript, k8sConfScript, nil)).To(Succeed())
+		Expect(m.configureSystem(ctx, conf, output, rm, nil)).To(Succeed())
 		ok, err := vfs.Exists(system.FS(), output.InitrdExtensionFile())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeTrue())
 		ignition, err := system.FS().ReadFile(output.InitrdExtensionFile())
 		Expect(err).NotTo(HaveOccurred())
+
+		// No butane.yaml, manifests or helm charts only the registries.yaml and k8s
 		Expect(ignition).NotTo(ContainSubstring("merge"))
 		Expect(ignition).NotTo(ContainSubstring("/etc/elemental/extensions.yaml"))
-		Expect(ignition).To(ContainSubstring("Kubernetes Resources Installer"))
+		Expect(ignition).NotTo(ContainSubstring("Kubernetes Resources Installer"))
 		Expect(ignition).To(ContainSubstring("Kubernetes Installation and Configuration"))
 		Expect(ignition).To(ContainSubstring("/var/lib/elemental/kubernetes/registries.yaml"))
 	})
@@ -139,7 +162,7 @@ passwd:
 		conf := &image.Configuration{}
 		ext := []api.SystemdExtension{{Name: "ext1", Image: "ext1-image"}}
 
-		Expect(m.configureIgnition(conf, output, "", "", ext)).To(Succeed())
+		Expect(m.configureSystem(ctx, conf, output, nil, ext)).To(Succeed())
 
 		ok, err := vfs.Exists(system.FS(), output.InitrdExtensionFile())
 		Expect(err).NotTo(HaveOccurred())
@@ -170,15 +193,12 @@ passwd:
     ssh_authorized_keys:
     - key1
 `
-		k8sScript := filepath.Join(output.OverlaysDir(), "path/to/k8s/script.sh")
-		k8sConfScript := filepath.Join(output.OverlaysDir(), "path/to/k8s/conf_script.sh")
-
 		Expect(v0.ParseAny([]byte(butaneConfigString), &butane)).To(Succeed())
 		conf := &image.Configuration{
 			ButaneConfig: butane,
 		}
 
-		Expect(m.configureIgnition(conf, output, k8sScript, k8sConfScript, nil)).To(MatchError(
+		Expect(m.configureSystem(ctx, conf, output, nil, nil)).To(MatchError(
 			ContainSubstring("No translator exists for variant unknown with version"),
 		))
 		ok, err := vfs.Exists(system.FS(), output.InitrdExtensionFile())
@@ -202,7 +222,7 @@ passwd:
 			ButaneConfig: butane,
 		}
 
-		Expect(m.configureIgnition(conf, output, "", "", nil)).To(Succeed())
+		Expect(m.configureSystem(ctx, conf, output, nil, nil)).To(Succeed())
 
 		// Igntion files are generated inside the CPIO extension
 		cpioContent, err := system.FS().ReadFile(output.InitrdExtensionFile())

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -23,26 +23,44 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"go.yaml.in/yaml/v3"
+
+	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
 	"github.com/suse/elemental/v3/internal/template"
 	"github.com/suse/elemental/v3/pkg/manifest/resolver"
+	"github.com/suse/elemental/v3/pkg/sys"
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
 const (
 	k8sResDeployScriptName  = "k8s_res_deploy.sh"
 	k8sConfDeployScriptName = "k8s_conf_deploy.sh"
+	k8sResourcesUnitName    = "k8s-resource-installer.service"
+	k8sConfigUnitName       = "k8s-config-installer.service"
+	k8sInstallSh            = "install.sh"
 )
 
-//go:embed templates/k8s_res_deploy.sh.tpl
-var k8sResDeployScriptTpl string
+var (
+	//go:embed templates/k8s-resource-installer.service.tpl
+	k8sResourceUnitTpl string
 
-//go:embed templates/k8s_conf_deploy.sh.tpl
-var k8sConfDeployScriptTpl string
+	//go:embed templates/k8s-config-installer.service.tpl
+	k8sConfigUnitTpl string
 
-func needsManifestsSetup(conf *image.Configuration, additionalManifests map[string][]byte) bool {
-	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsHA() || additionalManifests != nil
+	//go:embed templates/k8s-vip.yaml.tpl
+	k8sVIPManifestTpl string
+
+	//go:embed templates/k8s_res_deploy.sh.tpl
+	k8sResDeployScriptTpl string
+
+	//go:embed templates/k8s_conf_deploy.sh.tpl
+	k8sConfDeployScriptTpl string
+)
+
+func needsManifestsSetup(conf *image.Configuration) bool {
+	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsHA()
 }
 
 func needsHelmChartsSetup(conf *image.Configuration) bool {
@@ -50,100 +68,103 @@ func needsHelmChartsSetup(conf *image.Configuration) bool {
 }
 
 func isKubernetesEnabled(conf *image.Configuration) bool {
-	return conf.Release.Components.Kubernetes != nil || needsHelmChartsSetup(conf) || needsManifestsSetup(conf, nil)
+	return conf.Release.Components.Kubernetes != nil || needsHelmChartsSetup(conf) || needsManifestsSetup(conf)
 }
 
 func (m *Manager) configureKubernetes(
 	ctx context.Context,
 	conf *image.Configuration,
 	manifest *resolver.ResolvedManifest,
-	output Output,
-) (k8sResourceScript, k8sConfScript string, err error) {
-	if !isKubernetesEnabled(conf) {
-		m.system.Logger().Info("Kubernetes is not enabled, skipping configuration")
-		return "", "", nil
-	} else if manifest.CorePlatform.Components.Kubernetes == nil {
+	butaneCfg *butane.Config,
+) (err error) {
+	if manifest == nil ||
+		manifest.CorePlatform == nil ||
+		manifest.CorePlatform.Components.Kubernetes == nil {
 		m.system.Logger().Error("Kubernetes is enabled, but not part of the release")
-		return "", "", fmt.Errorf("kubernetes release not found")
+		return fmt.Errorf("kubernetes release not found")
 	}
 
 	var runtimeHelmCharts []string
-	var additionalManifests map[string][]byte
+
 	if needsHelmChartsSetup(conf) {
 		m.system.Logger().Info("Configuring Helm charts")
 
-		runtimeHelmCharts, additionalManifests, err = m.helm.Configure(conf, manifest)
+		runtimeHelmCharts, err = m.helm.Configure(conf, manifest, butaneCfg)
 		if err != nil {
-			return "", "", fmt.Errorf("configuring helm charts: %w", err)
+			return fmt.Errorf("configuring helm charts: %w", err)
 		}
 	}
 
 	var runtimeManifestsDir string
-	if needsManifestsSetup(conf, additionalManifests) {
+	if needsManifestsSetup(conf) {
 		m.system.Logger().Info("Configuring Kubernetes manifests")
 
-		runtimeManifestsDir, err = m.setupManifests(ctx, &conf.Kubernetes, additionalManifests, output)
+		runtimeManifestsDir, err = m.setupManifests(ctx, &conf.Kubernetes, butaneCfg)
 		if err != nil {
-			return "", "", fmt.Errorf("configuring kubernetes manifests: %w", err)
+			return fmt.Errorf("configuring kubernetes manifests: %w", err)
 		}
 	}
 
 	if len(runtimeHelmCharts) > 0 || runtimeManifestsDir != "" {
-		k8sResourceScript, err = writeK8sResDeployScript(m.system.FS(), output, runtimeManifestsDir, runtimeHelmCharts)
+		err = appendK8sResDeployScript(butaneCfg, runtimeManifestsDir, runtimeHelmCharts)
 		if err != nil {
-			return "", "", fmt.Errorf("writing kubernetes resource deployment script: %w", err)
+			return fmt.Errorf("generating kubernetes resource deployment script: %w", err)
+		}
+
+		err = appendK8sResUnit(conf, butaneCfg)
+		if err != nil {
+			return fmt.Errorf("generating kubernetes resource deployment unit: %w", err)
 		}
 	}
 
-	artifactsDir, installScript, err := m.unpackKubernetesArtifacts(ctx, manifest, output)
+	err = appendK8sConfigDeployScript(butaneCfg, conf.Kubernetes)
 	if err != nil {
-		return "", "", fmt.Errorf("unpacking kubernetes artifacts: %w", err)
+		return fmt.Errorf("generating kubernetes config deployment script: %w", err)
 	}
 
-	k8sConfScript, err = writeK8sConfigDeployScript(m.system.FS(), output, conf.Kubernetes, artifactsDir, installScript)
+	err = appendRke2Configuration(m.system, butaneCfg, &conf.Kubernetes)
 	if err != nil {
-		return "", "", fmt.Errorf("writing kubernetes config deployment script: %w", err)
+		return fmt.Errorf("generating RKE2 configuration: %w", err)
 	}
 
-	return k8sResourceScript, k8sConfScript, nil
+	return nil
 }
 
-func (m *Manager) setupManifests(ctx context.Context, k *kubernetes.Kubernetes, additionalManifests map[string][]byte, output Output) (string, error) {
+func (m *Manager) setupManifests(ctx context.Context, k *kubernetes.Kubernetes, butaneCfg *butane.Config) (string, error) {
 	fs := m.system.FS()
 
 	relativeManifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
-	manifestsDir := filepath.Join(output.OverlaysDir(), relativeManifestsPath)
-
-	if err := vfs.MkdirAll(fs, manifestsDir, vfs.DirPerm); err != nil {
-		return "", fmt.Errorf("setting up manifests directory '%s': %w", manifestsDir, err)
-	}
 
 	for _, manifest := range k.RemoteManifests {
-		path := filepath.Join(manifestsDir, filepath.Base(manifest))
+		targetPath := filepath.Join(relativeManifestsPath, filepath.Base(manifest))
 
-		if err := m.downloadFile(ctx, fs, manifest, path); err != nil {
+		rc, err := m.downloader.URLBody(ctx, manifest)
+		if err != nil {
 			return "", fmt.Errorf("downloading remote Kubernetes manifest '%s': %w", manifest, err)
+		}
+
+		err = butaneCfg.AddFileInlineFromReader(targetPath, rc, 0o644)
+		if err != nil {
+			return "", fmt.Errorf("reading contents for manifest %q: %w", manifest, err)
 		}
 	}
 
 	for _, manifest := range k.LocalManifests {
-		overlayPath := filepath.Join(manifestsDir, filepath.Base(manifest))
-		if err := vfs.CopyFile(fs, manifest, overlayPath); err != nil {
-			return "", fmt.Errorf("copying local manifest '%s' to '%s': %w", manifest, overlayPath, err)
+		targetPath := filepath.Join(relativeManifestsPath, filepath.Base(manifest))
+		mfst, err := fs.Open(manifest)
+		if err != nil {
+			return "", fmt.Errorf("opening local manifest %q: %w", manifest, err)
 		}
-	}
-
-	for name, manifest := range additionalManifests {
-		secretPath := filepath.Join(manifestsDir, filepath.Base(name))
-		if err := fs.WriteFile(secretPath, manifest, 0o644); err != nil {
-			return "", fmt.Errorf("writing secret %q: %w", secretPath, err)
+		err = butaneCfg.AddFileInlineFromReader(targetPath, mfst, 0o644)
+		if err != nil {
+			return "", fmt.Errorf("reading local manifest %q: %w", manifest, err)
 		}
 	}
 
 	return relativeManifestsPath, nil
 }
 
-func writeK8sResDeployScript(fs vfs.FS, output Output, runtimeManifestsDir string, runtimeHelmCharts []string) (string, error) {
+func appendK8sResDeployScript(butaneCfg *butane.Config, runtimeManifestsDir string, runtimeHelmCharts []string) error {
 	values := struct {
 		HelmCharts   []string
 		ManifestsDir string
@@ -154,28 +175,41 @@ func writeK8sResDeployScript(fs vfs.FS, output Output, runtimeManifestsDir strin
 
 	data, err := template.Parse(k8sResDeployScriptName, k8sResDeployScriptTpl, &values)
 	if err != nil {
-		return "", fmt.Errorf("parsing deployment template: %w", err)
+		return fmt.Errorf("parsing deployment template: %w", err)
 	}
 
-	relativeK8sPath := filepath.Join("/", image.KubernetesPath())
-	destDir := filepath.Join(output.OverlaysDir(), relativeK8sPath)
-
-	if err = vfs.MkdirAll(fs, destDir, vfs.DirPerm); err != nil {
-		return "", fmt.Errorf("creating destination directory: %w", err)
-	}
-
-	fullPath := filepath.Join(destDir, k8sResDeployScriptName)
-	relativePath := filepath.Join(relativeK8sPath, k8sResDeployScriptName)
-
-	if err = fs.WriteFile(fullPath, []byte(data), 0o744); err != nil {
-		return "", fmt.Errorf("writing deployment script %q: %w", fullPath, err)
-	}
-
-	return relativePath, nil
+	relativePath := filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName)
+	butaneCfg.AddFileInline(relativePath, &data, 0o744)
+	return nil
 }
 
-func writeK8sConfigDeployScript(fs vfs.FS, output Output, k kubernetes.Kubernetes, artifactsDir, installScript string) (string, error) {
+func appendK8sResUnit(conf *image.Configuration, butaneCfg *butane.Config) error {
+	k8sScript := filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName)
+	initHostname := "*"
+
+	if len(conf.Kubernetes.Nodes) > 0 {
+		initNode, err := kubernetes.FindInitNode(conf.Kubernetes.Nodes)
+		if err != nil {
+			return err
+		}
+
+		if initNode != nil {
+			initHostname = initNode.Hostname
+		}
+	}
+
+	k8sResourcesUnit, err := generateK8sResourcesUnit(k8sScript, initHostname)
+	if err != nil {
+		return err
+	}
+
+	butaneCfg.AddSystemdUnit(k8sResourcesUnitName, k8sResourcesUnit, true)
+	return nil
+}
+
+func appendK8sConfigDeployScript(butaneCfg *butane.Config, k kubernetes.Kubernetes) error {
 	relativeK8sPath := filepath.Join("/", image.KubernetesPath())
+	k8sInstallPath := filepath.Join("/", image.KubernetesInstallPath())
 
 	var (
 		initNode *kubernetes.Node
@@ -185,7 +219,7 @@ func writeK8sConfigDeployScript(fs vfs.FS, output Output, k kubernetes.Kubernete
 	if len(k.Nodes) > 1 {
 		initNode, err = kubernetes.FindInitNode(k.Nodes)
 		if err != nil {
-			return "", fmt.Errorf("finding init node: %w", err)
+			return fmt.Errorf("finding init node: %w", err)
 		}
 	}
 
@@ -205,8 +239,8 @@ func writeK8sConfigDeployScript(fs vfs.FS, output Output, k kubernetes.Kubernete
 		APIHost:       k.Network.APIHost,
 		KubernetesDir: relativeK8sPath,
 		InitNode:      kubernetes.Node{},
-		InstallPath:   artifactsDir,
-		InstallScript: installScript,
+		InstallPath:   k8sInstallPath,
+		InstallScript: filepath.Join(k8sInstallPath, k8sInstallSh),
 	}
 
 	if initNode != nil {
@@ -215,50 +249,153 @@ func writeK8sConfigDeployScript(fs vfs.FS, output Output, k kubernetes.Kubernete
 
 	data, err := template.Parse(k8sConfDeployScriptName, k8sConfDeployScriptTpl, &values)
 	if err != nil {
-		return "", fmt.Errorf("parsing deployment template: %w", err)
+		return fmt.Errorf("parsing deployment template: %w", err)
 	}
 
-	destDir := filepath.Join(output.OverlaysDir(), relativeK8sPath)
-
-	if err = vfs.MkdirAll(fs, destDir, vfs.DirPerm); err != nil {
-		return "", fmt.Errorf("creating destination directory: %w", err)
-	}
-
-	fullPath := filepath.Join(destDir, k8sConfDeployScriptName)
 	relativePath := filepath.Join(relativeK8sPath, k8sConfDeployScriptName)
+	butaneCfg.AddFileInline(relativePath, &data, 0o744)
+	return nil
+}
 
-	if err = fs.WriteFile(fullPath, []byte(data), 0o744); err != nil {
-		return "", fmt.Errorf("writing deployment script %q: %w", fullPath, err)
+func generateK8sResourcesUnit(deployScript, initHostname string) (string, error) {
+	values := struct {
+		KubernetesDir        string
+		ManifestDeployScript string
+		InitHostname         string
+	}{
+		KubernetesDir:        filepath.Dir(deployScript),
+		ManifestDeployScript: deployScript,
+		InitHostname:         initHostname,
 	}
 
-	return relativePath, nil
+	data, err := template.Parse(k8sResourcesUnitName, k8sResourceUnitTpl, &values)
+	if err != nil {
+		return "", fmt.Errorf("parsing resources unit template: %w", err)
+	}
+	return data, nil
+}
+
+func generateK8sConfigUnit(deployScript string) (string, error) {
+	values := struct {
+		ConfigDeployScript string
+	}{
+		ConfigDeployScript: deployScript,
+	}
+
+	data, err := template.Parse(k8sConfigUnitName, k8sConfigUnitTpl, &values)
+	if err != nil {
+		return "", fmt.Errorf("parsing config unit template: %w", err)
+	}
+	return data, nil
+}
+
+func kubernetesVIPManifest(k *kubernetes.Kubernetes) (string, error) {
+	vars := struct {
+		APIAddress4 string
+		APIAddress6 string
+	}{
+		APIAddress4: k.Network.APIVIP4,
+		APIAddress6: k.Network.APIVIP6,
+	}
+
+	return template.Parse("k8s-vip", k8sVIPManifestTpl, &vars)
+}
+
+func appendRke2Configuration(s *sys.System, butaneCfg *butane.Config, k *kubernetes.Kubernetes) error {
+	configScript := filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName)
+
+	c, err := kubernetes.NewCluster(s, k)
+	if err != nil {
+		return fmt.Errorf("failed parsing cluster: %w", err)
+	}
+
+	k8sConfigUnit, err := generateK8sConfigUnit(configScript)
+	if err != nil {
+		return fmt.Errorf("failed generating k8s config unit: %w", err)
+	}
+
+	butaneCfg.AddSystemdUnit(k8sConfigUnitName, k8sConfigUnit, true)
+
+	k8sPath := filepath.Join("/", image.KubernetesPath())
+
+	serverBytes, err := marshalConfig(c.ServerConfig)
+	if err != nil {
+		return fmt.Errorf("failed marshaling server config: %w", err)
+	}
+
+	butaneCfg.AddFileInline(filepath.Join(k8sPath, "server.yaml"), new(string(serverBytes)), 0o644)
+
+	if c.InitServerConfig != nil {
+		initServerBytes, err := marshalConfig(c.InitServerConfig)
+		if err != nil {
+			return fmt.Errorf("failed marshaling init-server config: %w", err)
+		}
+
+		butaneCfg.AddFileInline(filepath.Join(k8sPath, "init.yaml"), new(string(initServerBytes)), 0o644)
+	}
+
+	if c.AgentConfig != nil {
+		agentBytes, err := marshalConfig(c.AgentConfig)
+		if err != nil {
+			return fmt.Errorf("failed marshaling agent config: %w", err)
+		}
+
+		butaneCfg.AddFileInline(filepath.Join(k8sPath, "agent.yaml"), new(string(agentBytes)), 0o644)
+	}
+
+	if c.RegistriesConfig != nil {
+		registriesBytes, err := marshalConfig(c.RegistriesConfig)
+		if err != nil {
+			return fmt.Errorf("failed marshaling agent config: %w", err)
+		}
+
+		butaneCfg.AddFileInline(filepath.Join(k8sPath, "registries.yaml"), new(string(registriesBytes)), 0o644)
+	}
+
+	if k.Network.APIVIP4 != "" || k.Network.APIVIP6 != "" {
+		manifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
+
+		vip, err := kubernetesVIPManifest(k)
+		if err != nil {
+			return fmt.Errorf("failed marshaling agent config: %w", err)
+		}
+
+		butaneCfg.AddFileInline(filepath.Join(manifestsPath, "k8s-vip.yaml"), new(string(vip)), 0o644)
+	}
+
+	return nil
+}
+
+func marshalConfig(config map[string]any) ([]byte, error) {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("serializing kubernetes config: %w", err)
+	}
+
+	return data, nil
 }
 
 // unpackKubernetesArtifacts extracts Kubernetes distribution artifacts from an OCI image for installation at firstboot.
-func (m *Manager) unpackKubernetesArtifacts(ctx context.Context, manifest *resolver.ResolvedManifest, output Output) (artifactsDir, installScript string, err error) {
-	const k8sInstallSh = "install.sh"
-
+func (m *Manager) unpackKubernetesArtifacts(ctx context.Context, manifest *resolver.ResolvedManifest, output Output) error {
 	k8s := manifest.CorePlatform.Components.Kubernetes
 	fs := m.system.FS()
 
-	artifactsDir = filepath.Join("/", image.KubernetesInstallPath())
-	overlaysDir := filepath.Join(output.OverlaysDir(), artifactsDir)
+	overlaysDir := filepath.Join(output.OverlaysDir(), image.KubernetesInstallPath())
+	installScript := filepath.Join(overlaysDir, k8sInstallSh)
 
-	installScript = filepath.Join(artifactsDir, k8sInstallSh)
-
-	if err = vfs.MkdirAll(fs, overlaysDir, 0755); err != nil {
-		return "", "", fmt.Errorf("creating kubernetes artifacts directory: %w", err)
+	if err := vfs.MkdirAll(fs, overlaysDir, vfs.DirPerm); err != nil {
+		return fmt.Errorf("creating kubernetes artifacts directory: %w", err)
 	}
 
 	m.system.Logger().Info("Extracting Kubernetes artifacts from OCI image: %s", k8s.Image)
-	if err = m.unpackImage(ctx, k8s.Image, overlaysDir); err != nil {
-		return "", "", err
+	if err := m.unpackImage(ctx, k8s.Image, overlaysDir); err != nil {
+		return err
 	}
 
-	exists, _ := vfs.Exists(fs, filepath.Join(output.OverlaysDir(), installScript))
+	exists, _ := vfs.Exists(fs, installScript)
 	if !exists {
-		return "", "", fmt.Errorf("kubernetes install script %q not found", installScript)
+		return fmt.Errorf("kubernetes install script %q not found", installScript)
 	}
 
-	return artifactsDir, installScript, nil
+	return nil
 }

--- a/internal/config/kubernetes_test.go
+++ b/internal/config/kubernetes_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/auth"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
@@ -32,16 +33,13 @@ import (
 	"github.com/suse/elemental/v3/pkg/manifest/api/core"
 	"github.com/suse/elemental/v3/pkg/manifest/resolver"
 	"github.com/suse/elemental/v3/pkg/sys"
-	sysmock "github.com/suse/elemental/v3/pkg/sys/mock"
-	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
 var _ = Describe("Kubernetes", func() {
 	Describe("Resources trigger", func() {
 		It("Skips manifests setup if manifests are not provided", func() {
 			conf := &image.Configuration{}
-			var additionalManifests map[string][]byte
-			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeFalse())
+			Expect(needsManifestsSetup(conf)).To(BeFalse())
 		})
 
 		It("Requires manifests setup if local manifests are provided", func() {
@@ -50,15 +48,7 @@ var _ = Describe("Kubernetes", func() {
 					LocalManifests: []string{"/apache.yaml"},
 				},
 			}
-			var additionalManifests map[string][]byte
-			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeTrue())
-		})
-
-		It("Requires manifests setup if there are runtime secrets", func() {
-			conf := &image.Configuration{}
-			additionalManifests := make(map[string][]byte)
-			additionalManifests["example"] = []byte("test")
-			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeTrue())
+			Expect(needsManifestsSetup(conf)).To(BeTrue())
 		})
 
 		It("Requires manifests setup if remote manifests are provided", func() {
@@ -67,8 +57,7 @@ var _ = Describe("Kubernetes", func() {
 					RemoteManifests: []string{"https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml"},
 				},
 			}
-			var additionalManifests map[string][]byte
-			Expect(needsManifestsSetup(conf, additionalManifests)).To(BeTrue())
+			Expect(needsManifestsSetup(conf)).To(BeTrue())
 		})
 
 		It("Skips Helm setup if charts are not provided", func() {
@@ -123,52 +112,34 @@ var _ = Describe("Kubernetes", func() {
 	})
 
 	Describe("Configuration", func() {
-		var output = Output{
-			RootPath: "/_out",
-		}
-
 		var system *sys.System
-		var fs vfs.FS
-		var cleanup func()
 		var err error
+		var config *butane.Config
 
 		BeforeEach(func() {
-			fs, cleanup, err = sysmock.TestFS(nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(vfs.MkdirAll(fs, output.RootPath, vfs.DirPerm)).To(Succeed())
+			config = &butane.Config{}
 
 			system, err = sys.NewSystem(
 				sys.WithLogger(log.New(log.WithDiscardAll())),
-				sys.WithFS(fs),
 			)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		AfterEach(func() {
-			cleanup()
-		})
-
 		It("Fails to configure Helm charts", func() {
 			helmMock := &helmConfiguratorMock{
-				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
-					return nil, nil, fmt.Errorf("helm error")
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest, _ *butane.Config) ([]string, error) {
+					return nil, fmt.Errorf("helm error")
 				},
 			}
 
-			dlFunc := func(ctx context.Context, fs vfs.FS, url, path string) error {
-				return nil
-			}
-
 			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				installSh := filepath.Join(destDir, "install.sh")
-				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+				return nil
 			}
 
 			m := NewManager(
 				system,
 				helmMock,
-				WithDownloadFunc(dlFunc),
+				WithDownloader(&downloaderMock{}),
 				WithUnpackFunc(unpackFunc),
 			)
 
@@ -194,69 +165,26 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			script, confScript, err := m.configureKubernetes(context.Background(), conf, manifest, output)
+			err := m.configureKubernetes(context.Background(), conf, manifest, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("configuring helm charts: helm error"))
-			Expect(script).To(BeEmpty())
-			Expect(confScript).To(BeEmpty())
-		})
-
-		It("Fails to unpack Kubernetes artifacts", func() {
-			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				return fmt.Errorf("unpacking error")
-			}
-
-			m := NewManager(
-				system,
-				nil,
-				WithUnpackFunc(unpackFunc),
-			)
-
-			manifest := &resolver.ResolvedManifest{
-				CorePlatform: &core.ReleaseManifest{
-					Components: core.Components{
-						Kubernetes: &core.Kubernetes{
-							Version: "v1.35.0+rke2r1",
-							Image:   "registry.example.com/rke2:1.35_1.0",
-						},
-					},
-				},
-			}
-			conf := &image.Configuration{
-				Release: release.Release{
-					Components: release.Components{
-						Kubernetes: &struct{}{},
-					},
-				},
-			}
-
-			script, confScript, err := m.configureKubernetes(context.Background(), conf, manifest, output)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError("unpacking kubernetes artifacts: unpacking error"))
-			Expect(script).To(BeEmpty())
-			Expect(confScript).To(BeEmpty())
 		})
 
 		It("Succeeds to configure RKE2 with additional resources", func() {
 			helmMock := &helmConfiguratorMock{
-				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
-					return []string{"rancher.yaml"}, nil, nil
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest, _ *butane.Config) ([]string, error) {
+					return []string{"rancher.yaml"}, nil
 				},
 			}
 
-			dlFunc := func(ctx context.Context, fs vfs.FS, url, path string) error {
-				return nil
-			}
-
 			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				installSh := filepath.Join(destDir, "install.sh")
-				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+				return nil
 			}
 
 			m := NewManager(
 				system,
 				helmMock,
-				WithDownloadFunc(dlFunc),
+				WithDownloader(&downloaderMock{}),
 				WithUnpackFunc(unpackFunc),
 			)
 
@@ -288,36 +216,31 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			script, confScript, err := m.configureKubernetes(context.Background(), conf, manifest, output)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(script).To(Equal("/var/lib/elemental/kubernetes/k8s_res_deploy.sh"))
+			Expect(m.configureKubernetes(context.Background(), conf, manifest, config)).To(Succeed())
 
 			// Verify deployment script contents
-			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), script))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(ContainSubstring("deployHelmCharts"))
-			Expect(string(b)).To(ContainSubstring("rancher.yaml"))
-			Expect(string(b)).To(ContainSubstring("deployManifests"))
-			Expect(string(b)).To(ContainSubstring("deployPriorityManifests"))
+			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName))
+			Expect(data).NotTo(BeNil())
 
-			_, err = fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(*data).To(ContainSubstring("deployHelmCharts"))
+			Expect(*data).To(ContainSubstring("rancher.yaml"))
+			Expect(*data).To(ContainSubstring("deployManifests"))
+			Expect(*data).To(ContainSubstring("deployPriorityManifests"))
+
+			// k8s configuration script is generated
+			Expect(findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))).NotTo(BeNil())
 		})
 
 		It("Succeeds to configure RKE2 without additional resources", func() {
-			dlFunc := func(ctx context.Context, fs vfs.FS, url, path string) error {
-				return nil
-			}
 
 			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				installSh := filepath.Join(destDir, "install.sh")
-				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+				return nil
 			}
 
 			m := NewManager(
 				system,
 				nil,
-				WithDownloadFunc(dlFunc),
+				WithDownloader(&downloaderMock{}),
 				WithUnpackFunc(unpackFunc),
 			)
 
@@ -339,80 +262,66 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			script, confScript, err := m.configureKubernetes(context.Background(), conf, manifest, output)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(script).To(BeEmpty())
-			Expect(confScript).ToNot(BeEmpty())
+			Expect(m.configureKubernetes(context.Background(), conf, manifest, config)).To(Succeed())
+
+			Expect(findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))).NotTo(BeNil())
 		})
 
 		It("Uses server config for a single explicitly configured server node", func() {
-			conf := kubernetes.Kubernetes{
+			k8s := kubernetes.Kubernetes{
 				Nodes: kubernetes.Nodes{
 					{Hostname: "node01", Type: kubernetes.NodeTypeServer},
 				},
 			}
 
-			confScript, err := writeK8sConfigDeployScript(
-				fs,
-				output,
-				conf,
-				"/opt/k8s/install",
-				"/opt/k8s/install/install.sh",
-			)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(appendK8sConfigDeployScript(config, k8s)).To(Succeed())
 
-			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(ContainSubstring(`CONFIGFILE="/var/lib/elemental/kubernetes/${NODETYPE}.yaml"`))
-			Expect(string(b)).ToNot(ContainSubstring("init.yaml"))
+			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
+			Expect(data).NotTo(BeNil())
+
+			Expect(*data).To(ContainSubstring(`CONFIGFILE="/var/lib/elemental/kubernetes/${NODETYPE}.yaml"`))
+			Expect(*data).ToNot(ContainSubstring("init.yaml"))
 		})
 
 		It("Uses init config only for multi-node clusters", func() {
-			conf := kubernetes.Kubernetes{
+			k8s := kubernetes.Kubernetes{
 				Nodes: kubernetes.Nodes{
 					{Hostname: "server01", Type: kubernetes.NodeTypeServer},
 					{Hostname: "agent01", Type: kubernetes.NodeTypeAgent},
 				},
 			}
 
-			confScript, err := writeK8sConfigDeployScript(
-				fs,
-				output,
-				conf,
-				"/opt/k8s/install",
-				"/opt/k8s/install/install.sh",
-			)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(appendK8sConfigDeployScript(config, k8s)).To(Succeed())
 
-			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(ContainSubstring(`if [[ "${HOSTNAME}" = "server01" ]]; then`))
-			Expect(string(b)).To(ContainSubstring("CONFIGFILE=/var/lib/elemental/kubernetes/init.yaml"))
+			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
+			Expect(data).NotTo(BeNil())
+
+			Expect(*data).To(ContainSubstring(`if [[ "${HOSTNAME}" = "server01" ]]; then`))
+			Expect(*data).To(ContainSubstring("CONFIGFILE=/var/lib/elemental/kubernetes/init.yaml"))
 		})
 
 		It("Succeeds to configure RKE2 with additional resources and auth", func() {
 			additionalManifests := make(map[string][]byte)
 			additionalManifests["example-auth-priority.yaml"] = []byte("apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: example-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLmlvIjp7InVzZXJuYW1lIjoiZXhhbXBsZS11c2VyIiwicGFzc3dvcmQiOiJleGFtcGxlLXBhc3MiLCJhdXRoIjoiWlhoaGJYQnNaUzExYzJWeU9tVjRZVzF3YkdVdGNHRnpjdz09In19fQ==\n")
 			additionalManifests["endpoint-copier-operator-auth-priority.yaml"] = []byte("apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: endpoint-copier-operator-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoiZWNvLXVzZXIiLCJwYXNzd29yZCI6ImVjby1wYXNzIiwiYXV0aCI6IlpXTnZMWFZ6WlhJNlpXTnZMWEJoYzNNPSJ9fX0=\n")
+
 			helmMock := &helmConfiguratorMock{
-				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
-					return []string{"rancher.yaml"}, additionalManifests, nil
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest, bc *butane.Config) ([]string, error) {
+					for k, v := range additionalManifests {
+						bc.AddFileInline(filepath.Join("/", image.KubernetesManifestsPath(), k), new(string(v)), 0o644)
+					}
+					return []string{"rancher.yaml"}, nil
 				},
 			}
 
-			dlFunc := func(ctx context.Context, fs vfs.FS, url, path string) error {
-				return nil
-			}
-
 			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				installSh := filepath.Join(destDir, "install.sh")
-				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+				return nil
 			}
 
 			m := NewManager(
 				system,
 				helmMock,
-				WithDownloadFunc(dlFunc),
+				WithDownloader(&downloaderMock{}),
 				WithUnpackFunc(unpackFunc),
 			)
 
@@ -471,20 +380,20 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			script, confScript, err := m.configureKubernetes(context.Background(), conf, manifest, output)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(script).To(Equal("/var/lib/elemental/kubernetes/k8s_res_deploy.sh"))
+			Expect(m.configureKubernetes(context.Background(), conf, manifest, config)).To(Succeed())
 
 			// Verify deployment script contents
-			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), script))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(ContainSubstring("deployHelmCharts"))
-			Expect(string(b)).To(ContainSubstring("rancher.yaml"))
-			Expect(string(b)).To(ContainSubstring("deployManifests"))
-			Expect(string(b)).To(ContainSubstring("deployPriorityManifests"))
+			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName))
+			Expect(data).NotTo(BeNil())
 
-			_, err = fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(*data).To(ContainSubstring("deployHelmCharts"))
+			Expect(*data).To(ContainSubstring("rancher.yaml"))
+			Expect(*data).To(ContainSubstring("deployManifests"))
+			Expect(*data).To(ContainSubstring("deployPriorityManifests"))
+
+			// Verify config script contents
+			data = findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
+			Expect(data).NotTo(BeNil())
 
 			expectedECOManifestContents := `apiVersion: v1
 kind: Secret
@@ -494,12 +403,10 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
     .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLTEuY29tIjp7InVzZXJuYW1lIjoiZWNvLXVzZXIiLCJwYXNzd29yZCI6ImVjby1wYXNzIiwiYXV0aCI6IlpXTnZMWFZ6WlhJNlpXTnZMWEJoYzNNPSJ9fX0=`
-			ecoSecretManifests := "endpoint-copier-operator-auth-priority.yaml"
-			relativeManifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
-			manifestsDir := filepath.Join(output.OverlaysDir(), relativeManifestsPath)
-			b, err = fs.ReadFile(filepath.Join(manifestsDir, ecoSecretManifests))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(ContainSubstring(expectedECOManifestContents))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.KubernetesManifestsPath(), "endpoint-copier-operator-auth-priority.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(ContainSubstring(expectedECOManifestContents))
 
 			expectedExampleManifestContents := `apiVersion: v1
 kind: Secret
@@ -509,10 +416,10 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
     .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLmlvIjp7InVzZXJuYW1lIjoiZXhhbXBsZS11c2VyIiwicGFzc3dvcmQiOiJleGFtcGxlLXBhc3MiLCJhdXRoIjoiWlhoaGJYQnNaUzExYzJWeU9tVjRZVzF3YkdVdGNHRnpjdz09In19fQ==`
-			exampleSecretManifests := "example-auth-priority.yaml"
-			b, err = fs.ReadFile(filepath.Join(manifestsDir, exampleSecretManifests))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(b)).To(ContainSubstring(expectedExampleManifestContents))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.KubernetesManifestsPath(), "example-auth-priority.yaml"))
+			Expect(data).NotTo(BeNil())
+			Expect(*data).To(ContainSubstring(expectedExampleManifestContents))
 		})
 	})
 })

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -20,8 +20,10 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 
+	"github.com/suse/elemental/v3/internal/butane"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/pkg/extractor"
 	"github.com/suse/elemental/v3/pkg/http"
@@ -32,25 +34,29 @@ import (
 	"github.com/suse/elemental/v3/pkg/unpack"
 )
 
-type downloadFunc func(ctx context.Context, fs vfs.FS, url, path string) error
 type unpackFunc func(ctx context.Context, imageRef, destDir string) error
 
 type helmConfigurator interface {
-	Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error)
+	Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest, bConfig *butane.Config) ([]string, error)
 }
 
 type releaseManifestResolver interface {
 	Resolve(uri string) (*resolver.ResolvedManifest, error)
 }
 
+type downloader interface {
+	URLBody(ctx context.Context, url string) (io.ReadCloser, error)
+	File(ctx context.Context, fs vfs.FS, url, path string) error
+}
+
 type Manager struct {
 	system *sys.System
 	local  bool
 
-	rmResolver   releaseManifestResolver
-	downloadFile downloadFunc
-	unpackImage  unpackFunc
-	helm         helmConfigurator
+	rmResolver  releaseManifestResolver
+	downloader  downloader
+	unpackImage unpackFunc
+	helm        helmConfigurator
 }
 
 type Opts func(m *Manager)
@@ -61,9 +67,9 @@ func WithManifestResolver(r releaseManifestResolver) Opts {
 	}
 }
 
-func WithDownloadFunc(d downloadFunc) Opts {
+func WithDownloader(d downloader) Opts {
 	return func(m *Manager) {
-		m.downloadFile = d
+		m.downloader = d
 	}
 }
 
@@ -89,8 +95,8 @@ func NewManager(sys *sys.System, helm helmConfigurator, opts ...Opts) *Manager {
 		o(m)
 	}
 
-	if m.downloadFile == nil {
-		m.downloadFile = http.DownloadFile
+	if m.downloader == nil {
+		m.downloader = &http.Downloader{}
 	}
 
 	if m.unpackImage == nil {
@@ -128,11 +134,6 @@ func (m *Manager) ConfigureComponents(ctx context.Context, conf *image.Configura
 		return nil, fmt.Errorf("configuring custom scripts: %w", err)
 	}
 
-	k8sScript, k8sConfScript, err := m.configureKubernetes(ctx, conf, rm, output)
-	if err != nil {
-		return nil, fmt.Errorf("configuring kubernetes: %w", err)
-	}
-
 	extensions, err := enabledExtensions(rm, conf, m.system.Logger())
 	if err != nil {
 		return nil, fmt.Errorf("filtering enabled systemd extensions: %w", err)
@@ -144,7 +145,7 @@ func (m *Manager) ConfigureComponents(ctx context.Context, conf *image.Configura
 		}
 	}
 
-	if err = m.configureIgnition(conf, output, k8sScript, k8sConfScript, extensions); err != nil {
+	if err = m.configureSystem(ctx, conf, output, rm, extensions); err != nil {
 		return nil, fmt.Errorf("configuring ignition: %w", err)
 	}
 

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -20,12 +20,14 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/suse/elemental/v3/internal/butane"
 	v0 "github.com/suse/elemental/v3/internal/config/v0"
 	"github.com/suse/elemental/v3/internal/image"
 	"github.com/suse/elemental/v3/internal/image/kubernetes"
@@ -46,15 +48,24 @@ func TestConfigurationSuite(t *testing.T) {
 }
 
 type helmConfiguratorMock struct {
-	configureFunc func(*image.Configuration, *resolver.ResolvedManifest) ([]string, map[string][]byte, error)
+	configureFunc func(*image.Configuration, *resolver.ResolvedManifest, *butane.Config) ([]string, error)
 }
 
-func (h *helmConfiguratorMock) Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+func (h *helmConfiguratorMock) Configure(conf *image.Configuration, manifest *resolver.ResolvedManifest, bConf *butane.Config) ([]string, error) {
 	if h.configureFunc != nil {
-		return h.configureFunc(conf, manifest)
+		return h.configureFunc(conf, manifest, bConf)
 	}
 
 	panic("not implemented")
+}
+
+func findFileContentsInConfig(config *butane.Config, name string) *string {
+	for _, f := range config.Storage.Files {
+		if f.Path == name {
+			return f.Contents.Inline
+		}
+	}
+	return nil
 }
 
 type resolverMock struct {
@@ -69,6 +80,43 @@ func (r *resolverMock) Resolve(uri string) (*resolver.ResolvedManifest, error) {
 	panic("not implemented")
 }
 
+type downloaderMock struct {
+	fileFunc    func(ctx context.Context, fs vfs.FS, url, path string) error
+	urlBodyFunc func(ctx context.Context, url string) (io.ReadCloser, error)
+}
+type rcloser struct {
+	readFunc  func(p []byte) (n int, err error)
+	closeFunc func() error
+}
+
+func (r rcloser) Close() error {
+	if r.closeFunc != nil {
+		return r.closeFunc()
+	}
+	return nil
+}
+
+func (r rcloser) Read(p []byte) (n int, err error) {
+	if r.readFunc != nil {
+		return r.readFunc(p)
+	}
+	return 0, io.EOF
+}
+
+func (d downloaderMock) File(ctx context.Context, fs vfs.FS, url, path string) error {
+	if d.fileFunc != nil {
+		return d.fileFunc(ctx, fs, url, path)
+	}
+	return nil
+}
+
+func (d downloaderMock) URLBody(ctx context.Context, url string) (io.ReadCloser, error) {
+	if d.urlBodyFunc != nil {
+		return d.urlBodyFunc(ctx, url)
+	}
+	return rcloser{}, nil
+}
+
 var _ = Describe("Manager", func() {
 	var output = Output{
 		RootPath: "/_out",
@@ -78,7 +126,7 @@ var _ = Describe("Manager", func() {
 	var cleanup func()
 	var err error
 	var system *sys.System
-	var defaultHelmFunc func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error)
+	var defaultHelmFunc func(c *image.Configuration, rm *resolver.ResolvedManifest, bc *butane.Config) ([]string, error)
 	var defaultResolveFunc func(uri string) (*resolver.ResolvedManifest, error)
 	var butaneConfigString = `
 version: 1.6.0
@@ -156,8 +204,8 @@ passwd:
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		defaultHelmFunc = func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
-			return nil, nil, nil
+		defaultHelmFunc = func(c *image.Configuration, rm *resolver.ResolvedManifest, bc *butane.Config) ([]string, error) {
+			return nil, nil
 		}
 
 		defaultResolveFunc = func(uri string) (*resolver.ResolvedManifest, error) {
@@ -176,18 +224,18 @@ passwd:
 	})
 
 	It("Successfully applies configurations to output directory", func() {
-		var butane map[string]any
-		Expect(v0.ParseAny([]byte(butaneConfigString), &butane)).To(Succeed())
+		var bConf map[string]any
+		Expect(v0.ParseAny([]byte(butaneConfigString), &bConf)).To(Succeed())
 
 		conf := activeConfig
-		conf.ButaneConfig = butane
+		conf.ButaneConfig = bConf
 
 		m := NewManager(
 			system,
-			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
+			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest, bc *butane.Config) ([]string, error) {
 				helmPath := filepath.Join(output.OverlaysDir(), image.HelmPath())
 				if err := vfs.MkdirAll(fs, helmPath, vfs.DirPerm); err != nil {
-					return nil, nil, err
+					return nil, err
 				}
 
 				files := []string{}
@@ -195,10 +243,10 @@ passwd:
 					files = append(files, chart.Name)
 					_, err := fs.Create(filepath.Join(helmPath, chart.Name))
 					if err != nil {
-						return nil, nil, err
+						return nil, err
 					}
 				}
-				return files, nil, nil
+				return files, nil
 			}},
 			WithManifestResolver(&resolverMock{resolveFunc: func(uri string) (*resolver.ResolvedManifest, error) {
 				if uri == activeConfig.Release.ManifestURI {
@@ -207,10 +255,11 @@ passwd:
 
 				panic("missing release manifest")
 			}}),
-			WithDownloadFunc(func(ctx context.Context, fs vfs.FS, url, path string) error {
-				_, err := fs.Create(filepath.Join(path))
-				return err
-			}),
+			WithDownloader(&downloaderMock{
+				fileFunc: func(_ context.Context, fs vfs.FS, _, path string) error {
+					_, err := fs.Create(filepath.Join(path))
+					return err
+				}}),
 			WithUnpackFunc(func(ctx context.Context, imageRef, destDir string) error {
 				installSh := filepath.Join(destDir, "install.sh")
 				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
@@ -227,9 +276,7 @@ passwd:
 		Expect(err).ToNot(HaveOccurred())
 		_, err = fs.Stat(filepath.Join(output.OverlaysDir(), image.KubernetesInstallPath(), "install.sh"))
 		Expect(err).ToNot(HaveOccurred())
-		_, err = fs.Stat(filepath.Join(output.OverlaysDir(), image.KubernetesManifestsPath(), "remote-manifest1.yaml"))
-		Expect(err).ToNot(HaveOccurred())
-		_, err = fs.Stat(filepath.Join(output.OverlaysDir(), image.KubernetesManifestsPath(), "local-manifest1.yaml"))
+		_, err = fs.Stat(output.InitrdExtensionFile())
 		Expect(err).ToNot(HaveOccurred())
 		_, err = fs.Stat(filepath.Join(output.CatalystConfigDir(), "network", "nmstate1.yaml"))
 		Expect(err).ToNot(HaveOccurred())
@@ -298,10 +345,14 @@ passwd:
 		By("Failing helm configuration")
 		m := NewManager(
 			system,
-			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest) ([]string, map[string][]byte, error) {
-				return nil, nil, fmt.Errorf("unable to configure helm charts")
+			&helmConfiguratorMock{configureFunc: func(c *image.Configuration, rm *resolver.ResolvedManifest, _ *butane.Config) ([]string, error) {
+				return nil, fmt.Errorf("unable to configure helm charts")
 			}},
 			WithManifestResolver(&resolverMock{resolveFunc: defaultResolveFunc}),
+			WithUnpackFunc(func(ctx context.Context, imageRef, destDir string) error {
+				installSh := filepath.Join(destDir, "install.sh")
+				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
+			}),
 		)
 		conf := &image.Configuration{
 			Kubernetes: kubernetes.Kubernetes{
@@ -318,7 +369,7 @@ passwd:
 		r, err := m.ConfigureComponents(context.Background(), conf, output)
 		Expect(r).To(BeNil())
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError("configuring kubernetes: configuring helm charts: unable to configure helm charts"))
+		Expect(err).To(MatchError("configuring ignition: configuring helm charts: unable to configure helm charts"))
 
 		By("Failing to setup local Kubernetes manifests")
 		conf = &image.Configuration{
@@ -337,8 +388,13 @@ passwd:
 			system,
 			&helmConfiguratorMock{configureFunc: defaultHelmFunc},
 			WithManifestResolver(&resolverMock{resolveFunc: defaultResolveFunc}),
-			WithDownloadFunc(func(ctx context.Context, fs vfs.FS, url, path string) error {
-				return fmt.Errorf("download unavailable")
+			WithDownloader(&downloaderMock{
+				urlBodyFunc: func(ctx context.Context, url string) (io.ReadCloser, error) {
+					return nil, fmt.Errorf("download unavailable")
+				}}),
+			WithUnpackFunc(func(ctx context.Context, imageRef, destDir string) error {
+				installSh := filepath.Join(destDir, "install.sh")
+				return fs.WriteFile(installSh, []byte("#!/bin/sh\necho test"), 0755)
 			}),
 		)
 		conf = &image.Configuration{

--- a/internal/config/systemd_sysext.go
+++ b/internal/config/systemd_sysext.go
@@ -50,7 +50,7 @@ func (m *Manager) downloadSystemExtensions(ctx context.Context, extensions []api
 
 		if isRemoteURL(extension.Image) {
 			extensionPath := filepath.Join(extensionsDir, filepath.Base(extension.Image))
-			if err := m.downloadFile(ctx, fs, extension.Image, extensionPath); err != nil {
+			if err := m.downloader.File(ctx, fs, extension.Image, extensionPath); err != nil {
 				return fmt.Errorf("downloading systemd extension %s: %w", extension.Name, err)
 			}
 

--- a/pkg/http/download.go
+++ b/pkg/http/download.go
@@ -28,29 +28,21 @@ import (
 	"github.com/suse/elemental/v3/pkg/sys/vfs"
 )
 
-func DownloadFile(ctx context.Context, fs vfs.FS, url, path string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
+type Downloader struct{}
 
-	httpClient := &http.Client{Timeout: 90 * time.Second}
-	resp, err := httpClient.Do(req) // #nosec G704 -- url is assumed to be trusted.
+func (d Downloader) File(ctx context.Context, fs vfs.FS, url, path string) error {
+	r, err := d.URLBody(ctx, url)
 	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
+		return err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
+	defer func() { _ = r.Close() }()
 
 	file, err := fs.Create(path)
 	if err != nil {
 		return fmt.Errorf("creating file: %w", err)
 	}
 
-	_, err = io.Copy(file, resp.Body)
+	_, err = io.Copy(file, r)
 	if err != nil {
 		_ = file.Close()
 		return fmt.Errorf("copying file contents: %w", err)
@@ -61,4 +53,24 @@ func DownloadFile(ctx context.Context, fs vfs.FS, url, path string) error {
 	}
 
 	return nil
+}
+
+func (Downloader) URLBody(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	httpClient := &http.Client{Timeout: 90 * time.Second}
+	resp, err := httpClient.Do(req) // #nosec G704 -- url is assumed to be trusted.
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return resp.Body, nil
 }

--- a/pkg/http/download_test.go
+++ b/pkg/http/download_test.go
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package http
+package http_test
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/suse/elemental/v3/pkg/http"
 	"github.com/suse/elemental/v3/pkg/sys/mock"
 )
 
@@ -33,21 +34,27 @@ func TestDownloadSuite(t *testing.T) {
 }
 
 var _ = Describe("Invalid download attempts", func() {
+	var d *http.Downloader
+
+	BeforeEach(func() {
+		d = &http.Downloader{}
+	})
+
 	It("Fails to create a request for nil context", func() {
-		err := DownloadFile(nil, nil, "", "")
+		err := d.File(nil, nil, "", "")
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("creating request: net/http: nil Context"))
 	})
 
 	It("Fails to execute a request for invalid URL", func() {
-		err := DownloadFile(context.Background(), nil, "invalid-url", "")
+		err := d.File(context.Background(), nil, "invalid-url", "")
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("executing request: Get \"invalid-url\": unsupported protocol scheme \"\""))
 	})
 
 	It("Fails to download a request due to unexpected status code", func() {
 		url := "https://github.com/suse/elemental3"
-		err := DownloadFile(context.Background(), nil, url, "")
+		err := d.File(context.Background(), nil, url, "")
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("unexpected status code: 404"))
 	})
@@ -58,8 +65,16 @@ var _ = Describe("Invalid download attempts", func() {
 		DeferCleanup(cleanup)
 
 		url := "https://github.com/suse/elemental"
-		err = DownloadFile(context.Background(), fs, url, "downloads/abc")
+		err = d.File(context.Background(), fs, url, "downloads/abc")
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("creating file: Create downloads/abc: operation not permitted"))
+	})
+
+	It("Returns an io.ReadCloser to download the URL", func() {
+		url := "https://github.com/suse/elemental"
+		rc, err := d.URLBody(context.Background(), url)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rc).NotTo(BeNil())
+		Expect(rc.Close()).To(Succeed())
 	})
 })


### PR DESCRIPTION
This commit changes the customize behavior to embed generated and copied over files to ignition configuration instead of using the overlay directory tree during the installation.

Before some files were provisioned via Ignition and other via installation overlays. This commit sets a consistent behavior so that all configuration files in /var/lib/elemental are essentially provisioned at the same time via Ignition.

All unpacked k8s files (tarball, install script) are left as overlay as they were.