### PR TITLE
Error on unknown hostname

### DIFF
--- a/internal/config/kubernetes_test.go
+++ b/internal/config/kubernetes_test.go
@@ -345,6 +345,26 @@ var _ = Describe("Kubernetes", func() {
 			Expect(confScript).ToNot(BeEmpty())
 		})
 
+		It("Defaults to a server node for a single-node cluster with no declared nodes", func() {
+			conf := kubernetes.Kubernetes{}
+
+			confScript, err := writeK8sConfigDeployScript(
+				fs,
+				output,
+				conf,
+				"/opt/k8s/install",
+				"/opt/k8s/install/install.sh",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring(`NODETYPE="server"`))
+			Expect(string(b)).To(ContainSubstring(`CONFIGFILE="/var/lib/elemental/kubernetes/${NODETYPE}.yaml"`))
+			Expect(string(b)).ToNot(ContainSubstring("does not match any declared node"))
+			Expect(string(b)).ToNot(ContainSubstring("init.yaml"))
+		})
+
 		It("Uses server config for a single explicitly configured server node", func() {
 			conf := kubernetes.Kubernetes{
 				Nodes: kubernetes.Nodes{
@@ -388,6 +408,29 @@ var _ = Describe("Kubernetes", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(b)).To(ContainSubstring(`if [[ "${HOSTNAME}" = "server01" ]]; then`))
 			Expect(string(b)).To(ContainSubstring("CONFIGFILE=/var/lib/elemental/kubernetes/init.yaml"))
+		})
+
+		It("Aborts when the hostname matches no declared node", func() {
+			conf := kubernetes.Kubernetes{
+				Nodes: kubernetes.Nodes{
+					{Hostname: "server01", Type: kubernetes.NodeTypeServer},
+				},
+			}
+
+			confScript, err := writeK8sConfigDeployScript(
+				fs,
+				output,
+				conf,
+				"/opt/k8s/install",
+				"/opt/k8s/install/install.sh",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring(`if [[ ! -v "hosts[${HOSTNAME}]" ]]; then`))
+			Expect(string(b)).To(ContainSubstring("does not match any declared node"))
+			Expect(string(b)).ToNot(ContainSubstring(":-server"))
 		})
 
 		It("Succeeds to configure RKE2 with additional resources and auth", func() {

--- a/internal/config/templates/k8s_conf_deploy.sh.tpl
+++ b/internal/config/templates/k8s_conf_deploy.sh.tpl
@@ -13,7 +13,16 @@ HOSTNAME=$(</etc/hostname)
 [[ -z "${HOSTNAME}" ]] \
   && HOSTNAME=$(</proc/sys/kernel/hostname)
 
-NODETYPE="${hosts[${HOSTNAME}]:-server}"
+{{- if .Nodes }}
+if [[ ! -v "hosts[${HOSTNAME}]" ]]; then
+  echo "Error: hostname '${HOSTNAME}' does not match any declared node" >&2
+  exit 1
+fi
+
+NODETYPE="${hosts[${HOSTNAME}]}"
+{{- else }}
+NODETYPE="server"
+{{- end }}
 CONFIGFILE="{{ .KubernetesDir }}/${NODETYPE}.yaml"
 REGFILE="{{ .KubernetesDir }}/registries.yaml"
 


### PR DESCRIPTION
During kubernetes provisioning the current behavior is to assume a node
is a 'server' and if found in the list of nodes we set it to the found
node-type.

In this commit we abort with an error if the node is not found for
multi-node clusters.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
