### PR TITLE
Do not remove k8s deployment files

### DIFF
--- a/internal/config/templates/k8s-resource-installer.service.tpl
+++ b/internal/config/templates/k8s-resource-installer.service.tpl
@@ -12,7 +12,6 @@ ExecStartPre=/bin/sh -c 'until [ "$(systemctl show -p SubState --value rke2-serv
 ExecStart=/bin/bash "{{ .ManifestDeployScript }}" 
 ExecStartPost=/bin/sh -c "systemctl disable k8s-resource-installer.service"
 ExecStartPost=/bin/sh -c "rm -rf /etc/systemd/system/k8s-resource-installer.service"
-ExecStartPost=/bin/sh -c 'rm -rf "{{ .KubernetesDir }}"'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This commit prevents the cleanup of the k8s deployment files. The rationale is that those files are included in all nodes but the cleanup logic only triggered on the init node. This turns to be confusing when inspecting the nodes after installation and deployment.