### PR TITLE
Adds Installer information to release-info output

### DIFF
--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -271,6 +271,15 @@ func printInfraData(cm *core.ReleaseManifest, out io.Writer) error {
 		data = append(data, []string{"Operating System", osVersion, cm.Components.OperatingSystem.Image.Base})
 	}
 
+	if cm.Components.OperatingSystem.Image.ISO != "" {
+		installerVersion := "Unknown"
+		parts := strings.Split(cm.Components.OperatingSystem.Image.ISO, ":")
+		if len(parts) > 1 {
+			installerVersion = "SLES" + " " + strings.Split(parts[1], "-")[0]
+		}
+		data = append(data, []string{"Installer", installerVersion, cm.Components.OperatingSystem.Image.ISO})
+	}
+
 	if cm.Components.Kubernetes != nil {
 		data = append(data, []string{"Kubernetes", cm.Components.Kubernetes.Version, cm.Components.Kubernetes.Image})
 	}

--- a/internal/cli/action/release_info.go
+++ b/internal/cli/action/release_info.go
@@ -268,8 +268,17 @@ func printInfraData(cm *core.ReleaseManifest, out io.Writer) error {
 		if len(parts) > 1 {
 			osVersion = "SLES " + strings.Split(parts[1], "-")[0]
 		}
-		data = append(data, []string{"Operating System", osVersion, cm.Components.OperatingSystem.Image.Base})
 	}
+	data = append(data, []string{"Operating System", osVersion, cm.Components.OperatingSystem.Image.Base})
+
+	installerVersion := "Unknown"
+	if cm.Components.OperatingSystem.Image.ISO != "" {
+		parts := strings.Split(cm.Components.OperatingSystem.Image.ISO, ":")
+		if len(parts) > 1 {
+			installerVersion = "SLES" + " " + strings.Split(parts[1], "-")[0]
+		}
+	}
+	data = append(data, []string{"Installer", installerVersion, cm.Components.OperatingSystem.Image.ISO})
 
 	if cm.Components.Kubernetes != nil {
 		data = append(data, []string{"Kubernetes", cm.Components.Kubernetes.Version, cm.Components.Kubernetes.Image})

--- a/internal/cli/action/release_info_test.go
+++ b/internal/cli/action/release_info_test.go
@@ -102,6 +102,7 @@ components:
 		Expect(buffer).To(ContainSubstring("CORE PLATFORM"))
 		Expect(buffer).To(ContainSubstring("suse-core-test"))
 		Expect(buffer).To(ContainSubstring("registry.suse.com/elemental/base-os-kernel-default:16.0-2.4"))
+		Expect(buffer).To(ContainSubstring("registry.suse.com/elemental/base-os-kernel-default-iso:16.0-2.7"))
 
 		Expect(buffer).To(ContainSubstring("INFRASTRUCTURE COMPONENTS"))
 		Expect(buffer).To(ContainSubstring("SLES 16.0"))


### PR DESCRIPTION
This helps people use `release-info` output to download the required
images before running `customize` with `--local` flag as the image
referred to by Installer is used when building a VM using `customize`.


Example output:
```sh
# core manifest
$ cat /tmp/core/release_manifest.yaml | yq '.components.operatingSystem.image'
base: registry.suse.com/elemental/base-os-kernel-default:16.0-3.10
iso: registry.suse.com/elemental/base-os-kernel-default-iso:16.0-3.11

# before
$ sudo ./build/elemental3 release-info ./examples/elemental/customize/multi-node/suse-solution-manifest.yaml | grep -A2 "Operating System"
│ Operating System          │ SLES 16.0      │ registry.suse.com/elemental/base-os-kernel-default:16.0-3.16 │
│ Kubernetes                │ v1.35.6+rke2r1 │ registry.suse.com/elemental/rke2/rke2-tar:1.35.6_rke2r1-9.1  │

# after
$ sudo ./build/elemental3 release-info ./examples/elemental/customize/multi-node/suse-solution-manifest.yaml | grep -A2 "Operating System"
│ Operating System          │ SLES 16.0      │ registry.suse.com/elemental/base-os-kernel-default:16.0-3.16     │
│ Installer                 │ SLES 16.0      │ registry.suse.com/elemental/base-os-kernel-default-iso:16.0-3.15 │
│ Kubernetes                │ v1.35.6+rke2r1 │ registry.suse.com/elemental/rke2/rke2-tar:1.35.6_rke2r1-9.1      │
```