### PR TITLE
Elemental3 AWS enablement

### DIFF
--- a/docs/configuration-directory.md
+++ b/docs/configuration-directory.md
@@ -147,6 +147,7 @@ network:
     apiVIP: 192.168.122.100
     apiHost: api.cluster01.example.com
     apiVIP6: fd12:3456:789a::21
+    apiVIPMode: managed
 ```
 
 * `manifests` - Optional; Defines remote Kubernetes manifests to be deployed on the cluster.
@@ -170,9 +171,10 @@ network:
   * `type` - Required; Selects the Kubernetes node type, either server (for control plane nodes) or agent (for worker nodes).
   * `init` - Optional; Indicates which node should function as the cluster initializer. The initializer node is the server node which bootstraps the cluster and allows other nodes to join it. If unset, the first server in the node list will be selected as the initializer.
 * `network`:
-  * `apiVIP` - Required for multi-node clusters if not using `apiVIP6`; Specifies the IPv4 address which will serve as the cluster LoadBalancer, backed by MetalLB.
-  * `apiVIP6` -  Required for multi-node clusters if not using `apiVIP`; Specifies the IPv6 address which will serve as the cluster LoadBalancer, backed by MetalLB.
+  * `apiVIP` - Required for multi-node clusters if not using `apiVIP6`; Specifies the IPv4 address which will serve as the cluster LoadBalancer.
+  * `apiVIP6` -  Required for multi-node clusters if not using `apiVIP`; Specifies the IPv6 address which will serve as the cluster LoadBalancer.
   * `apiHost` - Optional; Specifies the domain address for accessing the cluster.
+  * `apiVIPMode` - Optional; Specifies how the API VIP will be handled. Supported values: `managed` (default), `external`. `managed` uses MetalLB to serve the desired IPv4/IPv6 addresses. `external` expects a user-defined third-party loadbalancing mechanism for IPv4/IPv6 address handling.
 
 ### Kubernetes Directory
 

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -60,7 +60,7 @@ var (
 )
 
 func needsManifestsSetup(conf *image.Configuration) bool {
-	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsHA()
+	return len(conf.Kubernetes.RemoteManifests) > 0 || len(conf.Kubernetes.LocalManifests) > 0 || conf.Kubernetes.Network.IsManagedInternally()
 }
 
 func needsHelmChartsSetup(conf *image.Configuration) bool {
@@ -352,7 +352,7 @@ func appendRke2Configuration(s *sys.System, butaneCfg *butane.Config, k *kuberne
 		butaneCfg.AddFileInline(filepath.Join(k8sPath, "registries.yaml"), new(string(registriesBytes)), 0o644)
 	}
 
-	if k.Network.APIVIP4 != "" || k.Network.APIVIP6 != "" {
+	if k.Network.IsManagedInternally() {
 		manifestsPath := filepath.Join("/", image.KubernetesManifestsPath())
 
 		vip, err := kubernetesVIPManifest(k)

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -254,10 +254,12 @@ func generateK8sResourcesUnit(deployScript string, initNode *kubernetes.Node) (s
 		KubernetesDir        string
 		ManifestDeployScript string
 		InitNode             kubernetes.Node
+		RuntimeEnvPath       string
 	}{
 		KubernetesDir:        filepath.Dir(deployScript),
 		ManifestDeployScript: deployScript,
 		InitNode:             kubernetes.Node{},
+		RuntimeEnvPath:       filepath.Join("/", image.RuntimeEnvPath()),
 	}
 
 	if initNode != nil {

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -318,12 +318,12 @@ func appendRke2Configuration(s *sys.System, butaneCfg *butane.Config, k *kuberne
 
 	k8sPath := filepath.Join("/", image.KubernetesPath())
 
-	serverBytes, err := marshalConfig(c.ServerConfig)
+	joiningServerBytes, err := marshalConfig(c.JoiningServerConfig)
 	if err != nil {
 		return fmt.Errorf("failed marshaling server config: %w", err)
 	}
 
-	butaneCfg.AddFileInline(filepath.Join(k8sPath, "server.yaml"), new(string(serverBytes)), 0o644)
+	butaneCfg.AddFileInline(filepath.Join(k8sPath, "server.yaml"), new(string(joiningServerBytes)), 0o644)
 
 	if c.InitServerConfig != nil {
 		initServerBytes, err := marshalConfig(c.InitServerConfig)

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -22,6 +22,7 @@ import (
 	_ "embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"go.yaml.in/yaml/v3"
 
@@ -107,7 +108,12 @@ func (m *Manager) configureKubernetes(
 
 	var initNode *kubernetes.Node
 	if len(conf.Kubernetes.Nodes) == 0 {
-		// TODO(ivpe): to be added in a separate commit
+		// Utilise the new runtime configuration approach to ensure that we specify a default
+		// 'initialiser server' setup if no nodes are defined. This ensures that both statically
+		// and runtime defined nodes will work with the same approach, without having to expose
+		// a static/runtime specific configuration flag to the user.
+		envContent := strings.Join([]string{"IS_INIT_NODE=true", "NODETYPE=server"}, "\n")
+		butaneCfg.AddFileInline(filepath.Join("/", image.RuntimeEnvPath()), &envContent, 0o644)
 	} else {
 		initNode, err = kubernetes.FindInitNode(conf.Kubernetes.Nodes)
 		if err != nil {
@@ -268,8 +274,10 @@ func generateK8sResourcesUnit(deployScript string, initNode *kubernetes.Node) (s
 func generateK8sConfigUnit(deployScript string) (string, error) {
 	values := struct {
 		ConfigDeployScript string
+		RuntimeEnvPath     string
 	}{
 		ConfigDeployScript: deployScript,
+		RuntimeEnvPath:     filepath.Join("/", image.RuntimeEnvPath()),
 	}
 
 	data, err := template.Parse(k8sConfigUnitName, k8sConfigUnitTpl, &values)

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -105,19 +105,29 @@ func (m *Manager) configureKubernetes(
 		}
 	}
 
+	var initNode *kubernetes.Node
+	if len(conf.Kubernetes.Nodes) == 0 {
+		// TODO(ivpe): to be added in a separate commit
+	} else {
+		initNode, err = kubernetes.FindInitNode(conf.Kubernetes.Nodes)
+		if err != nil {
+			return fmt.Errorf("attempting to find init node: %w", err)
+		}
+	}
+
 	if len(runtimeHelmCharts) > 0 || runtimeManifestsDir != "" {
 		err = appendK8sResDeployScript(butaneCfg, runtimeManifestsDir, runtimeHelmCharts)
 		if err != nil {
 			return fmt.Errorf("generating kubernetes resource deployment script: %w", err)
 		}
 
-		err = appendK8sResUnit(conf, butaneCfg)
+		err = appendK8sResUnit(butaneCfg, initNode)
 		if err != nil {
 			return fmt.Errorf("generating kubernetes resource deployment unit: %w", err)
 		}
 	}
 
-	err = appendK8sConfigDeployScript(butaneCfg, conf.Kubernetes)
+	err = appendK8sConfigDeployScript(butaneCfg, conf.Kubernetes, initNode)
 	if err != nil {
 		return fmt.Errorf("generating kubernetes config deployment script: %w", err)
 	}
@@ -183,22 +193,10 @@ func appendK8sResDeployScript(butaneCfg *butane.Config, runtimeManifestsDir stri
 	return nil
 }
 
-func appendK8sResUnit(conf *image.Configuration, butaneCfg *butane.Config) error {
+func appendK8sResUnit(butaneCfg *butane.Config, initNode *kubernetes.Node) error {
 	k8sScript := filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName)
-	initHostname := "*"
 
-	if len(conf.Kubernetes.Nodes) > 0 {
-		initNode, err := kubernetes.FindInitNode(conf.Kubernetes.Nodes)
-		if err != nil {
-			return err
-		}
-
-		if initNode != nil {
-			initHostname = initNode.Hostname
-		}
-	}
-
-	k8sResourcesUnit, err := generateK8sResourcesUnit(k8sScript, initHostname)
+	k8sResourcesUnit, err := generateK8sResourcesUnit(k8sScript, initNode)
 	if err != nil {
 		return err
 	}
@@ -207,21 +205,9 @@ func appendK8sResUnit(conf *image.Configuration, butaneCfg *butane.Config) error
 	return nil
 }
 
-func appendK8sConfigDeployScript(butaneCfg *butane.Config, k kubernetes.Kubernetes) error {
+func appendK8sConfigDeployScript(butaneCfg *butane.Config, k kubernetes.Kubernetes, initNode *kubernetes.Node) error {
 	relativeK8sPath := filepath.Join("/", image.KubernetesPath())
 	k8sInstallPath := filepath.Join("/", image.KubernetesInstallPath())
-
-	var (
-		initNode *kubernetes.Node
-		err      error
-	)
-
-	if len(k.Nodes) > 1 {
-		initNode, err = kubernetes.FindInitNode(k.Nodes)
-		if err != nil {
-			return fmt.Errorf("finding init node: %w", err)
-		}
-	}
 
 	values := struct {
 		Nodes         kubernetes.Nodes
@@ -257,15 +243,19 @@ func appendK8sConfigDeployScript(butaneCfg *butane.Config, k kubernetes.Kubernet
 	return nil
 }
 
-func generateK8sResourcesUnit(deployScript, initHostname string) (string, error) {
+func generateK8sResourcesUnit(deployScript string, initNode *kubernetes.Node) (string, error) {
 	values := struct {
 		KubernetesDir        string
 		ManifestDeployScript string
-		InitHostname         string
+		InitNode             kubernetes.Node
 	}{
 		KubernetesDir:        filepath.Dir(deployScript),
 		ManifestDeployScript: deployScript,
-		InitHostname:         initHostname,
+		InitNode:             kubernetes.Node{},
+	}
+
+	if initNode != nil {
+		values.InitNode = *initNode
 	}
 
 	data, err := template.Parse(k8sResourcesUnitName, k8sResourceUnitTpl, &values)

--- a/internal/config/kubernetes_test.go
+++ b/internal/config/kubernetes_test.go
@@ -115,6 +115,9 @@ var _ = Describe("Kubernetes", func() {
 		var system *sys.System
 		var err error
 		var config *butane.Config
+		var defaultManifest *resolver.ResolvedManifest
+		var defaultUnpack func(ctx context.Context, imageRef, destDir string) error
+		var defaultHelm *helmConfiguratorMock
 
 		BeforeEach(func() {
 			config = &butane.Config{}
@@ -123,27 +126,8 @@ var _ = Describe("Kubernetes", func() {
 				sys.WithLogger(log.New(log.WithDiscardAll())),
 			)
 			Expect(err).ToNot(HaveOccurred())
-		})
 
-		It("Fails to configure Helm charts", func() {
-			helmMock := &helmConfiguratorMock{
-				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest, _ *butane.Config) ([]string, error) {
-					return nil, fmt.Errorf("helm error")
-				},
-			}
-
-			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				return nil
-			}
-
-			m := NewManager(
-				system,
-				helmMock,
-				WithDownloader(&downloaderMock{}),
-				WithUnpackFunc(unpackFunc),
-			)
-
-			manifest := &resolver.ResolvedManifest{
+			defaultManifest = &resolver.ResolvedManifest{
 				CorePlatform: &core.ReleaseManifest{
 					Components: core.Components{
 						Kubernetes: &core.Kubernetes{
@@ -153,6 +137,32 @@ var _ = Describe("Kubernetes", func() {
 					},
 				},
 			}
+
+			defaultUnpack = func(ctx context.Context, imageRef, destDir string) error {
+				return nil
+			}
+
+			defaultHelm = &helmConfiguratorMock{
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest, _ *butane.Config) ([]string, error) {
+					return []string{}, nil
+				},
+			}
+		})
+
+		It("Fails to configure Helm charts", func() {
+			helmMock := &helmConfiguratorMock{
+				configureFunc: func(conf *image.Configuration, manifest *resolver.ResolvedManifest, _ *butane.Config) ([]string, error) {
+					return nil, fmt.Errorf("helm error")
+				},
+			}
+
+			m := NewManager(
+				system,
+				helmMock,
+				WithDownloader(&downloaderMock{}),
+				WithUnpackFunc(defaultUnpack),
+			)
+
 			conf := &image.Configuration{
 				Release: release.Release{
 					Components: release.Components{
@@ -165,7 +175,7 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			err := m.configureKubernetes(context.Background(), conf, manifest, config)
+			err := m.configureKubernetes(context.Background(), conf, defaultManifest, config)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("configuring helm charts: helm error"))
 		})
@@ -177,27 +187,13 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				return nil
-			}
-
 			m := NewManager(
 				system,
 				helmMock,
 				WithDownloader(&downloaderMock{}),
-				WithUnpackFunc(unpackFunc),
+				WithUnpackFunc(defaultUnpack),
 			)
 
-			manifest := &resolver.ResolvedManifest{
-				CorePlatform: &core.ReleaseManifest{
-					Components: core.Components{
-						Kubernetes: &core.Kubernetes{
-							Version: "v1.35.0+rke2r1",
-							Image:   "registry.example.com/rke2:1.35_1.0",
-						},
-					},
-				},
-			}
 			conf := &image.Configuration{
 				Kubernetes: kubernetes.Kubernetes{
 					RemoteManifests: []string{"some-url"},
@@ -216,7 +212,7 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			Expect(m.configureKubernetes(context.Background(), conf, manifest, config)).To(Succeed())
+			Expect(m.configureKubernetes(context.Background(), conf, defaultManifest, config)).To(Succeed())
 
 			// Verify deployment script contents
 			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName))
@@ -232,28 +228,13 @@ var _ = Describe("Kubernetes", func() {
 		})
 
 		It("Succeeds to configure RKE2 without additional resources", func() {
-
-			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				return nil
-			}
-
 			m := NewManager(
 				system,
 				nil,
 				WithDownloader(&downloaderMock{}),
-				WithUnpackFunc(unpackFunc),
+				WithUnpackFunc(defaultUnpack),
 			)
 
-			manifest := &resolver.ResolvedManifest{
-				CorePlatform: &core.ReleaseManifest{
-					Components: core.Components{
-						Kubernetes: &core.Kubernetes{
-							Version: "v1.35.0+rke2r1",
-							Image:   "registry.example.com/rke2:1.35_1.0",
-						},
-					},
-				},
-			}
 			conf := &image.Configuration{
 				Release: release.Release{
 					Components: release.Components{
@@ -262,73 +243,90 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			Expect(m.configureKubernetes(context.Background(), conf, manifest, config)).To(Succeed())
+			Expect(m.configureKubernetes(context.Background(), conf, defaultManifest, config)).To(Succeed())
 
 			Expect(findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))).NotTo(BeNil())
 		})
 
-		It("Defaults to a server node for a single-node cluster with no declared nodes", func() {
-			k8s := kubernetes.Kubernetes{}
+		It("Defaults to a server init node for a single-node cluster with no declared nodes", func() {
+			m := NewManager(
+				system,
+				defaultHelm,
+				WithDownloader(&downloaderMock{}),
+				WithUnpackFunc(defaultUnpack),
+			)
 
-			Expect(appendK8sConfigDeployScript(config, k8s)).To(Succeed())
+			conf := &image.Configuration{Kubernetes: kubernetes.Kubernetes{}}
+
+			Expect(m.configureKubernetes(context.Background(), conf, defaultManifest, config)).To(Succeed())
 
 			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
 			Expect(data).NotTo(BeNil())
 
-			Expect(*data).To(ContainSubstring(`NODETYPE="server"`))
-			Expect(*data).To(ContainSubstring(`CONFIGFILE="/var/lib/elemental/kubernetes/${NODETYPE}.yaml"`))
-			Expect(*data).ToNot(ContainSubstring("does not match any declared node"))
-			Expect(*data).ToNot(ContainSubstring("init.yaml"))
+			Expect(*data).To(ContainSubstring(`: "${K8S_DIR:=/var/lib/elemental/kubernetes}"`))
+			Expect(*data).To(ContainSubstring(`: "${INIT_PATH:=${K8S_DIR}/init.yaml}"`))
+			Expect(*data).To(ContainSubstring(`: "${IS_INIT_NODE:=${is_init_node}}"`))
+			Expect(*data).To(ContainSubstring(`[[ "${IS_INIT_NODE}" == "true" ]] && CONFIGFILE="${INIT_PATH}"`))
+			// Configuration specific to statically defined init node should not be present when no nodes where defined.
+			Expect(*data).ToNot(ContainSubstring(`[[ "${HOSTNAME}" == "{{ .InitNode.Hostname }}" ]] && is_init_node=true`))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.RuntimeEnvPath()))
+			Expect(data).NotTo(BeNil())
+
+			Expect(*data).To(ContainSubstring(`IS_INIT_NODE=true`))
+			Expect(*data).To(ContainSubstring(`NODETYPE=server`))
 		})
 
-		It("Uses server config for a single explicitly configured server node", func() {
-			k8s := kubernetes.Kubernetes{
-				Nodes: kubernetes.Nodes{
-					{Hostname: "node01", Type: kubernetes.NodeTypeServer},
+		It("Uses server init config for a single explicitly configured server node", func() {
+			m := NewManager(
+				system,
+				defaultHelm,
+				WithDownloader(&downloaderMock{}),
+				WithUnpackFunc(defaultUnpack),
+			)
+
+			conf := &image.Configuration{
+				Kubernetes: kubernetes.Kubernetes{
+					Nodes: kubernetes.Nodes{
+						{Hostname: "node01", Type: kubernetes.NodeTypeServer},
+					},
 				},
 			}
 
-			Expect(appendK8sConfigDeployScript(config, k8s)).To(Succeed())
+			Expect(m.configureKubernetes(context.Background(), conf, defaultManifest, config)).To(Succeed())
 
 			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
 			Expect(data).NotTo(BeNil())
 
-			Expect(*data).To(ContainSubstring(`CONFIGFILE="/var/lib/elemental/kubernetes/${NODETYPE}.yaml"`))
-			Expect(*data).ToNot(ContainSubstring("init.yaml"))
+			Expect(*data).To(ContainSubstring(`: "${K8S_DIR:=/var/lib/elemental/kubernetes}"`))
+			Expect(*data).To(ContainSubstring(`: "${INIT_PATH:=${K8S_DIR}/init.yaml}"`))
+			Expect(*data).To(ContainSubstring(`: "${IS_INIT_NODE:=${is_init_node}}"`))
+			Expect(*data).To(ContainSubstring(`[[ "${HOSTNAME}" == "node01" ]] && is_init_node=true`))
+			Expect(*data).To(ContainSubstring(`[[ "${IS_INIT_NODE}" == "true" ]] && CONFIGFILE="${INIT_PATH}"`))
+
+			data = findFileContentsInConfig(config, filepath.Join("/", image.RuntimeEnvPath()))
+			Expect(data).To(BeNil())
 		})
 
-		It("Uses init config only for multi-node clusters", func() {
-			k8s := kubernetes.Kubernetes{
-				Nodes: kubernetes.Nodes{
-					{Hostname: "server01", Type: kubernetes.NodeTypeServer},
-					{Hostname: "agent01", Type: kubernetes.NodeTypeAgent},
+		It("Fails when there is no server in the static node configuration", func() {
+			m := NewManager(
+				system,
+				defaultHelm,
+				WithDownloader(&downloaderMock{}),
+				WithUnpackFunc(defaultUnpack),
+			)
+
+			conf := &image.Configuration{
+				Kubernetes: kubernetes.Kubernetes{
+					Nodes: kubernetes.Nodes{
+						{Hostname: "node01", Type: kubernetes.NodeTypeAgent},
+					},
 				},
 			}
 
-			Expect(appendK8sConfigDeployScript(config, k8s)).To(Succeed())
-
-			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
-			Expect(data).NotTo(BeNil())
-
-			Expect(*data).To(ContainSubstring(`if [[ "${HOSTNAME}" = "server01" ]]; then`))
-			Expect(*data).To(ContainSubstring("CONFIGFILE=/var/lib/elemental/kubernetes/init.yaml"))
-		})
-
-		It("Aborts when the hostname matches no declared node", func() {
-			k8s := kubernetes.Kubernetes{
-				Nodes: kubernetes.Nodes{
-					{Hostname: "server01", Type: kubernetes.NodeTypeServer},
-				},
-			}
-
-			Expect(appendK8sConfigDeployScript(config, k8s)).To(Succeed())
-
-			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sConfDeployScriptName))
-			Expect(data).NotTo(BeNil())
-
-			Expect(*data).To(ContainSubstring(`if [[ ! -v "hosts[${HOSTNAME}]" ]]; then`))
-			Expect(*data).To(ContainSubstring("does not match any declared node"))
-			Expect(*data).ToNot(ContainSubstring("NODETYPE=\"server\""))
+			err := m.configureKubernetes(context.Background(), conf, defaultManifest, config)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`could not find suitable init node from node list: [{Hostname:node01 Type:agent Init:false}]`))
 		})
 
 		It("Succeeds to configure RKE2 with additional resources and auth", func() {
@@ -345,27 +343,13 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			unpackFunc := func(ctx context.Context, imageRef, destDir string) error {
-				return nil
-			}
-
 			m := NewManager(
 				system,
 				helmMock,
 				WithDownloader(&downloaderMock{}),
-				WithUnpackFunc(unpackFunc),
+				WithUnpackFunc(defaultUnpack),
 			)
 
-			manifest := &resolver.ResolvedManifest{
-				CorePlatform: &core.ReleaseManifest{
-					Components: core.Components{
-						Kubernetes: &core.Kubernetes{
-							Version: "v1.35.0+rke2r1",
-							Image:   "registry.example.com/rke2:1.35_1.0",
-						},
-					},
-				},
-			}
 			conf := &image.Configuration{
 				Kubernetes: kubernetes.Kubernetes{
 					RemoteManifests: []string{"some-url"},
@@ -411,7 +395,7 @@ var _ = Describe("Kubernetes", func() {
 				},
 			}
 
-			Expect(m.configureKubernetes(context.Background(), conf, manifest, config)).To(Succeed())
+			Expect(m.configureKubernetes(context.Background(), conf, defaultManifest, config)).To(Succeed())
 
 			// Verify deployment script contents
 			data := findFileContentsInConfig(config, filepath.Join("/", image.KubernetesPath(), k8sResDeployScriptName))

--- a/internal/config/templates/k8s-config-installer.service.tpl
+++ b/internal/config/templates/k8s-config-installer.service.tpl
@@ -8,6 +8,7 @@ Type=oneshot
 TimeoutSec=900
 Restart=on-failure
 RestartSec=60
+EnvironmentFile=-{{ .RuntimeEnvPath }}
 # TODO (atanasdinov): Figure out a declarative, non-hardcoded approach for installing selinux modules
 ExecStartPre=/bin/sh -c "semodule -i /usr/share/selinux/packages/rke2.pp"
 ExecStart=/bin/bash "{{ .ConfigDeployScript }}"

--- a/internal/config/templates/k8s-resource-installer.service.tpl
+++ b/internal/config/templates/k8s-resource-installer.service.tpl
@@ -1,13 +1,19 @@
 [Unit]
 Description=Kubernetes Resources Installer
 After=k8s-config-installer.service
-ConditionHost={{ .InitHostname }}
+{{- if .InitNode.Hostname }}
+ConditionHost={{ .InitNode.Hostname }}
+{{- end }}
 
 [Service]
 Type=oneshot
 TimeoutSec=900
 Restart=on-failure
 RestartSec=60
+{{- if not .InitNode.Hostname }}
+EnvironmentFile={{ .RuntimeEnvPath }}
+ExecCondition=/bin/sh -c '[ "$${IS_INIT_NODE}" = "true" ]'
+{{- end }}
 ExecStartPre=/bin/sh -c 'until [ "$(systemctl show -p SubState --value rke2-server.service)" = "running" ]; do sleep 10; done'
 ExecStart=/bin/bash "{{ .ManifestDeployScript }}" 
 ExecStartPost=/bin/sh -c "systemctl disable k8s-resource-installer.service"

--- a/internal/config/templates/k8s_conf_deploy.sh.tpl
+++ b/internal/config/templates/k8s_conf_deploy.sh.tpl
@@ -2,6 +2,11 @@
 
 set -uo pipefail
 
+: "${K8S_DIR:={{ .KubernetesDir }}}"
+: "${INIT_PATH:=${K8S_DIR}/init.yaml}"
+: "${REGFILE:=${K8S_DIR}/registries.yaml}"
+: "${BASE_CONF_NAME:=00-elemental-base-rke2-config.yaml}"
+
 declare -A hosts
 
 {{- range .Nodes }}
@@ -13,32 +18,24 @@ HOSTNAME=$(</etc/hostname)
 [[ -z "${HOSTNAME}" ]] \
   && HOSTNAME=$(</proc/sys/kernel/hostname)
 
-{{- if .Nodes }}
-if [[ ! -v "hosts[${HOSTNAME}]" ]]; then
-  echo "Error: hostname '${HOSTNAME}' does not match any declared node" >&2
+: "${NODETYPE:=${hosts[$HOSTNAME]:-}}"
+[[ -z "${NODETYPE}" ]] && {
+  echo "Error: Undeclared 'NODETYPE' for hostname '${HOSTNAME}'" >&2
   exit 1
-fi
+}
 
-NODETYPE="${hosts[${HOSTNAME}]}"
-{{- else }}
-NODETYPE="server"
-{{- end }}
-
-CONFIGFILE="{{ .KubernetesDir }}/${NODETYPE}.yaml"
-REGFILE="{{ .KubernetesDir }}/registries.yaml"
-
+is_init_node=false
 {{- if .InitNode.Hostname }}
-if [[ "${HOSTNAME}" = "{{ .InitNode.Hostname }}" ]]; then
-  echo "Setting up init node"
-  CONFIGFILE={{ .KubernetesDir }}/init.yaml
-fi
+[[ "${HOSTNAME}" == "{{ .InitNode.Hostname }}" ]] && is_init_node=true
 {{- end }}
 
-# Better to append if a file exist
-# Useful if some custom configuration are done at boot
-mkdir -p /etc/rancher/rke2
-echo "Copying RKE2 config file ${CONFIGFILE}"
-cat ${CONFIGFILE} >> /etc/rancher/rke2/config.yaml
+: "${IS_INIT_NODE:=${is_init_node}}"
+CONFIGFILE="${K8S_DIR}/${NODETYPE}.yaml"
+[[ "${IS_INIT_NODE}" == "true" ]] && CONFIGFILE="${INIT_PATH}"
+
+RKE2_CFG_DROP_IN_PATH="/etc/rancher/rke2/config.yaml.d"
+mkdir -p "${RKE2_CFG_DROP_IN_PATH}"
+cp "${CONFIGFILE}" "${RKE2_CFG_DROP_IN_PATH}/${BASE_CONF_NAME}"
 
 if [[ -e "${REGFILE}" ]]; then
   cp "${REGFILE}" /etc/rancher/rke2/registries.yaml
@@ -64,4 +61,4 @@ if ! sh "{{ .InstallScript }}"; then
   exit 1
 fi
 
-systemctl enable --now rke2-${NODETYPE}.service
+systemctl enable --now "rke2-${NODETYPE}.service"

--- a/internal/config/v0/config.go
+++ b/internal/config/v0/config.go
@@ -229,7 +229,7 @@ func parseKubernetes(f vfs.FS, configDir Dir, k *kubernetes.Kubernetes, r *relea
 		return fmt.Errorf("reading config file: %w", err)
 	}
 
-	if k.Network.APIVIP4 != "" || k.Network.APIVIP6 != "" {
+	if k.Network.IsManagedInternally() {
 		containsChart := func(name string) bool {
 			return slices.ContainsFunc(r.Components.HelmCharts, func(c release.HelmChart) bool {
 				return c.Name == name

--- a/internal/config/v0/config_test.go
+++ b/internal/config/v0/config_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -186,6 +187,28 @@ var _ = Describe("Configuration", Label("configuration"), func() {
 		Expect(conf.Release.ManifestURI).To(Equal("file:/tmp/config-dir/release-manifest.yaml"))
 	})
 
+	It("Successfully parses apiVIPMode managed internally", func() {
+		clusterYAML := strings.Replace(kubernetesClusterYAML, "  apiVIP: 192.168.120.100.sslip.io", "  apiVIP: 192.168.120.100.sslip.io\n  apiVIPMode: managed", 1)
+		Expect(fs.WriteFile(configDir.ClusterFilepath(), []byte(clusterYAML), 0644)).To(Succeed())
+
+		conf, err := Parse(fs, configDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(containsChart("metallb", conf.Release.Components.HelmCharts)).To(BeTrue())
+		Expect(containsChart("endpoint-copier-operator", conf.Release.Components.HelmCharts)).To(BeTrue())
+	})
+
+	It("Successfully parses apiVIPMode managed externally", func() {
+		clusterYAML := strings.Replace(kubernetesClusterYAML, "  apiVIP: 192.168.120.100.sslip.io", "  apiVIP: 192.168.120.100.sslip.io\n  apiVIPMode: external", 1)
+		Expect(fs.WriteFile(configDir.ClusterFilepath(), []byte(clusterYAML), 0644)).To(Succeed())
+
+		conf, err := Parse(fs, configDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(containsChart("metallb", conf.Release.Components.HelmCharts)).To(BeFalse())
+		Expect(containsChart("endpoint-copier-operator", conf.Release.Components.HelmCharts)).To(BeFalse())
+	})
+
 	It("Successfully parses network script", func() {
 		Expect(fs.Remove(filepath.Join(configDir.NetworkDir(), "node1.foo.yaml"))).To(Succeed())
 
@@ -298,6 +321,15 @@ raw:
 		Expect(err).To(HaveOccurred())
 		// Parse will fail first on reading the file
 		Expect(err.Error()).To(ContainSubstring("reading config file"))
+	})
+
+	It("Fails on invalid apiVIPMode value", func() {
+		clusterYAML := strings.Replace(kubernetesClusterYAML, "  apiVIP: 192.168.120.100.sslip.io", "  apiVIP: 192.168.120.100.sslip.io\n  apiVIPMode: invalid", 1)
+		Expect(fs.WriteFile(configDir.ClusterFilepath(), []byte(clusterYAML), 0644)).To(Succeed())
+
+		_, err := Parse(fs, configDir)
+
+		Expect(err.Error()).To(ContainSubstring(`validation failed: field "Configuration.Kubernetes.Network.APIVIPMode" must be one of [managed external], but got "invalid"`))
 	})
 })
 

--- a/internal/image/kubernetes/cluster.go
+++ b/internal/image/kubernetes/cluster.go
@@ -44,14 +44,15 @@ const (
 type ConfigMap map[string]any
 
 type Cluster struct {
-	// ServerConfig contains the server configurations for a single node cluster
-	// or the additional server nodes in a multi node cluster.
-	ServerConfig ConfigMap
-	// InitServerConfig contains the initial server configurations for a multi node cluster
+	// JoiningServerConfig contains the server configurations for a node that will
+	// join to an existing cluster.
+	JoiningServerConfig ConfigMap
+	// InitServerConfig contains the server configurations for the node that will
+	// initially bootstrap the cluster.
 	InitServerConfig ConfigMap
 	// AgentConfig contains the agent configurations in multi node clusters.
 	AgentConfig ConfigMap
-	// RegistriesConfig contains the configurations for private or embedded registries
+	// RegistriesConfig contains the configurations for private or embedded registries.
 	RegistriesConfig ConfigMap
 }
 
@@ -66,34 +67,8 @@ func NewCluster(s *sys.System, kube *Kubernetes) (*Cluster, error) {
 		return nil, fmt.Errorf("parsing server config: %w", err)
 	}
 
-	if len(kube.Nodes) < 2 {
-		setSingleNodeConfigDefaults(s.Logger(), kube, serverConfig)
-		return &Cluster{
-			ServerConfig:     serverConfig,
-			RegistriesConfig: registriesConfig,
-		}, nil
-	}
-
-	var ip4 netip.Addr
-	if kube.Network.APIVIP4 != "" {
-		ip4, err = netip.ParseAddr(kube.Network.APIVIP4)
-		if err != nil {
-			return nil, fmt.Errorf("parsing kubernetes ipv4 address: %w", err)
-		}
-	}
-
-	var ip6 netip.Addr
-	if kube.Network.APIVIP6 != "" {
-		ip6, err = netip.ParseAddr(kube.Network.APIVIP6)
-		if err != nil {
-			return nil, fmt.Errorf("parsing kubernetes ipv6 address: %w", err)
-		}
-	}
-
-	prioritizeIPv6 := IsIPv6Priority(serverConfig)
-	err = setMultiNodeConfigDefaults(s.Logger(), kube, serverConfig, ip4, ip6, prioritizeIPv6)
-	if err != nil {
-		return nil, fmt.Errorf("failed setting multi-node configuration: %w", err)
+	if err := setServerDefaults(s.Logger(), kube, serverConfig); err != nil {
+		return nil, fmt.Errorf("setting server default configurations: %w", err)
 	}
 
 	agentConfig, err := ParseKubernetesConfig(s, kube.Config.AgentFilePath)
@@ -102,20 +77,23 @@ func NewCluster(s *sys.System, kube *Kubernetes) (*Cluster, error) {
 	}
 
 	// Ensure the agent uses the same cluster configuration values as the server
-	agentConfig[tokenKey] = serverConfig[tokenKey]
-	agentConfig[serverKey] = serverConfig[serverKey]
-	agentConfig[selinuxKey] = serverConfig[selinuxKey]
-	agentConfig[cniKey] = serverConfig[cniKey]
+	for _, key := range []string{tokenKey, serverKey, selinuxKey, cniKey} {
+		if v, ok := serverConfig[key]; ok {
+			agentConfig[key] = v
+		}
+	}
 
+	// Config for the initial server node is the same as the one for any joining 'server'
+	// nodes, excluding the 'server: <url>' connection url.
 	initConfig := ConfigMap{}
 	maps.Copy(initConfig, serverConfig)
 	delete(initConfig, serverKey)
 
 	return &Cluster{
-		InitServerConfig: initConfig,
-		ServerConfig:     serverConfig,
-		AgentConfig:      agentConfig,
-		RegistriesConfig: registriesConfig,
+		InitServerConfig:    initConfig,
+		JoiningServerConfig: serverConfig,
+		AgentConfig:         agentConfig,
+		RegistriesConfig:    registriesConfig,
 	}, err
 }
 
@@ -148,43 +126,52 @@ func ParseKubernetesConfig(s *sys.System, configFile string) (ConfigMap, error) 
 	return config, nil
 }
 
-func setSingleNodeConfigDefaults(logger log.Logger, kube *Kubernetes, config ConfigMap) {
-	if kube.Network.APIVIP4 != "" {
-		appendClusterTLSSAN(logger, config, kube.Network.APIVIP4)
-	}
-
-	if kube.Network.APIVIP6 != "" {
-		appendClusterTLSSAN(logger, config, kube.Network.APIVIP6)
-	}
-
-	if kube.Network.APIHost != "" {
-		appendClusterTLSSAN(logger, config, kube.Network.APIHost)
-	}
-	delete(config, serverKey)
-}
-
-func setMultiNodeConfigDefaults(logger log.Logger, kube *Kubernetes, config ConfigMap, ip4 netip.Addr, ip6 netip.Addr, prioritizeIPv6 bool) error {
+func setServerDefaults(logger log.Logger, kube *Kubernetes, server ConfigMap) error {
 	const rke2ServerPort = 9345
+	var serverAddr netip.Addr
 
-	err := setClusterAPIAddress(config, ip4, ip6, rke2ServerPort, prioritizeIPv6)
-	if err != nil {
-		return err
-	}
-
-	setClusterToken(logger, config)
+	// Parse VIP IPv4 address. If defined and valid,
+	// append the address to the server's tls-san configuration
+	// and set it as the valid server url address.
 	if kube.Network.APIVIP4 != "" {
-		appendClusterTLSSAN(logger, config, kube.Network.APIVIP4)
+		ip4, err := netip.ParseAddr(kube.Network.APIVIP4)
+		if err != nil {
+			return fmt.Errorf("parsing kubernetes ipv4 address: %w", err)
+		}
+
+		appendClusterTLSSAN(logger, server, kube.Network.APIVIP4)
+		serverAddr = ip4
 	}
 
+	// Parse VIP IPv6 address. If defined and valid,
+	// append the address to the server's tls-san configuraiton.
+	// If IPv6 is prioritiesed, or IPv4 has not been defined, set
+	// it as the valid server url address.
 	if kube.Network.APIVIP6 != "" {
-		appendClusterTLSSAN(logger, config, kube.Network.APIVIP6)
+		ip6, err := netip.ParseAddr(kube.Network.APIVIP6)
+		if err != nil {
+			return fmt.Errorf("parsing kubernetes ipv6 address: %w", err)
+		}
+
+		appendClusterTLSSAN(logger, server, kube.Network.APIVIP6)
+
+		if IsIPv6Priority(server) || kube.Network.APIVIP4 == "" {
+			serverAddr = ip6
+		}
 	}
 
-	setSELinux(config)
+	// Add the cluster domain address to the tls-san, if provided.
 	if kube.Network.APIHost != "" {
-		appendClusterTLSSAN(logger, config, kube.Network.APIHost)
+		appendClusterTLSSAN(logger, server, kube.Network.APIHost)
 	}
 
+	// If the server address exists, use it to construct the server's connection endpoint.
+	// Note: 'serverAddr' will only be empty for standalone cluster scenarios.
+	if serverAddr.IsValid() {
+		server[serverKey] = fmt.Sprintf("https://%s", netip.AddrPortFrom(serverAddr, rke2ServerPort).String())
+	}
+
+	setClusterToken(logger, server)
 	return nil
 }
 
@@ -197,29 +184,6 @@ func setClusterToken(logger log.Logger, config ConfigMap) {
 
 	logger.Info("Generated cluster token: %s", token)
 	config[tokenKey] = token
-}
-
-func setClusterAPIAddress(config ConfigMap, ip4 netip.Addr, ip6 netip.Addr, port uint16, prioritizeIPv6 bool) error {
-	if !ip4.IsValid() && !ip6.IsValid() {
-		return fmt.Errorf("attempted to set an invalid cluster API address")
-	}
-
-	if ip6.IsValid() && (prioritizeIPv6 || !ip4.IsValid()) {
-		config[serverKey] = fmt.Sprintf("https://%s", netip.AddrPortFrom(ip6, port).String())
-		return nil
-	}
-
-	config[serverKey] = fmt.Sprintf("https://%s", netip.AddrPortFrom(ip4, port).String())
-
-	return nil
-}
-
-func setSELinux(config ConfigMap) {
-	if _, ok := config[selinuxKey].(bool); ok {
-		return
-	}
-
-	config[selinuxKey] = false
 }
 
 func appendClusterTLSSAN(logger log.Logger, config ConfigMap, address string) {

--- a/internal/image/kubernetes/cluster_test.go
+++ b/internal/image/kubernetes/cluster_test.go
@@ -1,7 +1,7 @@
 package kubernetes
 
 import (
-	"net/netip"
+	"maps"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -55,10 +55,9 @@ var _ = Describe("Cluster", func() {
 		var err error
 
 		fs, cleanup, err = sysmock.TestFS(map[string]any{
-			"/etc/kubernetes/single-node/server.yaml":    exampleServerYaml,
-			"/etc/kubernetes/multi-node/server.yaml":     exampleServerYaml,
-			"/etc/kubernetes/multi-node/agent.yaml":      exampleAgentYaml,
-			"/etc/kubernetes/multi-node/registries.yaml": exampleRegistriesYaml,
+			"/etc/kubernetes/config-dir/server.yaml":     exampleServerYaml,
+			"/etc/kubernetes/config-dir/agent.yaml":      exampleAgentYaml,
+			"/etc/kubernetes/config-dir/registries.yaml": exampleRegistriesYaml,
 			"/etc/kubernetes/empty/server.yaml":          "",
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -85,16 +84,28 @@ var _ = Describe("Cluster", func() {
 		cluster, err := NewCluster(s, kubernetes)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cluster.ServerConfig).ToNot(BeEmpty())
-		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"192.168.122.50", "api.suse.com"}))
-		Expect(cluster.ServerConfig["cni"]).To(BeNil())
-		Expect(cluster.ServerConfig["token"]).To(BeNil())
-		Expect(cluster.ServerConfig["server"]).To(BeNil())
-		Expect(cluster.ServerConfig["selinux"]).To(BeNil())
-		Expect(cluster.ServerConfig["disable"]).To(BeNil())
-		Expect(cluster.AgentConfig).To(BeEmpty())
+		Expect(cluster.JoiningServerConfig).ToNot(BeEmpty())
+		Expect(len(cluster.JoiningServerConfig)).To(Equal(3))
+		Expect(cluster.JoiningServerConfig["token"]).ToNot(BeNil())
+		Expect(cluster.JoiningServerConfig["server"]).To(Equal("https://192.168.122.50:9345"))
+		Expect(cluster.JoiningServerConfig["tls-san"]).To(ContainElements([]string{"192.168.122.50", "api.suse.com"}))
+		Expect(cluster.JoiningServerConfig["cni"]).To(BeNil())
+		Expect(cluster.JoiningServerConfig["selinux"]).To(BeNil())
+		Expect(cluster.JoiningServerConfig["disable"]).To(BeNil())
+
+		expectedAgent := ConfigMap{}
+		maps.Copy(expectedAgent, cluster.JoiningServerConfig)
+		delete(expectedAgent, "tls-san")
+		Expect(len(cluster.AgentConfig)).To(Equal(2))
+		Expect(cluster.AgentConfig).To(Equal(expectedAgent))
+
+		expectedInit := ConfigMap{}
+		maps.Copy(expectedInit, cluster.JoiningServerConfig)
+		delete(expectedInit, "server")
+		Expect(len(cluster.InitServerConfig)).To(Equal(2))
+		Expect(cluster.InitServerConfig).To(Equal(expectedInit))
 	})
-	It("Loads values from single-node server config", func() {
+	It("Loads configurations for runtime defined nodes", func() {
 		kubernetes := &Kubernetes{
 			Network: Network{
 				APIHost: "api.suse.com",
@@ -102,74 +113,9 @@ var _ = Describe("Cluster", func() {
 				APIVIP6: "fd12:3456:789a::21",
 			},
 			Config: Config{
-				ServerFilePath: "/etc/kubernetes/single-node/server.yaml",
-				AgentFilePath:  "",
-			},
-		}
-
-		cluster, err := NewCluster(s, kubernetes)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(cluster.ServerConfig).ToNot(BeEmpty())
-		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))
-		Expect(cluster.ServerConfig["token"]).To(Equal("token123"))
-		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
-		Expect(cluster.ServerConfig["selinux"]).To(BeTrue())
-		Expect(cluster.ServerConfig["server"]).To(BeNil())
-
-		Expect(cluster.AgentConfig).To(BeNil())
-	})
-	It("Loads values from single-node server config when one server node is explicitly configured", func() {
-		kubernetes := &Kubernetes{
-			Network: Network{
-				APIHost: "api.suse.com",
-				APIVIP4: "192.168.122.50",
-			},
-			Nodes: Nodes{
-				{
-					Hostname: "node01",
-					Type:     NodeTypeServer,
-				},
-			},
-			Config: Config{
-				ServerFilePath: "/etc/kubernetes/single-node/server.yaml",
-			},
-		}
-
-		cluster, err := NewCluster(s, kubernetes)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(cluster.ServerConfig).ToNot(BeEmpty())
-		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))
-		Expect(cluster.ServerConfig["token"]).To(Equal("token123"))
-		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "api.suse.com"}))
-		Expect(cluster.ServerConfig["selinux"]).To(BeTrue())
-		Expect(cluster.ServerConfig["server"]).To(BeNil())
-
-		Expect(cluster.InitServerConfig).To(BeNil())
-		Expect(cluster.AgentConfig).To(BeNil())
-	})
-	It("Loads values from multi-node config", func() {
-		kubernetes := &Kubernetes{
-			Network: Network{
-				APIHost: "api.suse.com",
-				APIVIP4: "192.168.122.50",
-				APIVIP6: "fd12:3456:789a::21",
-			},
-			Nodes: Nodes{
-				{
-					Hostname: "host1.suse.com",
-					Type:     NodeTypeServer,
-				},
-				{
-					Hostname: "host2.suse.com",
-					Type:     NodeTypeAgent,
-				},
-			},
-			Config: Config{
-				ServerFilePath:     "/etc/kubernetes/multi-node/server.yaml",
-				AgentFilePath:      "/etc/kubernetes/multi-node/agent.yaml",
-				RegistriesFilePath: "/etc/kubernetes/multi-node/registries.yaml",
+				ServerFilePath:     "/etc/kubernetes/config-dir/server.yaml",
+				AgentFilePath:      "/etc/kubernetes/config-dir/agent.yaml",
+				RegistriesFilePath: "/etc/kubernetes/config-dir/registries.yaml",
 			},
 		}
 
@@ -187,56 +133,176 @@ var _ = Describe("Cluster", func() {
 		_, ok = example["endpoint"].([]any)
 		Expect(ok).To(BeTrue())
 
-		Expect(cluster.ServerConfig).ToNot(BeEmpty())
-		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))
-		Expect(cluster.ServerConfig["token"]).To(Equal("token123"))
-		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
-		Expect(cluster.ServerConfig["selinux"]).To(BeTrue())
-		Expect(cluster.ServerConfig["server"]).To(Equal("https://192.168.122.50:9345"))
+		Expect(cluster.JoiningServerConfig).ToNot(BeEmpty())
+		Expect(len(cluster.JoiningServerConfig)).To(Equal(6))
+		Expect(cluster.JoiningServerConfig["cni"]).To(Equal("calico"))
+		Expect(cluster.JoiningServerConfig["token"]).To(Equal("token123"))
+		Expect(cluster.JoiningServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
+		Expect(cluster.JoiningServerConfig["disable"]).To(ContainElement("rke2-coredns"))
+		Expect(cluster.JoiningServerConfig["selinux"]).To(BeTrue())
+		Expect(cluster.JoiningServerConfig["server"]).To(Equal("https://192.168.122.50:9345"))
 
-		Expect(cluster.InitServerConfig).ToNot(BeEmpty())
-		Expect(cluster.InitServerConfig["cni"]).To(Equal("calico"))
-		Expect(cluster.InitServerConfig["token"]).To(Equal("token123"))
-		Expect(cluster.InitServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
-		Expect(cluster.InitServerConfig["selinux"]).To(BeTrue())
-		Expect(cluster.InitServerConfig["server"]).To(BeNil())
+		expectedAgent := ConfigMap{}
+		maps.Copy(expectedAgent, cluster.JoiningServerConfig)
+		delete(expectedAgent, "tls-san")
+		delete(expectedAgent, "disable")
+		expectedAgent["debug"] = true
+		Expect(len(cluster.AgentConfig)).To(Equal(5))
+		Expect(cluster.AgentConfig).To(Equal(expectedAgent))
 
-		Expect(cluster.AgentConfig).ToNot(BeEmpty())
-		// server settings override the agent.yaml
-		Expect(cluster.AgentConfig["cni"]).To(Equal("calico"))
-		Expect(cluster.AgentConfig["token"]).To(Equal("token123"))
-		Expect(cluster.AgentConfig["server"]).To(Equal("https://192.168.122.50:9345"))
-		Expect(cluster.AgentConfig["selinux"]).To(BeTrue())
-		Expect(cluster.AgentConfig["debug"]).To(BeTrue())
+		expectedInit := ConfigMap{}
+		maps.Copy(expectedInit, cluster.JoiningServerConfig)
+		delete(expectedInit, "server")
+		Expect(len(cluster.InitServerConfig)).To(Equal(5))
+		Expect(cluster.InitServerConfig).To(Equal(expectedInit))
+	})
+
+	It("Loads configurations for statically defined nodes", func() {
+		kubernetes := &Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.122.50",
+				APIVIP6: "fd12:3456:789a::21",
+			},
+			Nodes: Nodes{
+				{
+					Hostname: "host1.suse.com",
+					Type:     NodeTypeServer,
+				},
+				{
+					Hostname: "host2.suse.com",
+					Type:     NodeTypeAgent,
+				},
+			},
+			Config: Config{
+				ServerFilePath:     "/etc/kubernetes/config-dir/server.yaml",
+				AgentFilePath:      "/etc/kubernetes/config-dir/agent.yaml",
+				RegistriesFilePath: "/etc/kubernetes/config-dir/registries.yaml",
+			},
+		}
+
+		cluster, err := NewCluster(s, kubernetes)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.RegistriesConfig).ToNot(BeEmpty())
+		Expect(cluster.RegistriesConfig["mirrors"]).ToNot(BeEmpty())
+		mirrors, ok := cluster.RegistriesConfig["mirrors"].(ConfigMap)
+		Expect(ok).To(BeTrue())
+		Expect(mirrors["mirror.example.com"]).ToNot(BeEmpty())
+		example, ok := mirrors["mirror.example.com"].(ConfigMap)
+		Expect(ok).To(BeTrue())
+		Expect(example["endpoint"]).ToNot(BeEmpty())
+		_, ok = example["endpoint"].([]any)
+		Expect(ok).To(BeTrue())
+
+		Expect(cluster.JoiningServerConfig).ToNot(BeEmpty())
+		Expect(len(cluster.JoiningServerConfig)).To(Equal(6))
+		Expect(cluster.JoiningServerConfig["cni"]).To(Equal("calico"))
+		Expect(cluster.JoiningServerConfig["token"]).To(Equal("token123"))
+		Expect(cluster.JoiningServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
+		Expect(cluster.JoiningServerConfig["selinux"]).To(BeTrue())
+		Expect(cluster.JoiningServerConfig["server"]).To(Equal("https://192.168.122.50:9345"))
+
+		expectedAgent := ConfigMap{}
+		maps.Copy(expectedAgent, cluster.JoiningServerConfig)
+		delete(expectedAgent, "tls-san")
+		delete(expectedAgent, "disable")
+		expectedAgent["debug"] = true
+		Expect(len(cluster.AgentConfig)).To(Equal(5))
+		Expect(cluster.AgentConfig).To(Equal(expectedAgent))
+
+		expectedInit := ConfigMap{}
+		maps.Copy(expectedInit, cluster.JoiningServerConfig)
+		delete(expectedInit, "server")
+		Expect(len(cluster.InitServerConfig)).To(Equal(5))
+		Expect(cluster.InitServerConfig).To(Equal(expectedInit))
 	})
 })
 
 var _ = Describe("Cluster Helpers", func() {
-	It("sets cluster API address", func() {
-		config := map[string]any{}
+	It("sets default server configuration with IPv4 url", func() {
+		serverValues := ConfigMap{}
+		kubeConfig := Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.122.50",
+				APIVIP6: "fd12:3456:789a::21",
+			},
+		}
 
-		ip4, err := netip.ParseAddr("192.168.122.50")
+		err := setServerDefaults(log.New(log.WithDiscardAll()), &kubeConfig, serverValues)
 		Expect(err).ToNot(HaveOccurred())
 
-		ip6, err := netip.ParseAddr("fd12:3456:789a::21")
+		Expect(serverValues).ToNot(BeEmpty())
+		Expect(serverValues["server"]).To(Equal("https://192.168.122.50:9345"))
+		Expect(serverValues["tls-san"]).To(ContainElements([]string{"192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
+		Expect(serverValues["token"]).ToNot(BeEmpty())
+	})
+
+	It("sets default server configuration with IPv6 url", func() {
+		serverValues := ConfigMap{}
+		kubeConfig := Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP6: "fd12:3456:789a::21",
+			},
+		}
+
+		By("using IPv6 when IPv4 is missing")
+		err := setServerDefaults(log.New(log.WithDiscardAll()), &kubeConfig, serverValues)
 		Expect(err).ToNot(HaveOccurred())
 
-		var emptyIP netip.Addr
+		Expect(serverValues).ToNot(BeEmpty())
+		Expect(serverValues["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+		Expect(serverValues["tls-san"]).To(ContainElements([]string{"fd12:3456:789a::21", "api.suse.com"}))
+		Expect(serverValues["token"]).ToNot(BeEmpty())
 
-		setClusterAPIAddress(config, ip4, emptyIP, 9345, false)
-		Expect(config["server"]).To(Equal("https://192.168.122.50:9345"))
+		By("prioritizing IPv6")
+		serverValues = ConfigMap{"cluster-cidr": "fd12:3456:789b::/56"}
+		kubeConfig.Network.APIVIP4 = "192.168.122.50"
 
-		setClusterAPIAddress(config, ip4, ip6, 9345, false)
-		Expect(config["server"]).To(Equal("https://192.168.122.50:9345"))
+		err = setServerDefaults(log.New(log.WithDiscardAll()), &kubeConfig, serverValues)
+		Expect(err).ToNot(HaveOccurred())
 
-		setClusterAPIAddress(config, ip4, ip6, 9345, true)
-		Expect(config["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+		Expect(serverValues).ToNot(BeEmpty())
+		Expect(serverValues["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+		Expect(serverValues["tls-san"]).To(ContainElements([]string{"192.168.122.50", "fd12:3456:789a::21", "api.suse.com"}))
+		Expect(serverValues["token"]).ToNot(BeEmpty())
 
-		setClusterAPIAddress(config, emptyIP, ip6, 9345, true)
-		Expect(config["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+	})
 
-		setClusterAPIAddress(config, ip4, ip6, 9345, true)
-		Expect(config["server"]).To(Equal("https://[fd12:3456:789a::21]:9345"))
+	It("does not set server url if both IPv4 and IPv6 are missing", func() {
+		serverValues := ConfigMap{}
+		kubeConfig := Kubernetes{}
+		err := setServerDefaults(log.New(log.WithDiscardAll()), &kubeConfig, serverValues)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serverValues["server"]).To(BeNil())
+	})
+
+	It("fails to set default server configuration when IPv4 is broken", func() {
+		serverValues := ConfigMap{}
+		kubeConfig := Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.300.10",
+			},
+		}
+		err := setServerDefaults(log.New(log.WithDiscardAll()), &kubeConfig, serverValues)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(`parsing kubernetes ipv4 address: ParseAddr("192.168.300.10"): IPv4 field has value >255`))
+	})
+
+	It("fails to set default server configuration when IPv6 is broken", func() {
+		serverValues := ConfigMap{}
+		kubeConfig := Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP6: "fd12:3456:789a::2g",
+			},
+		}
+		err := setServerDefaults(log.New(log.WithDiscardAll()), &kubeConfig, serverValues)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(`parsing kubernetes ipv6 address: ParseAddr("fd12:3456:789a::2g"): unexpected character, want colon (at "g")`))
 	})
 
 	It("appends cluster tls-san", func() {

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -133,11 +133,12 @@ func FindInitNode(nodes Nodes) (*Node, error) {
 }
 
 type Network struct {
-	APIHost string `yaml:"apiHost"`
-	APIVIP4 string `yaml:"apiVIP,omitempty" validate:"omitempty"`
-	APIVIP6 string `yaml:"apiVIP6,omitempty" validate:"omitempty,ipv6"`
+	APIHost    string `yaml:"apiHost"`
+	APIVIP4    string `yaml:"apiVIP,omitempty" validate:"omitempty"`
+	APIVIP6    string `yaml:"apiVIP6,omitempty" validate:"omitempty,ipv6"`
+	APIVIPMode string `yaml:"apiVIPMode,omitempty" validate:"omitempty,oneof=managed external"`
 }
 
-func (n Network) IsHA() bool {
-	return n.APIVIP4 != "" || n.APIVIP6 != ""
+func (n Network) IsManagedInternally() bool {
+	return (n.APIVIP4 != "" || n.APIVIP6 != "") && (n.APIVIPMode == "managed" || n.APIVIPMode == "")
 }

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -112,9 +112,15 @@ type Node struct {
 
 type Nodes []Node
 
-// FindInitNode loops through the nodes and returns the first one with init field set to true, or if none found, picks the first server Node.
+// FindInitNode loops through all available node definitions and returns the first one with
+// 'init: true', or if none is found, picks the first server Node. Returns an error if list consists only
+// of agent nodes. Returns nil if node list is empty.
 func FindInitNode(nodes Nodes) (*Node, error) {
 	var pick *Node
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+
 	for _, n := range nodes {
 		if n.Init {
 			return &n, nil
@@ -126,7 +132,7 @@ func FindInitNode(nodes Nodes) (*Node, error) {
 	}
 
 	if pick == nil {
-		return nil, fmt.Errorf("finding suitable init-node")
+		return nil, fmt.Errorf("could not find suitable init node from node list: %+v", nodes)
 	}
 
 	return pick, nil

--- a/internal/image/paths.go
+++ b/internal/image/paths.go
@@ -38,6 +38,10 @@ func ElementalPath() string {
 	return filepath.Join("var", "lib", "elemental")
 }
 
+func RuntimeEnvPath() string {
+	return filepath.Join(ElementalPath(), "runtime.env")
+}
+
 func KubernetesPath() string {
 	return filepath.Join(ElementalPath(), "kubernetes")
 }


### PR DESCRIPTION
The suggested changes enable users to be able to spin up single/multi node UC clusters on AWS (and possibly other cloud providers as well).

To enable this type of runtime configuration the following concepts have been introduced/changed:
1. New `network.apiVIPMode` configuration under `kubernetes/cluster.yaml` - Accepts either `external`, or `managed`. Where `managed` is the default and represents the current MetalLB + ECO workflow that we have and `external` expects third-party provided load balancing. 
   - **Why is this needed?** - Generally we needed a way to disable deploying MetalLB + ECO for multi-node clusters. For could specific use-cases, having MetalLB and ECO deployed by default makes little sense, as each cloud provider will have a way of load balancing the cluster.
   - **Why `managed` and not `metallb`?** - I opted to keep `managed` over `metallb`, as I do not foresee us supporting two different load balancing methods by default. Furthermore, any other load balancing method, could easily be setup through the already established paths and the `external` value. `managed` gives us the flexibility to change out MetalLB in favour of something else if necessary without touching the UX. 
 2. The [`NewCluster()`](https://github.com/ipetrov117/elemental/blob/cloud_enablement/internal/image/kubernetes/cluster.go#L59) func now always returns configurations for the `init`, `joining-server` and `agent` nodes. 
     - **Why is this needed?** - To truly support spinning different types of clusters (e.g. single / multi node), while also not burdening the user with having to do the configuration themselves,  the image needs to have all the necessary information (e.g. `init.yaml`, `server.yaml` and `agent.yaml` files) already defined in it. 
 3. Based on (2), now all single-node clusters utilise the `init.yaml` configuration, instead of the `server.yaml` configuration.
     - **Why is this needed?** - This clearly separates the responsibilities that these two files represent and ensure that we do not hit issues, where `init.yaml` is needed, but is not present, because we have wrongly counted server node numbers.
 4. Some standardisation in how we determine the init node during static node definitions was introduced - now init node validation is done at a single place, as opposed to doing separate validations throughout functions.
 5. Both `k8s-config-installer.service` and `k8s-resource-installer.service` have been reworked to support partial configuration through an environment variables file.
     - **Why is this needed?** - This is the actual change that enables users to configure the RKE2 node type at runtime. Without this change the services and underlying scripts worked strictly with statically defined variables, which was not enough for the cloud environment use-case.
     - **Why an environment file for runtime configurations?** - Setting yet another custom configuration schema that the user needed to be aware of seemed unnecessary when we already have `ignition` and the general environment file support in systemd.
     - **How does the service workflow now look?**
         - `k8s-config-installer.service` - The service now accepts an optional environment variable located under `/var/lib/elemental/runtime.env`. If the file is present, all env vars are exposed to the `k8s_conf_deploy.sh` script. This means that the script by default runs with the statically defined configurations done during `customize`, but now supports for those configurations to be overridden from this env file.
             - **Is `k8s_conf_deploy.sh` fully configurable?** - No, and that is on purpose. I opted for going for as minimal configurations as possible and expanding whenever needed. That said, the main configurations that the user would do are the type of the node (`NODE_TYPE`) and whether the node is an init node (`IS_INIT_NODE`). Right now, only node specific configurations are exposed, whether we expose cluster specific, is a topic for a different discussion IMO.
         - `k8s-resource-installer.service` - If there is static node definitions under `cluster.yaml` then the service is created with the standard `ConditionHost={{ .InitNode.Hostname }}`, but if no static definitions are found, then the service is created expecting the `runtime.env` env file and is **only** triggered if this env file holds a `IS_INIT_NODE=true` env. Other than that the functionality of the script is untouched.

With all these changes, we now have the following two workflows:
1. `static` (existing workflow):
    - User defines a static node configuration under `cluster.yaml`
    - `k8s-config-installer.service` is templated with a non-empty `hosts[]` array and the standard existing workflow for RKE2 config is followed.
    - `k8s-resource-installer.service` is templated with `ConditionHost={{ .InitHostname }}`. 
2. `runtime` for cloud provider (e.g. AWS):
    - User builds a customized image that has no static nodes defined and has the `ignition.platform.id=aws` kernel arg.
    - Through butane, or pure ignition user creates an ignition config file that holds at a minimum logic for:
        - Setting the hostname
        - Creating the `runtime.env` file under `/var/lib/elemental`. Where the `runtime.env`, depending on the node can hold:
           - For initial server node: `NODE_TYPE=server` + `IS_INIT_NODE=true`
           - For joining servers: just `NODE_TYPE=server`
           - For joining agents: just `NODE_TYPE=agent`
    - User passes the created ignition configuration to the EC2 instance launch command as `user-data` and this gets propagated to ignition.
    - Later during boot `k8s-config-installer.service` uses the envs from `runtime.env` and spins up the correct RKE2 configuration.
    - `k8s-resource-installer.service` runs only if `runtime.env` holds `IS_INIT_NODE=true`.

Caveats:
1. Right now spinning multiple clusters from the same customized image in a cloud provider is not possible as the node's VIP configuration is still static - This is a very valid feature that should be considered. It has not been introduced as part of this PR, as we first need to agree on the minimal setup and approach when it comes to runtime configuration and then start expanding. 
2. A single node cluster can be converted to a multi node cluster, only if its initial VIP configuration was provided. - This ties back to (1) and will be fixed when (1) is implemented. Again, getting the runtime configuration right will be an incremental process.

Tests done:
- [X] Single node cluster on AWS 
- [X] Multi-node (3 cp and 1 wk) cluster on AWS
- [X] Single node cluster deployment with static configuration on VM (ensure existing logic compatibility)
- [X] Multi-node (3cp and 1 wk) cluster deployment with static configuration on VM (ensure existing logic compatibility).


From my PoV, this feature should be considered "Tech Preview" until we iron out the approach, introduce implementation for the caveats and fix the inevitable issues that will come up. Nevertheless, it offers a good ground to iterate on.

> Note: This enables AWS deployments, other environments could need minor tweaks, for example Proxmox requires a minor tweak that is not part of this PR and will be introduced later on when we finalise the approach.