### PR TITLE
[release-3.0] Backport bug fixes

### DIFF
--- a/internal/config/helm.go
+++ b/internal/config/helm.go
@@ -46,7 +46,7 @@ type helmChart interface {
 	GetName() string
 	GetInlineValues() map[string]any
 	GetRepositoryName() string
-	ToCRD(values []byte, repository string, hasAuth, skipTLSVerify bool) *helm.CRD
+	ToCRD(values []byte, repository string, hasAuth, skipTLSVerify bool) (*helm.CRD, error)
 }
 
 type Helm struct {
@@ -264,7 +264,10 @@ func (h *Helm) appendHelmChart(chart helmChart, repositories, valueFiles map[str
 		return fmt.Errorf("resolving values for chart %s: %w", name, err)
 	}
 
-	crd := chart.ToCRD(values, repository, needsAuth, skipTLSVerify)
+	crd, err := chart.ToCRD(values, repository, needsAuth, skipTLSVerify)
+	if err != nil {
+		return fmt.Errorf("constructing HelmChart custom resource: %w", err)
+	}
 	*crds = append(*crds, crd)
 
 	return nil

--- a/internal/config/helm_test.go
+++ b/internal/config/helm_test.go
@@ -370,11 +370,11 @@ var _ = Describe("Helm tests", Label("helm"), func() {
 						Repositories: []*kubernetes.HelmRepository{
 							{
 								Name: "apache",
-								URL:  "https://example.com/apache",
+								URL:  "https://example.com/apache/",
 							},
 							{
 								Name: "nginx",
-								URL:  "oci://example.com/web",
+								URL:  "oci://example.com/web/",
 							},
 						},
 					},
@@ -498,7 +498,7 @@ metadata:
 spec:
     chart: apache
     version: 10.7.0
-    repo: https://example.com/apache
+    repo: https://example.com/apache/
     valuesContent: |
         image:
             debug: true
@@ -592,7 +592,7 @@ spec:
 							},
 							{
 								Name: "nginx",
-								URL:  "oci://example.com/web",
+								URL:  "oci://example.com/web/", // trailing slash
 							},
 							{
 								Name: "storage",

--- a/internal/config/kubernetes.go
+++ b/internal/config/kubernetes.go
@@ -182,7 +182,7 @@ func writeK8sConfigDeployScript(fs vfs.FS, output Output, k kubernetes.Kubernete
 		err      error
 	)
 
-	if len(k.Nodes) > 0 {
+	if len(k.Nodes) > 1 {
 		initNode, err = kubernetes.FindInitNode(k.Nodes)
 		if err != nil {
 			return "", fmt.Errorf("finding init node: %w", err)

--- a/internal/config/kubernetes_test.go
+++ b/internal/config/kubernetes_test.go
@@ -345,6 +345,51 @@ var _ = Describe("Kubernetes", func() {
 			Expect(confScript).ToNot(BeEmpty())
 		})
 
+		It("Uses server config for a single explicitly configured server node", func() {
+			conf := kubernetes.Kubernetes{
+				Nodes: kubernetes.Nodes{
+					{Hostname: "node01", Type: kubernetes.NodeTypeServer},
+				},
+			}
+
+			confScript, err := writeK8sConfigDeployScript(
+				fs,
+				output,
+				conf,
+				"/opt/k8s/install",
+				"/opt/k8s/install/install.sh",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring(`CONFIGFILE="/var/lib/elemental/kubernetes/${NODETYPE}.yaml"`))
+			Expect(string(b)).ToNot(ContainSubstring("init.yaml"))
+		})
+
+		It("Uses init config only for multi-node clusters", func() {
+			conf := kubernetes.Kubernetes{
+				Nodes: kubernetes.Nodes{
+					{Hostname: "server01", Type: kubernetes.NodeTypeServer},
+					{Hostname: "agent01", Type: kubernetes.NodeTypeAgent},
+				},
+			}
+
+			confScript, err := writeK8sConfigDeployScript(
+				fs,
+				output,
+				conf,
+				"/opt/k8s/install",
+				"/opt/k8s/install/install.sh",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			b, err := fs.ReadFile(filepath.Join(output.OverlaysDir(), confScript))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(b)).To(ContainSubstring(`if [[ "${HOSTNAME}" = "server01" ]]; then`))
+			Expect(string(b)).To(ContainSubstring("CONFIGFILE=/var/lib/elemental/kubernetes/init.yaml"))
+		})
+
 		It("Succeeds to configure RKE2 with additional resources and auth", func() {
 			additionalManifests := make(map[string][]byte)
 			additionalManifests["example-auth-priority.yaml"] = []byte("apiVersion: v1\nkind: Secret\nmetadata:\n    namespace: kube-system\n    name: example-auth\ntype: kubernetes.io/dockerconfigjson\ndata:\n    .dockerconfigjson: eyJhdXRocyI6eyJleGFtcGxlLmlvIjp7InVzZXJuYW1lIjoiZXhhbXBsZS11c2VyIiwicGFzc3dvcmQiOiJleGFtcGxlLXBhc3MiLCJhdXRoIjoiWlhoaGJYQnNaUzExYzJWeU9tVjRZVzF3YkdVdGNHRnpjdz09In19fQ==\n")

--- a/internal/config/templates/k8s_conf_deploy.sh.tpl
+++ b/internal/config/templates/k8s_conf_deploy.sh.tpl
@@ -17,10 +17,12 @@ NODETYPE="${hosts[${HOSTNAME}]:-server}"
 CONFIGFILE="{{ .KubernetesDir }}/${NODETYPE}.yaml"
 REGFILE="{{ .KubernetesDir }}/registries.yaml"
 
+{{- if .InitNode.Hostname }}
 if [[ "${HOSTNAME}" = "{{ .InitNode.Hostname }}" ]]; then
   echo "Setting up init node"
   CONFIGFILE={{ .KubernetesDir }}/init.yaml
 fi
+{{- end }}
 
 # Better to append if a file exist
 # Useful if some custom configuration are done at boot

--- a/internal/image/kubernetes/cluster_test.go
+++ b/internal/image/kubernetes/cluster_test.go
@@ -119,6 +119,36 @@ var _ = Describe("Cluster", func() {
 
 		Expect(cluster.AgentConfig).To(BeNil())
 	})
+	It("Loads values from single-node server config when one server node is explicitly configured", func() {
+		kubernetes := &Kubernetes{
+			Network: Network{
+				APIHost: "api.suse.com",
+				APIVIP4: "192.168.122.50",
+			},
+			Nodes: Nodes{
+				{
+					Hostname: "node01",
+					Type:     NodeTypeServer,
+				},
+			},
+			Config: Config{
+				ServerFilePath: "/etc/kubernetes/single-node/server.yaml",
+			},
+		}
+
+		cluster, err := NewCluster(s, kubernetes)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cluster.ServerConfig).ToNot(BeEmpty())
+		Expect(cluster.ServerConfig["cni"]).To(Equal("calico"))
+		Expect(cluster.ServerConfig["token"]).To(Equal("token123"))
+		Expect(cluster.ServerConfig["tls-san"]).To(ContainElements([]string{"10.10.10.1", "cluster1.suse.com", "192.168.122.50", "api.suse.com"}))
+		Expect(cluster.ServerConfig["selinux"]).To(BeTrue())
+		Expect(cluster.ServerConfig["server"]).To(BeNil())
+
+		Expect(cluster.InitServerConfig).To(BeNil())
+		Expect(cluster.AgentConfig).To(BeNil())
+	})
 	It("Loads values from multi-node config", func() {
 		kubernetes := &Kubernetes{
 			Network: Network{

--- a/internal/image/kubernetes/kubernetes.go
+++ b/internal/image/kubernetes/kubernetes.go
@@ -93,7 +93,7 @@ func (c *HelmChart) GetRepositoryName() string {
 	return c.RepositoryName
 }
 
-func (c *HelmChart) ToCRD(values []byte, repository string, hasAuth, skipTLSVerify bool) *helm.CRD {
+func (c *HelmChart) ToCRD(values []byte, repository string, hasAuth, skipTLSVerify bool) (*helm.CRD, error) {
 	return helm.NewCRD(c.TargetNamespace, c.Name, c.Version, string(values), repository, hasAuth, skipTLSVerify)
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -78,18 +78,22 @@ type SecretData struct {
 	Password         *string `yaml:"password,omitempty"`
 }
 
-func NewCRD(namespace, chart, version, valuesContent string, repository string, auth, skipTLSVerify bool) *CRD {
+func NewCRD(namespace, chart, version, valuesContent string, repository string, auth, skipTLSVerify bool) (crd *CRD, err error) {
 	name := chart
 	isOCI := strings.HasPrefix(repository, "oci://")
 	if isOCI {
 		// The repository is in fact an OCI registry.
 		// Use the full path for the chart identifier and drop the "repository" value.
 		// The latter is only valid for HTTP(s) repositories.
-		chart, _ = url.JoinPath(repository, name)
+		chart, err = url.JoinPath(repository, name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid path for chart %s: %w", name, err)
+		}
+
 		repository = ""
 	}
 
-	crd := &CRD{
+	crd = &CRD{
 		APIVersion: helmChartAPIVersion,
 		Kind:       helmChartKind,
 		Metadata: Metadata{
@@ -120,5 +124,5 @@ func NewCRD(namespace, chart, version, valuesContent string, repository string, 
 		}
 	}
 
-	return crd
+	return crd, nil
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -19,6 +19,7 @@ package helm
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -84,7 +85,7 @@ func NewCRD(namespace, chart, version, valuesContent string, repository string, 
 		// The repository is in fact an OCI registry.
 		// Use the full path for the chart identifier and drop the "repository" value.
 		// The latter is only valid for HTTP(s) repositories.
-		chart = fmt.Sprintf("%s/%s", repository, name)
+		chart, _ = url.JoinPath(repository, name)
 		repository = ""
 	}
 

--- a/pkg/manifest/api/shared.go
+++ b/pkg/manifest/api/shared.go
@@ -99,7 +99,7 @@ func (c *HelmChart) GetRepositoryName() string {
 	return c.Repository
 }
 
-func (c *HelmChart) ToCRD(values []byte, repository string, hasAuth bool, skipTLSVerify bool) *helm.CRD {
+func (c *HelmChart) ToCRD(values []byte, repository string, hasAuth bool, skipTLSVerify bool) (*helm.CRD, error) {
 	return helm.NewCRD(c.Namespace, c.Chart, c.Version, string(values), repository, hasAuth, skipTLSVerify)
 }
 

--- a/pkg/repart/disk_repart.go
+++ b/pkg/repart/disk_repart.go
@@ -20,9 +20,11 @@ package repart
 import (
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -45,6 +47,8 @@ const (
 	// Do not change these values as this could break backward compatibility on already installed systems (e.g. reseting a system)
 	configType   = "2ecf8b13-6846-4e8a-9bc3-284ff5e2ac22"
 	recoveryType = "3265f37b-3105-4777-bd97-cfcd9cc7cf99"
+
+	blkdiscardNotSupported = 2 // blkdiscard exit code for devices that do not support discard requests
 )
 
 //go:embed templates/partition.conf.tpl
@@ -176,7 +180,34 @@ func repartDisk(s *sys.System, d *deployment.Disk, empty string) (err error) {
 		parts[i] = Partition{Partition: part}
 	}
 
-	return runSystemdRepart(s, d.Device, parts, fmt.Sprintf("--empty=%s", empty))
+	// systemd-repart trimming the disk could result in the entire disk waiting to be fully zero'd out. This could hang
+	// installs on large drives. Now, before systemd-repart is triggered, we manually discard the entire disk in one pass
+	// through blkdiscard. This results in a native TRIM being executed whenever the drive typically runs the TRIM engine.
+	if empty == "force" {
+		err = discardDevice(s, d.Device)
+		if err != nil {
+			return err
+		}
+	}
+
+	return runSystemdRepart(s, d.Device, parts, fmt.Sprintf("--empty=%s", empty), "--discard=no")
+}
+
+// discardDevice discards the given device in a single pass. Devices not
+// supporting discard requests fail silently, unexpected failures, such as "device in us" exit immediately.
+// Runs without '--force' on to prevent accidentally trimming an in-use disk.
+func discardDevice(s *sys.System, device string) error {
+	_, err := s.Runner().Run("blkdiscard", device)
+	if err == nil {
+		return nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == blkdiscardNotSupported {
+		s.Logger().Warn("Device '%s' does not support discard, continuing without trimming it", device)
+		return nil
+	}
+	return fmt.Errorf("failed discarding device '%s': %w", device, err)
 }
 
 // runSystemdRepart runs systemd-repart for the given partitions and target device. It appends to the generated command the


### PR DESCRIPTION
Backports fixes for:
- Kubernetes Node Handling (#481)
- systemd-repart discard hanging on large disks (#556)
- Helm chart OCI paths(#545)
> Note: As #545 makes changes over the new manifest [`v0` schema structure](https://github.com/SUSE/elemental/pull/545/changes/1db7b95312cb336ddbc3e13c34e925381fa84811#diff-0198dc25fe61a076c2c290a5c2f3a2edbbab41631b985e1e9d639574019cfd88) which is currently not in `release-3.0` I had to manually change the `ToCRD()` function [here](https://github.com/ipetrov117/elemental/blob/release-3.0-backports/pkg/manifest/api/shared.go#L102).


Tested on:
- Single node cluster (ISO + RAW)
- Multi node cluster (ISO)